### PR TITLE
Fix Password Handling in MySQL DSN Parser

### DIFF
--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -20,7 +20,7 @@ class MySQLDSNParser implements DSNParser {
         port: url.port ? parseInt(url.port) : 3306,
         database: url.pathname.substring(1), // Remove leading '/'
         user: url.username,
-        password: url.password,
+        password: url.password ? decodeURIComponent(url.password) : '',
       };
       
       // Handle query parameters


### PR DESCRIPTION
### Change Summary
This PR fixes an issue with password handling in the MySQL DSN Parser. Passwords were being automatically URL-encoded by the JavaScript URL constructor, but needed to be decoded before being passed to the MySQL connector.

### Problem
When using database connection strings with special characters in passwords (like `^, =, ;, `etc.), authentication was failing because:

- The URL constructor automatically URL-encodes special characters in the password component
- The encoded password was being sent directly to MySQL without decoding
- This resulted in connection failures for passwords containing special characters

### Solution
Added [decodeURIComponent()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to properly decode the password after extraction from the URL object:

### Why It's Required
Without this fix, users with special characters in their database passwords (like in the multi-tenant DB configuration) couldn't connect properly
Special characters like` ^, ;, =, `etc. are common in secure passwords but were causing authentication failures
Real-world example: The password `k^Pa7$a3g0-M+Lu2` in our dev configuration was being incorrectly handled

### Testing

- Verified connection with passwords containing various special characters
- Confirmed backward compatibility with passwords that don't contain special characters
- Successfully connected to a database
