### PR TITLE
feat: implement allowed keywords for SQL queries

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "always"
+} 

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -42,9 +42,7 @@ class MariadbDSNParser implements DSNParser {
 
       return config;
     } catch (error) {
-      throw new Error(
-        `Failed to parse MariaDB DSN: ${error instanceof Error ? error.message : String(error)}`
-      );
+      throw new Error(`Failed to parse MariaDB DSN: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
@@ -295,9 +293,7 @@ export class MariaDBConnector implements Connector {
 
     try {
       // In MariaDB, if no schema is provided, use the current database context
-      const schemaClause = schema
-        ? 'WHERE ROUTINE_SCHEMA = ?'
-        : 'WHERE ROUTINE_SCHEMA = DATABASE()';
+      const schemaClause = schema ? 'WHERE ROUTINE_SCHEMA = ?' : 'WHERE ROUTINE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema] : [];
 
@@ -326,9 +322,7 @@ export class MariaDBConnector implements Connector {
 
     try {
       // In MariaDB, if no schema is provided, use the current database context
-      const schemaClause = schema
-        ? 'WHERE r.ROUTINE_SCHEMA = ?'
-        : 'WHERE r.ROUTINE_SCHEMA = DATABASE()';
+      const schemaClause = schema ? 'WHERE r.ROUTINE_SCHEMA = ?' : 'WHERE r.ROUTINE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, procedureName] : [procedureName];
 

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -1,4 +1,4 @@
-import mariadb from "mariadb";
+import mariadb from 'mariadb';
 import {
   Connector,
   ConnectorRegistry,
@@ -7,8 +7,8 @@ import {
   TableColumn,
   TableIndex,
   StoredProcedure,
-} from "../interface.js";
-import { allowedKeywords } from "../../utils/allowed-keywords.js";
+} from '../interface.js';
+import { allowedKeywords } from '../../utils/allowed-keywords.js';
 
 /**
  * MariaDB DSN Parser
@@ -34,8 +34,8 @@ class MariadbDSNParser implements DSNParser {
 
       // Handle query parameters
       url.searchParams.forEach((value, key) => {
-        if (key === "ssl") {
-          config.ssl = value === "true" ? {} : undefined;
+        if (key === 'ssl') {
+          config.ssl = value === 'true' ? {} : undefined;
         }
         // Add other parameters as needed
       });
@@ -43,21 +43,19 @@ class MariadbDSNParser implements DSNParser {
       return config;
     } catch (error) {
       throw new Error(
-        `Failed to parse MariaDB DSN: ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        `Failed to parse MariaDB DSN: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
 
   getSampleDSN(): string {
-    return "mariadb://root:password@localhost:3306/db";
+    return 'mariadb://root:password@localhost:3306/db';
   }
 
   isValidDSN(dsn: string): boolean {
     try {
       const url = new URL(dsn);
-      return url.protocol === "mariadb:";
+      return url.protocol === 'mariadb:';
     } catch (error) {
       return false;
     }
@@ -68,8 +66,8 @@ class MariadbDSNParser implements DSNParser {
  * MariaDB Connector Implementation
  */
 export class MariaDBConnector implements Connector {
-  id = "mariadb";
-  name = "MariaDB";
+  id = 'mariadb';
+  name = 'MariaDB';
   dsnParser = new MariadbDSNParser();
 
   private pool: mariadb.Pool | null = null;
@@ -81,11 +79,11 @@ export class MariaDBConnector implements Connector {
       this.pool = mariadb.createPool(config);
 
       // Test the connection
-      console.error("Testing connection to MariaDB...");
-      const [rows] = await this.pool.query("SELECT 1");
-      console.error("Successfully connected to MariaDB database");
+      console.error('Testing connection to MariaDB...');
+      const [rows] = await this.pool.query('SELECT 1');
+      console.error('Successfully connected to MariaDB database');
     } catch (err) {
-      console.error("Failed to connect to MariaDB database:", err);
+      console.error('Failed to connect to MariaDB database:', err);
       throw err;
     }
   }
@@ -99,7 +97,7 @@ export class MariaDBConnector implements Connector {
 
   async getSchemas(): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
@@ -112,23 +110,21 @@ export class MariaDBConnector implements Connector {
 
       return rows.map((row) => row.SCHEMA_NAME);
     } catch (error) {
-      console.error("Error getting schemas:", error);
+      console.error('Error getting schemas:', error);
       throw error;
     }
   }
 
   async getTables(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MariaDB, if no schema is provided, use the current active database (DATABASE())
       // MariaDB uses the terms 'database' and 'schema' interchangeably
       // The DATABASE() function returns the current database context
-      const schemaClause = schema
-        ? "WHERE TABLE_SCHEMA = ?"
-        : "WHERE TABLE_SCHEMA = DATABASE()";
+      const schemaClause = schema ? 'WHERE TABLE_SCHEMA = ?' : 'WHERE TABLE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema] : [];
 
@@ -145,22 +141,20 @@ export class MariaDBConnector implements Connector {
 
       return rows.map((row) => row.TABLE_NAME);
     } catch (error) {
-      console.error("Error getting tables:", error);
+      console.error('Error getting tables:', error);
       throw error;
     }
   }
 
   async tableExists(tableName: string, schema?: string): Promise<boolean> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MariaDB, if no schema is provided, use the current active database
       // DATABASE() function returns the name of the current database
-      const schemaClause = schema
-        ? "WHERE TABLE_SCHEMA = ?"
-        : "WHERE TABLE_SCHEMA = DATABASE()";
+      const schemaClause = schema ? 'WHERE TABLE_SCHEMA = ?' : 'WHERE TABLE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
@@ -176,24 +170,19 @@ export class MariaDBConnector implements Connector {
 
       return rows[0].COUNT > 0;
     } catch (error) {
-      console.error("Error checking if table exists:", error);
+      console.error('Error checking if table exists:', error);
       throw error;
     }
   }
 
-  async getTableIndexes(
-    tableName: string,
-    schema?: string
-  ): Promise<TableIndex[]> {
+  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MariaDB, if no schema is provided, use the current active database
-      const schemaClause = schema
-        ? "TABLE_SCHEMA = ?"
-        : "TABLE_SCHEMA = DATABASE()";
+      const schemaClause = schema ? 'TABLE_SCHEMA = ?' : 'TABLE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
@@ -231,7 +220,7 @@ export class MariaDBConnector implements Connector {
         const indexName = row.INDEX_NAME;
         const columnName = row.COLUMN_NAME;
         const isUnique = row.NON_UNIQUE === 0; // In MariaDB, NON_UNIQUE=0 means the index is unique
-        const isPrimary = indexName === "PRIMARY";
+        const isPrimary = indexName === 'PRIMARY';
 
         if (!indexMap.has(indexName)) {
           indexMap.set(indexName, {
@@ -258,26 +247,21 @@ export class MariaDBConnector implements Connector {
 
       return results;
     } catch (error) {
-      console.error("Error getting table indexes:", error);
+      console.error('Error getting table indexes:', error);
       throw error;
     }
   }
 
-  async getTableSchema(
-    tableName: string,
-    schema?: string
-  ): Promise<TableColumn[]> {
+  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MariaDB, schema is synonymous with database
       // If no schema is provided, use the current database context via DATABASE() function
       // This means tables will be retrieved from whatever database the connection is currently using
-      const schemaClause = schema
-        ? "WHERE TABLE_SCHEMA = ?"
-        : "WHERE TABLE_SCHEMA = DATABASE()";
+      const schemaClause = schema ? 'WHERE TABLE_SCHEMA = ?' : 'WHERE TABLE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
@@ -299,21 +283,21 @@ export class MariaDBConnector implements Connector {
 
       return rows;
     } catch (error) {
-      console.error("Error getting table schema:", error);
+      console.error('Error getting table schema:', error);
       throw error;
     }
   }
 
   async getStoredProcedures(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MariaDB, if no schema is provided, use the current database context
       const schemaClause = schema
-        ? "WHERE ROUTINE_SCHEMA = ?"
-        : "WHERE ROUTINE_SCHEMA = DATABASE()";
+        ? 'WHERE ROUTINE_SCHEMA = ?'
+        : 'WHERE ROUTINE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema] : [];
 
@@ -330,24 +314,21 @@ export class MariaDBConnector implements Connector {
 
       return rows.map((row) => row.ROUTINE_NAME);
     } catch (error) {
-      console.error("Error getting stored procedures:", error);
+      console.error('Error getting stored procedures:', error);
       throw error;
     }
   }
 
-  async getStoredProcedureDetail(
-    procedureName: string,
-    schema?: string
-  ): Promise<StoredProcedure> {
+  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MariaDB, if no schema is provided, use the current database context
       const schemaClause = schema
-        ? "WHERE r.ROUTINE_SCHEMA = ?"
-        : "WHERE r.ROUTINE_SCHEMA = DATABASE()";
+        ? 'WHERE r.ROUTINE_SCHEMA = ?'
+        : 'WHERE r.ROUTINE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, procedureName] : [procedureName];
 
@@ -382,10 +363,8 @@ export class MariaDBConnector implements Connector {
       )) as [any[], any];
 
       if (rows.length === 0) {
-        const schemaName = schema || "current schema";
-        throw new Error(
-          `Stored procedure '${procedureName}' not found in ${schemaName}`
-        );
+        const schemaName = schema || 'current schema';
+        throw new Error(`Stored procedure '${procedureName}' not found in ${schemaName}`);
       }
 
       const procedure = rows[0];
@@ -397,7 +376,7 @@ export class MariaDBConnector implements Connector {
         const schemaValue = schema || (await this.getCurrentSchema());
 
         // For full definition - different approaches based on type
-        if (procedure.procedure_type === "procedure") {
+        if (procedure.procedure_type === 'procedure') {
           // Try to get the definition from SHOW CREATE PROCEDURE
           try {
             const [defRows] = (await this.pool.query(`
@@ -405,12 +384,10 @@ export class MariaDBConnector implements Connector {
             `)) as [any[], any];
 
             if (defRows && defRows.length > 0) {
-              definition = defRows[0]["Create Procedure"];
+              definition = defRows[0]['Create Procedure'];
             }
           } catch (err) {
-            console.error(
-              `Error getting procedure definition with SHOW CREATE: ${err}`
-            );
+            console.error(`Error getting procedure definition with SHOW CREATE: ${err}`);
           }
         } else {
           // Try to get the definition for functions
@@ -420,12 +397,10 @@ export class MariaDBConnector implements Connector {
             `)) as [any[], any];
 
             if (defRows && defRows.length > 0) {
-              definition = defRows[0]["Create Function"];
+              definition = defRows[0]['Create Function'];
             }
           } catch (innerErr) {
-            console.error(
-              `Error getting function definition with SHOW CREATE: ${innerErr}`
-            );
+            console.error(`Error getting function definition with SHOW CREATE: ${innerErr}`);
           }
         }
 
@@ -456,44 +431,38 @@ export class MariaDBConnector implements Connector {
       return {
         procedure_name: procedure.procedure_name,
         procedure_type: procedure.procedure_type,
-        language: "sql", // MariaDB procedures are generally in SQL
-        parameter_list: procedure.parameter_list || "",
-        return_type:
-          procedure.routine_type === "function"
-            ? procedure.return_type
-            : undefined,
+        language: 'sql', // MariaDB procedures are generally in SQL
+        parameter_list: procedure.parameter_list || '',
+        return_type: procedure.routine_type === 'function' ? procedure.return_type : undefined,
         definition: definition || undefined,
       };
     } catch (error) {
-      console.error("Error getting stored procedure detail:", error);
+      console.error('Error getting stored procedure detail:', error);
       throw error;
     }
   }
 
   // Helper method to get current schema (database) name
   private async getCurrentSchema(): Promise<string> {
-    const [rows] = (await this.pool!.query("SELECT DATABASE() AS DB")) as [
-      any[],
-      any
-    ];
+    const [rows] = (await this.pool!.query('SELECT DATABASE() AS DB')) as [any[], any];
     return rows[0].DB;
   }
 
   async executeQuery(query: string): Promise<QueryResult> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const safetyCheck = this.validateQuery(query);
     if (!safetyCheck.isValid) {
-      throw new Error(safetyCheck.message || "Query validation failed");
+      throw new Error(safetyCheck.message || 'Query validation failed');
     }
 
     try {
       const [rows, fields] = (await this.pool.query(query)) as [any[], any];
       return { rows, fields };
     } catch (error) {
-      console.error("Error executing query:", error);
+      console.error('Error executing query:', error);
       throw error;
     }
   }
@@ -501,12 +470,10 @@ export class MariaDBConnector implements Connector {
   validateQuery(query: string): { isValid: boolean; message?: string } {
     // Basic check to prevent non-SELECT queries
     const normalizedQuery = query.trim().toLowerCase();
-    if (
-      !allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))
-    ) {
+    if (!allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))) {
       return {
         isValid: false,
-        message: "Only SELECT queries are allowed for security reasons.",
+        message: 'Only SELECT queries are allowed for security reasons.',
       };
     }
     return { isValid: true };

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -1,5 +1,14 @@
-import mysql from 'mysql2/promise';
-import { Connector, ConnectorRegistry, DSNParser, QueryResult, TableColumn, TableIndex, StoredProcedure } from '../interface.js';
+import mysql from "mysql2/promise";
+import {
+  Connector,
+  ConnectorRegistry,
+  DSNParser,
+  QueryResult,
+  TableColumn,
+  TableIndex,
+  StoredProcedure,
+} from "../interface.js";
+import { allowedKeywords } from "../../utils/allowed-keywords.js";
 
 /**
  * MySQL DSN Parser
@@ -14,37 +23,41 @@ class MySQLDSNParser implements DSNParser {
 
     try {
       const url = new URL(dsn);
-      
+
       const config: mysql.ConnectionOptions = {
         host: url.hostname,
         port: url.port ? parseInt(url.port) : 3306,
         database: url.pathname.substring(1), // Remove leading '/'
         user: url.username,
-        password: url.password ? decodeURIComponent(url.password) : '',
+        password: url.password ? decodeURIComponent(url.password) : "",
       };
-      
+
       // Handle query parameters
       url.searchParams.forEach((value, key) => {
-        if (key === 'ssl') {
-          config.ssl = value === 'true' ? {} : undefined;
+        if (key === "ssl") {
+          config.ssl = value === "true" ? {} : undefined;
         }
         // Add other parameters as needed
       });
-      
+
       return config;
     } catch (error) {
-      throw new Error(`Failed to parse MySQL DSN: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to parse MySQL DSN: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 
   getSampleDSN(): string {
-    return 'mysql://root:password@localhost:3306/mysql';
+    return "mysql://root:password@localhost:3306/mysql";
   }
 
   isValidDSN(dsn: string): boolean {
     try {
       const url = new URL(dsn);
-      return url.protocol === 'mysql:';
+      return url.protocol === "mysql:";
     } catch (error) {
       return false;
     }
@@ -55,19 +68,19 @@ class MySQLDSNParser implements DSNParser {
  * MySQL Connector Implementation
  */
 export class MySQLConnector implements Connector {
-  id = 'mysql';
-  name = 'MySQL';
+  id = "mysql";
+  name = "MySQL";
   dsnParser = new MySQLDSNParser();
-  
+
   private pool: mysql.Pool | null = null;
 
   async connect(dsn: string): Promise<void> {
     try {
       const config = await this.dsnParser.parse(dsn);
       this.pool = mysql.createPool(config);
-      
+
       // Test the connection
-      const [rows] = await this.pool.query('SELECT 1');
+      const [rows] = await this.pool.query("SELECT 1");
       console.error("Successfully connected to MySQL database");
     } catch (err) {
       console.error("Failed to connect to MySQL database:", err);
@@ -84,18 +97,18 @@ export class MySQLConnector implements Connector {
 
   async getSchemas(): Promise<string[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     try {
       // In MySQL, schemas are equivalent to databases
-      const [rows] = await this.pool.query(`
+      const [rows] = (await this.pool.query(`
         SELECT SCHEMA_NAME 
         FROM INFORMATION_SCHEMA.SCHEMATA
         ORDER BY SCHEMA_NAME
-      `) as [any[], any];
-      
-      return rows.map(row => row.SCHEMA_NAME);
+      `)) as [any[], any];
+
+      return rows.map((row) => row.SCHEMA_NAME);
     } catch (error) {
       console.error("Error getting schemas:", error);
       throw error;
@@ -104,28 +117,31 @@ export class MySQLConnector implements Connector {
 
   async getTables(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     try {
       // In MySQL, if no schema is provided, use the current active database (DATABASE())
       // MySQL uses the terms 'database' and 'schema' interchangeably
       // The DATABASE() function returns the current database context
-      const schemaClause = schema ? 
-        'WHERE TABLE_SCHEMA = ?' : 
-        'WHERE TABLE_SCHEMA = DATABASE()';
+      const schemaClause = schema
+        ? "WHERE TABLE_SCHEMA = ?"
+        : "WHERE TABLE_SCHEMA = DATABASE()";
 
       const queryParams = schema ? [schema] : [];
-      
+
       // Get all tables from the specified schema or current database
-      const [rows] = await this.pool.query(`
+      const [rows] = (await this.pool.query(
+        `
         SELECT TABLE_NAME 
         FROM INFORMATION_SCHEMA.TABLES 
         ${schemaClause}
         ORDER BY TABLE_NAME
-      `, queryParams) as [any[], any];
-      
-      return rows.map(row => row.TABLE_NAME);
+      `,
+        queryParams
+      )) as [any[], any];
+
+      return rows.map((row) => row.TABLE_NAME);
     } catch (error) {
       console.error("Error getting tables:", error);
       throw error;
@@ -134,25 +150,28 @@ export class MySQLConnector implements Connector {
 
   async tableExists(tableName: string, schema?: string): Promise<boolean> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     try {
       // In MySQL, if no schema is provided, use the current active database
       // DATABASE() function returns the name of the current database
-      const schemaClause = schema ? 
-        'WHERE TABLE_SCHEMA = ?' : 
-        'WHERE TABLE_SCHEMA = DATABASE()';
+      const schemaClause = schema
+        ? "WHERE TABLE_SCHEMA = ?"
+        : "WHERE TABLE_SCHEMA = DATABASE()";
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
-      const [rows] = await this.pool.query(`
+      const [rows] = (await this.pool.query(
+        `
         SELECT COUNT(*) AS COUNT
         FROM INFORMATION_SCHEMA.TABLES 
         ${schemaClause} 
         AND TABLE_NAME = ?
-      `, queryParams) as [any[], any];
-      
+      `,
+        queryParams
+      )) as [any[], any];
+
       return rows[0].COUNT > 0;
     } catch (error) {
       console.error("Error checking if table exists:", error);
@@ -160,21 +179,25 @@ export class MySQLConnector implements Connector {
     }
   }
 
-  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
+  async getTableIndexes(
+    tableName: string,
+    schema?: string
+  ): Promise<TableIndex[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     try {
       // In MySQL, if no schema is provided, use the current active database
-      const schemaClause = schema ? 
-        'TABLE_SCHEMA = ?' : 
-        'TABLE_SCHEMA = DATABASE()';
+      const schemaClause = schema
+        ? "TABLE_SCHEMA = ?"
+        : "TABLE_SCHEMA = DATABASE()";
 
       const queryParams = schema ? [schema, tableName] : [tableName];
-      
+
       // Get information about indexes
-      const [indexRows] = await this.pool.query(`
+      const [indexRows] = (await this.pool.query(
+        `
         SELECT 
           INDEX_NAME,
           COLUMN_NAME,
@@ -188,33 +211,38 @@ export class MySQLConnector implements Connector {
         ORDER BY 
           INDEX_NAME, 
           SEQ_IN_INDEX
-      `, queryParams) as [any[], any];
-      
+      `,
+        queryParams
+      )) as [any[], any];
+
       // Process the results to group columns by index
-      const indexMap = new Map<string, {
-        columns: string[],
-        is_unique: boolean,
-        is_primary: boolean
-      }>();
-      
+      const indexMap = new Map<
+        string,
+        {
+          columns: string[];
+          is_unique: boolean;
+          is_primary: boolean;
+        }
+      >();
+
       for (const row of indexRows) {
         const indexName = row.INDEX_NAME;
         const columnName = row.COLUMN_NAME;
         const isUnique = row.NON_UNIQUE === 0; // In MySQL, NON_UNIQUE=0 means the index is unique
-        const isPrimary = indexName === 'PRIMARY';
-        
+        const isPrimary = indexName === "PRIMARY";
+
         if (!indexMap.has(indexName)) {
           indexMap.set(indexName, {
             columns: [],
             is_unique: isUnique,
-            is_primary: isPrimary
+            is_primary: isPrimary,
           });
         }
-        
+
         const indexInfo = indexMap.get(indexName)!;
         indexInfo.columns.push(columnName);
       }
-      
+
       // Convert the map to the expected TableIndex format
       const results: TableIndex[] = [];
       indexMap.forEach((indexInfo, indexName) => {
@@ -222,10 +250,10 @@ export class MySQLConnector implements Connector {
           index_name: indexName,
           column_names: indexInfo.columns,
           is_unique: indexInfo.is_unique,
-          is_primary: indexInfo.is_primary
+          is_primary: indexInfo.is_primary,
         });
       });
-      
+
       return results;
     } catch (error) {
       console.error("Error getting table indexes:", error);
@@ -233,23 +261,27 @@ export class MySQLConnector implements Connector {
     }
   }
 
-  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
+  async getTableSchema(
+    tableName: string,
+    schema?: string
+  ): Promise<TableColumn[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     try {
       // In MySQL, schema is synonymous with database
       // If no schema is provided, use the current database context via DATABASE() function
       // This means tables will be retrieved from whatever database the connection is currently using
-      const schemaClause = schema ? 
-        'WHERE TABLE_SCHEMA = ?' : 
-        'WHERE TABLE_SCHEMA = DATABASE()';
+      const schemaClause = schema
+        ? "WHERE TABLE_SCHEMA = ?"
+        : "WHERE TABLE_SCHEMA = DATABASE()";
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
       // Get table columns
-      const [rows] = await this.pool.query(`
+      const [rows] = (await this.pool.query(
+        `
         SELECT 
           COLUMN_NAME as column_name, 
           DATA_TYPE as data_type, 
@@ -259,8 +291,10 @@ export class MySQLConnector implements Connector {
         ${schemaClause}
         AND TABLE_NAME = ?
         ORDER BY ORDINAL_POSITION
-      `, queryParams) as [any[], any];
-      
+      `,
+        queryParams
+      )) as [any[], any];
+
       return rows;
     } catch (error) {
       console.error("Error getting table schema:", error);
@@ -270,47 +304,54 @@ export class MySQLConnector implements Connector {
 
   async getStoredProcedures(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     try {
       // In MySQL, if no schema is provided, use the current database context
-      const schemaClause = schema ? 
-        'WHERE ROUTINE_SCHEMA = ?' : 
-        'WHERE ROUTINE_SCHEMA = DATABASE()';
+      const schemaClause = schema
+        ? "WHERE ROUTINE_SCHEMA = ?"
+        : "WHERE ROUTINE_SCHEMA = DATABASE()";
 
       const queryParams = schema ? [schema] : [];
-      
+
       // Get all stored procedures and functions
-      const [rows] = await this.pool.query(`
+      const [rows] = (await this.pool.query(
+        `
         SELECT ROUTINE_NAME
         FROM INFORMATION_SCHEMA.ROUTINES
         ${schemaClause}
         ORDER BY ROUTINE_NAME
-      `, queryParams) as [any[], any];
-      
-      return rows.map(row => row.ROUTINE_NAME);
+      `,
+        queryParams
+      )) as [any[], any];
+
+      return rows.map((row) => row.ROUTINE_NAME);
     } catch (error) {
       console.error("Error getting stored procedures:", error);
       throw error;
     }
   }
 
-  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
+  async getStoredProcedureDetail(
+    procedureName: string,
+    schema?: string
+  ): Promise<StoredProcedure> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     try {
       // In MySQL, if no schema is provided, use the current database context
-      const schemaClause = schema ? 
-        'WHERE r.ROUTINE_SCHEMA = ?' : 
-        'WHERE r.ROUTINE_SCHEMA = DATABASE()';
+      const schemaClause = schema
+        ? "WHERE r.ROUTINE_SCHEMA = ?"
+        : "WHERE r.ROUTINE_SCHEMA = DATABASE()";
 
       const queryParams = schema ? [schema, procedureName] : [procedureName];
-      
+
       // Get details of the stored procedure
-      const [rows] = await this.pool.query(`
+      const [rows] = (await this.pool.query(
+        `
         SELECT 
           r.ROUTINE_NAME AS procedure_name,
           CASE 
@@ -334,58 +375,69 @@ export class MySQLConnector implements Connector {
         FROM INFORMATION_SCHEMA.ROUTINES r
         ${schemaClause}
         AND r.ROUTINE_NAME = ?
-      `, queryParams) as [any[], any];
-      
+      `,
+        queryParams
+      )) as [any[], any];
+
       if (rows.length === 0) {
-        const schemaName = schema || 'current schema';
-        throw new Error(`Stored procedure '${procedureName}' not found in ${schemaName}`);
+        const schemaName = schema || "current schema";
+        throw new Error(
+          `Stored procedure '${procedureName}' not found in ${schemaName}`
+        );
       }
-      
+
       const procedure = rows[0];
 
       // If ROUTINE_DEFINITION is NULL, try to get the procedure body from mysql.proc
       let definition = procedure.ROUTINE_DEFINITION;
-      
+
       try {
-        const schemaValue = schema || await this.getCurrentSchema();
-        
+        const schemaValue = schema || (await this.getCurrentSchema());
+
         // For full definition - different approaches based on type
-        if (procedure.procedure_type === 'procedure') {
+        if (procedure.procedure_type === "procedure") {
           // Try to get the definition from SHOW CREATE PROCEDURE
           try {
-            const [defRows] = await this.pool.query(`
+            const [defRows] = (await this.pool.query(`
               SHOW CREATE PROCEDURE ${schemaValue}.${procedureName}
-            `) as [any[], any];
-            
+            `)) as [any[], any];
+
             if (defRows && defRows.length > 0) {
-              definition = defRows[0]['Create Procedure'];
+              definition = defRows[0]["Create Procedure"];
             }
           } catch (err) {
-            console.error(`Error getting procedure definition with SHOW CREATE: ${err}`);
+            console.error(
+              `Error getting procedure definition with SHOW CREATE: ${err}`
+            );
           }
         } else {
           // Try to get the definition for functions
           try {
-            const [defRows] = await this.pool.query(`
+            const [defRows] = (await this.pool.query(`
               SHOW CREATE FUNCTION ${schemaValue}.${procedureName}
-            `) as [any[], any];
-            
+            `)) as [any[], any];
+
             if (defRows && defRows.length > 0) {
-              definition = defRows[0]['Create Function'];
+              definition = defRows[0]["Create Function"];
             }
           } catch (innerErr) {
-            console.error(`Error getting function definition with SHOW CREATE: ${innerErr}`);
+            console.error(
+              `Error getting function definition with SHOW CREATE: ${innerErr}`
+            );
           }
         }
-        
+
         // Last attempt - try to get from information_schema.routines if not found yet
         if (!definition) {
-          const [bodyRows] = await this.pool.query(`
+          const [bodyRows] = (await this.pool.query(
+            `
             SELECT ROUTINE_DEFINITION, ROUTINE_BODY 
             FROM INFORMATION_SCHEMA.ROUTINES
             WHERE ROUTINE_SCHEMA = ? AND ROUTINE_NAME = ?
-          `, [schemaValue, procedureName]) as [any[], any];
-          
+          `,
+            [schemaValue, procedureName]
+          )) as [any[], any];
+
           if (bodyRows && bodyRows.length > 0) {
             if (bodyRows[0].ROUTINE_DEFINITION) {
               definition = bodyRows[0].ROUTINE_DEFINITION;
@@ -398,14 +450,17 @@ export class MySQLConnector implements Connector {
         // Ignore errors when getting definition - it's optional
         console.error(`Error getting procedure/function details: ${error}`);
       }
-      
+
       return {
         procedure_name: procedure.procedure_name,
         procedure_type: procedure.procedure_type,
-        language: 'sql', // MySQL procedures are generally in SQL
-        parameter_list: procedure.parameter_list || '',
-        return_type: procedure.routine_type === 'function' ? procedure.return_type : undefined,
-        definition: definition || undefined
+        language: "sql", // MySQL procedures are generally in SQL
+        parameter_list: procedure.parameter_list || "",
+        return_type:
+          procedure.routine_type === "function"
+            ? procedure.return_type
+            : undefined,
+        definition: definition || undefined,
       };
     } catch (error) {
       console.error("Error getting stored procedure detail:", error);
@@ -415,22 +470,25 @@ export class MySQLConnector implements Connector {
 
   // Helper method to get current schema (database) name
   private async getCurrentSchema(): Promise<string> {
-    const [rows] = await this.pool!.query('SELECT DATABASE() AS DB') as [any[], any];
+    const [rows] = (await this.pool!.query("SELECT DATABASE() AS DB")) as [
+      any[],
+      any
+    ];
     return rows[0].DB;
   }
 
   async executeQuery(query: string): Promise<QueryResult> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const safetyCheck = this.validateQuery(query);
     if (!safetyCheck.isValid) {
       throw new Error(safetyCheck.message || "Query validation failed");
     }
 
     try {
-      const [rows, fields] = await this.pool.query(query) as [any[], any];
+      const [rows, fields] = (await this.pool.query(query)) as [any[], any];
       return { rows, fields };
     } catch (error) {
       console.error("Error executing query:", error);
@@ -441,10 +499,12 @@ export class MySQLConnector implements Connector {
   validateQuery(query: string): { isValid: boolean; message?: string } {
     // Basic check to prevent non-SELECT queries
     const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery.startsWith('select')) {
+    if (
+      !allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))
+    ) {
       return {
         isValid: false,
-        message: "Only SELECT queries are allowed for security reasons."
+        message: "Only SELECT queries are allowed for security reasons.",
       };
     }
     return { isValid: true };

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -42,9 +42,7 @@ class MySQLDSNParser implements DSNParser {
 
       return config;
     } catch (error) {
-      throw new Error(
-        `Failed to parse MySQL DSN: ${error instanceof Error ? error.message : String(error)}`
-      );
+      throw new Error(`Failed to parse MySQL DSN: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
@@ -293,9 +291,7 @@ export class MySQLConnector implements Connector {
 
     try {
       // In MySQL, if no schema is provided, use the current database context
-      const schemaClause = schema
-        ? 'WHERE ROUTINE_SCHEMA = ?'
-        : 'WHERE ROUTINE_SCHEMA = DATABASE()';
+      const schemaClause = schema ? 'WHERE ROUTINE_SCHEMA = ?' : 'WHERE ROUTINE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema] : [];
 
@@ -324,9 +320,7 @@ export class MySQLConnector implements Connector {
 
     try {
       // In MySQL, if no schema is provided, use the current database context
-      const schemaClause = schema
-        ? 'WHERE r.ROUTINE_SCHEMA = ?'
-        : 'WHERE r.ROUTINE_SCHEMA = DATABASE()';
+      const schemaClause = schema ? 'WHERE r.ROUTINE_SCHEMA = ?' : 'WHERE r.ROUTINE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, procedureName] : [procedureName];
 

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -1,4 +1,4 @@
-import mysql from "mysql2/promise";
+import mysql from 'mysql2/promise';
 import {
   Connector,
   ConnectorRegistry,
@@ -7,8 +7,8 @@ import {
   TableColumn,
   TableIndex,
   StoredProcedure,
-} from "../interface.js";
-import { allowedKeywords } from "../../utils/allowed-keywords.js";
+} from '../interface.js';
+import { allowedKeywords } from '../../utils/allowed-keywords.js';
 
 /**
  * MySQL DSN Parser
@@ -29,13 +29,13 @@ class MySQLDSNParser implements DSNParser {
         port: url.port ? parseInt(url.port) : 3306,
         database: url.pathname.substring(1), // Remove leading '/'
         user: url.username,
-        password: url.password ? decodeURIComponent(url.password) : "",
+        password: url.password ? decodeURIComponent(url.password) : '',
       };
 
       // Handle query parameters
       url.searchParams.forEach((value, key) => {
-        if (key === "ssl") {
-          config.ssl = value === "true" ? {} : undefined;
+        if (key === 'ssl') {
+          config.ssl = value === 'true' ? {} : undefined;
         }
         // Add other parameters as needed
       });
@@ -43,21 +43,19 @@ class MySQLDSNParser implements DSNParser {
       return config;
     } catch (error) {
       throw new Error(
-        `Failed to parse MySQL DSN: ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        `Failed to parse MySQL DSN: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
 
   getSampleDSN(): string {
-    return "mysql://root:password@localhost:3306/mysql";
+    return 'mysql://root:password@localhost:3306/mysql';
   }
 
   isValidDSN(dsn: string): boolean {
     try {
       const url = new URL(dsn);
-      return url.protocol === "mysql:";
+      return url.protocol === 'mysql:';
     } catch (error) {
       return false;
     }
@@ -68,8 +66,8 @@ class MySQLDSNParser implements DSNParser {
  * MySQL Connector Implementation
  */
 export class MySQLConnector implements Connector {
-  id = "mysql";
-  name = "MySQL";
+  id = 'mysql';
+  name = 'MySQL';
   dsnParser = new MySQLDSNParser();
 
   private pool: mysql.Pool | null = null;
@@ -80,10 +78,10 @@ export class MySQLConnector implements Connector {
       this.pool = mysql.createPool(config);
 
       // Test the connection
-      const [rows] = await this.pool.query("SELECT 1");
-      console.error("Successfully connected to MySQL database");
+      const [rows] = await this.pool.query('SELECT 1');
+      console.error('Successfully connected to MySQL database');
     } catch (err) {
-      console.error("Failed to connect to MySQL database:", err);
+      console.error('Failed to connect to MySQL database:', err);
       throw err;
     }
   }
@@ -97,7 +95,7 @@ export class MySQLConnector implements Connector {
 
   async getSchemas(): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
@@ -110,23 +108,21 @@ export class MySQLConnector implements Connector {
 
       return rows.map((row) => row.SCHEMA_NAME);
     } catch (error) {
-      console.error("Error getting schemas:", error);
+      console.error('Error getting schemas:', error);
       throw error;
     }
   }
 
   async getTables(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MySQL, if no schema is provided, use the current active database (DATABASE())
       // MySQL uses the terms 'database' and 'schema' interchangeably
       // The DATABASE() function returns the current database context
-      const schemaClause = schema
-        ? "WHERE TABLE_SCHEMA = ?"
-        : "WHERE TABLE_SCHEMA = DATABASE()";
+      const schemaClause = schema ? 'WHERE TABLE_SCHEMA = ?' : 'WHERE TABLE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema] : [];
 
@@ -143,22 +139,20 @@ export class MySQLConnector implements Connector {
 
       return rows.map((row) => row.TABLE_NAME);
     } catch (error) {
-      console.error("Error getting tables:", error);
+      console.error('Error getting tables:', error);
       throw error;
     }
   }
 
   async tableExists(tableName: string, schema?: string): Promise<boolean> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MySQL, if no schema is provided, use the current active database
       // DATABASE() function returns the name of the current database
-      const schemaClause = schema
-        ? "WHERE TABLE_SCHEMA = ?"
-        : "WHERE TABLE_SCHEMA = DATABASE()";
+      const schemaClause = schema ? 'WHERE TABLE_SCHEMA = ?' : 'WHERE TABLE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
@@ -174,24 +168,19 @@ export class MySQLConnector implements Connector {
 
       return rows[0].COUNT > 0;
     } catch (error) {
-      console.error("Error checking if table exists:", error);
+      console.error('Error checking if table exists:', error);
       throw error;
     }
   }
 
-  async getTableIndexes(
-    tableName: string,
-    schema?: string
-  ): Promise<TableIndex[]> {
+  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MySQL, if no schema is provided, use the current active database
-      const schemaClause = schema
-        ? "TABLE_SCHEMA = ?"
-        : "TABLE_SCHEMA = DATABASE()";
+      const schemaClause = schema ? 'TABLE_SCHEMA = ?' : 'TABLE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
@@ -229,7 +218,7 @@ export class MySQLConnector implements Connector {
         const indexName = row.INDEX_NAME;
         const columnName = row.COLUMN_NAME;
         const isUnique = row.NON_UNIQUE === 0; // In MySQL, NON_UNIQUE=0 means the index is unique
-        const isPrimary = indexName === "PRIMARY";
+        const isPrimary = indexName === 'PRIMARY';
 
         if (!indexMap.has(indexName)) {
           indexMap.set(indexName, {
@@ -256,26 +245,21 @@ export class MySQLConnector implements Connector {
 
       return results;
     } catch (error) {
-      console.error("Error getting table indexes:", error);
+      console.error('Error getting table indexes:', error);
       throw error;
     }
   }
 
-  async getTableSchema(
-    tableName: string,
-    schema?: string
-  ): Promise<TableColumn[]> {
+  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MySQL, schema is synonymous with database
       // If no schema is provided, use the current database context via DATABASE() function
       // This means tables will be retrieved from whatever database the connection is currently using
-      const schemaClause = schema
-        ? "WHERE TABLE_SCHEMA = ?"
-        : "WHERE TABLE_SCHEMA = DATABASE()";
+      const schemaClause = schema ? 'WHERE TABLE_SCHEMA = ?' : 'WHERE TABLE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
@@ -297,21 +281,21 @@ export class MySQLConnector implements Connector {
 
       return rows;
     } catch (error) {
-      console.error("Error getting table schema:", error);
+      console.error('Error getting table schema:', error);
       throw error;
     }
   }
 
   async getStoredProcedures(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MySQL, if no schema is provided, use the current database context
       const schemaClause = schema
-        ? "WHERE ROUTINE_SCHEMA = ?"
-        : "WHERE ROUTINE_SCHEMA = DATABASE()";
+        ? 'WHERE ROUTINE_SCHEMA = ?'
+        : 'WHERE ROUTINE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema] : [];
 
@@ -328,24 +312,21 @@ export class MySQLConnector implements Connector {
 
       return rows.map((row) => row.ROUTINE_NAME);
     } catch (error) {
-      console.error("Error getting stored procedures:", error);
+      console.error('Error getting stored procedures:', error);
       throw error;
     }
   }
 
-  async getStoredProcedureDetail(
-    procedureName: string,
-    schema?: string
-  ): Promise<StoredProcedure> {
+  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     try {
       // In MySQL, if no schema is provided, use the current database context
       const schemaClause = schema
-        ? "WHERE r.ROUTINE_SCHEMA = ?"
-        : "WHERE r.ROUTINE_SCHEMA = DATABASE()";
+        ? 'WHERE r.ROUTINE_SCHEMA = ?'
+        : 'WHERE r.ROUTINE_SCHEMA = DATABASE()';
 
       const queryParams = schema ? [schema, procedureName] : [procedureName];
 
@@ -380,10 +361,8 @@ export class MySQLConnector implements Connector {
       )) as [any[], any];
 
       if (rows.length === 0) {
-        const schemaName = schema || "current schema";
-        throw new Error(
-          `Stored procedure '${procedureName}' not found in ${schemaName}`
-        );
+        const schemaName = schema || 'current schema';
+        throw new Error(`Stored procedure '${procedureName}' not found in ${schemaName}`);
       }
 
       const procedure = rows[0];
@@ -395,7 +374,7 @@ export class MySQLConnector implements Connector {
         const schemaValue = schema || (await this.getCurrentSchema());
 
         // For full definition - different approaches based on type
-        if (procedure.procedure_type === "procedure") {
+        if (procedure.procedure_type === 'procedure') {
           // Try to get the definition from SHOW CREATE PROCEDURE
           try {
             const [defRows] = (await this.pool.query(`
@@ -403,12 +382,10 @@ export class MySQLConnector implements Connector {
             `)) as [any[], any];
 
             if (defRows && defRows.length > 0) {
-              definition = defRows[0]["Create Procedure"];
+              definition = defRows[0]['Create Procedure'];
             }
           } catch (err) {
-            console.error(
-              `Error getting procedure definition with SHOW CREATE: ${err}`
-            );
+            console.error(`Error getting procedure definition with SHOW CREATE: ${err}`);
           }
         } else {
           // Try to get the definition for functions
@@ -418,12 +395,10 @@ export class MySQLConnector implements Connector {
             `)) as [any[], any];
 
             if (defRows && defRows.length > 0) {
-              definition = defRows[0]["Create Function"];
+              definition = defRows[0]['Create Function'];
             }
           } catch (innerErr) {
-            console.error(
-              `Error getting function definition with SHOW CREATE: ${innerErr}`
-            );
+            console.error(`Error getting function definition with SHOW CREATE: ${innerErr}`);
           }
         }
 
@@ -454,44 +429,38 @@ export class MySQLConnector implements Connector {
       return {
         procedure_name: procedure.procedure_name,
         procedure_type: procedure.procedure_type,
-        language: "sql", // MySQL procedures are generally in SQL
-        parameter_list: procedure.parameter_list || "",
-        return_type:
-          procedure.routine_type === "function"
-            ? procedure.return_type
-            : undefined,
+        language: 'sql', // MySQL procedures are generally in SQL
+        parameter_list: procedure.parameter_list || '',
+        return_type: procedure.routine_type === 'function' ? procedure.return_type : undefined,
         definition: definition || undefined,
       };
     } catch (error) {
-      console.error("Error getting stored procedure detail:", error);
+      console.error('Error getting stored procedure detail:', error);
       throw error;
     }
   }
 
   // Helper method to get current schema (database) name
   private async getCurrentSchema(): Promise<string> {
-    const [rows] = (await this.pool!.query("SELECT DATABASE() AS DB")) as [
-      any[],
-      any
-    ];
+    const [rows] = (await this.pool!.query('SELECT DATABASE() AS DB')) as [any[], any];
     return rows[0].DB;
   }
 
   async executeQuery(query: string): Promise<QueryResult> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const safetyCheck = this.validateQuery(query);
     if (!safetyCheck.isValid) {
-      throw new Error(safetyCheck.message || "Query validation failed");
+      throw new Error(safetyCheck.message || 'Query validation failed');
     }
 
     try {
       const [rows, fields] = (await this.pool.query(query)) as [any[], any];
       return { rows, fields };
     } catch (error) {
-      console.error("Error executing query:", error);
+      console.error('Error executing query:', error);
       throw error;
     }
   }
@@ -499,12 +468,10 @@ export class MySQLConnector implements Connector {
   validateQuery(query: string): { isValid: boolean; message?: string } {
     // Basic check to prevent non-SELECT queries
     const normalizedQuery = query.trim().toLowerCase();
-    if (
-      !allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))
-    ) {
+    if (!allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))) {
       return {
         isValid: false,
-        message: "Only SELECT queries are allowed for security reasons.",
+        message: 'Only SELECT queries are allowed for security reasons.',
       };
     }
     return { isValid: true };

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -1,6 +1,15 @@
-import pg from 'pg';
+import pg from "pg";
 const { Pool } = pg;
-import { Connector, ConnectorRegistry, DSNParser, QueryResult, TableColumn, TableIndex, StoredProcedure } from '../interface.js';
+import {
+  Connector,
+  ConnectorRegistry,
+  DSNParser,
+  QueryResult,
+  TableColumn,
+  TableIndex,
+  StoredProcedure,
+} from "../interface.js";
+import { allowedKeywords } from "../../utils/allowed-keywords.js";
 
 /**
  * PostgreSQL DSN Parser
@@ -17,37 +26,41 @@ class PostgresDSNParser implements DSNParser {
       // For PostgreSQL, we can actually pass the DSN directly to the Pool constructor
       // But we'll parse it here for consistency and to extract components if needed
       const url = new URL(dsn);
-      
+
       const config: pg.PoolConfig = {
         host: url.hostname,
         port: url.port ? parseInt(url.port) : 5432,
         database: url.pathname.substring(1), // Remove leading '/'
         user: url.username,
-        password: url.password ? decodeURIComponent(url.password) : '',
+        password: url.password ? decodeURIComponent(url.password) : "",
       };
-      
+
       // Handle query parameters (like sslmode, etc.)
       url.searchParams.forEach((value, key) => {
-        if (key === 'sslmode') {
-          config.ssl = value !== 'disable';
+        if (key === "sslmode") {
+          config.ssl = value !== "disable";
         }
         // Add other parameters as needed
       });
-      
+
       return config;
     } catch (error) {
-      throw new Error(`Failed to parse PostgreSQL DSN: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to parse PostgreSQL DSN: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 
   getSampleDSN(): string {
-    return 'postgres://postgres:password@localhost:5432/postgres?sslmode=disable';
+    return "postgres://postgres:password@localhost:5432/postgres?sslmode=disable";
   }
 
   isValidDSN(dsn: string): boolean {
     try {
       const url = new URL(dsn);
-      return url.protocol === 'postgres:' || url.protocol === 'postgresql:';
+      return url.protocol === "postgres:" || url.protocol === "postgresql:";
     } catch (error) {
       return false;
     }
@@ -58,17 +71,17 @@ class PostgresDSNParser implements DSNParser {
  * PostgreSQL Connector Implementation
  */
 export class PostgresConnector implements Connector {
-  id = 'postgres';
-  name = 'PostgreSQL';
+  id = "postgres";
+  name = "PostgreSQL";
   dsnParser = new PostgresDSNParser();
-  
+
   private pool: pg.Pool | null = null;
 
   async connect(dsn: string): Promise<void> {
     try {
       const config = await this.dsnParser.parse(dsn);
       this.pool = new Pool(config);
-      
+
       // Test the connection
       const client = await this.pool.connect();
       console.error("Successfully connected to PostgreSQL database");
@@ -88,9 +101,9 @@ export class PostgresConnector implements Connector {
 
   async getSchemas(): Promise<string[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const client = await this.pool.connect();
     try {
       const result = await client.query(`
@@ -99,8 +112,8 @@ export class PostgresConnector implements Connector {
         WHERE schema_name NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
         ORDER BY schema_name
       `);
-      
-      return result.rows.map(row => row.schema_name);
+
+      return result.rows.map((row) => row.schema_name);
     } finally {
       client.release();
     }
@@ -108,23 +121,26 @@ export class PostgresConnector implements Connector {
 
   async getTables(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
       // 'public' is the standard default schema in PostgreSQL databases
-      const schemaToUse = schema || 'public';
-      
-      const result = await client.query(`
+      const schemaToUse = schema || "public";
+
+      const result = await client.query(
+        `
         SELECT table_name 
         FROM information_schema.tables 
         WHERE table_schema = $1
         ORDER BY table_name
-      `, [schemaToUse]);
-      
-      return result.rows.map(row => row.table_name);
+      `,
+        [schemaToUse]
+      );
+
+      return result.rows.map((row) => row.table_name);
     } finally {
       client.release();
     }
@@ -132,40 +148,47 @@ export class PostgresConnector implements Connector {
 
   async tableExists(tableName: string, schema?: string): Promise<boolean> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
-      const schemaToUse = schema || 'public';
-      
-      const result = await client.query(`
+      const schemaToUse = schema || "public";
+
+      const result = await client.query(
+        `
         SELECT EXISTS (
           SELECT FROM information_schema.tables 
           WHERE table_schema = $1 
           AND table_name = $2
         )
-      `, [schemaToUse, tableName]);
-      
+      `,
+        [schemaToUse, tableName]
+      );
+
       return result.rows[0].exists;
     } finally {
       client.release();
     }
   }
 
-  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
+  async getTableIndexes(
+    tableName: string,
+    schema?: string
+  ): Promise<TableIndex[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
-      const schemaToUse = schema || 'public';
-      
+      const schemaToUse = schema || "public";
+
       // Query to get all indexes for the table
-      const result = await client.query(`
+      const result = await client.query(
+        `
         SELECT 
           i.relname as index_name,
           array_agg(a.attname) as column_names,
@@ -192,32 +215,38 @@ export class PostgresConnector implements Connector {
           ix.indisprimary
         ORDER BY 
           i.relname
-      `, [tableName, schemaToUse]);
-      
-      return result.rows.map(row => ({
+      `,
+        [tableName, schemaToUse]
+      );
+
+      return result.rows.map((row) => ({
         index_name: row.index_name,
         column_names: row.column_names,
         is_unique: row.is_unique,
-        is_primary: row.is_primary
+        is_primary: row.is_primary,
       }));
     } finally {
       client.release();
     }
   }
 
-  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
+  async getTableSchema(
+    tableName: string,
+    schema?: string
+  ): Promise<TableColumn[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
       // Tables are created in the 'public' schema by default unless otherwise specified
-      const schemaToUse = schema || 'public';
-      
+      const schemaToUse = schema || "public";
+
       // Get table columns
-      const result = await client.query(`
+      const result = await client.query(
+        `
         SELECT 
           column_name, 
           data_type, 
@@ -227,8 +256,10 @@ export class PostgresConnector implements Connector {
         WHERE table_schema = $1
         AND table_name = $2
         ORDER BY ordinal_position
-      `, [schemaToUse, tableName]);
-      
+      `,
+        [schemaToUse, tableName]
+      );
+
       return result.rows;
     } finally {
       client.release();
@@ -237,41 +268,48 @@ export class PostgresConnector implements Connector {
 
   async getStoredProcedures(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
-      const schemaToUse = schema || 'public';
-      
+      const schemaToUse = schema || "public";
+
       // Get stored procedures and functions from PostgreSQL
-      const result = await client.query(`
+      const result = await client.query(
+        `
         SELECT 
           routine_name
         FROM information_schema.routines
         WHERE routine_schema = $1
         ORDER BY routine_name
-      `, [schemaToUse]);
-      
-      return result.rows.map(row => row.routine_name);
+      `,
+        [schemaToUse]
+      );
+
+      return result.rows.map((row) => row.routine_name);
     } finally {
       client.release();
     }
   }
 
-  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
+  async getStoredProcedureDetail(
+    procedureName: string,
+    schema?: string
+  ): Promise<StoredProcedure> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
-      const schemaToUse = schema || 'public';
-      
+      const schemaToUse = schema || "public";
+
       // Get stored procedure details from PostgreSQL
-      const result = await client.query(`
+      const result = await client.query(
+        `
         SELECT 
           routine_name as procedure_name,
           routine_type,
@@ -294,32 +332,42 @@ export class PostgresConnector implements Connector {
         FROM information_schema.routines
         WHERE routine_schema = $1
         AND routine_name = $2
-      `, [schemaToUse, procedureName]);
-      
+      `,
+        [schemaToUse, procedureName]
+      );
+
       if (result.rows.length === 0) {
-        throw new Error(`Stored procedure '${procedureName}' not found in schema '${schemaToUse}'`);
+        throw new Error(
+          `Stored procedure '${procedureName}' not found in schema '${schemaToUse}'`
+        );
       }
-      
+
       const procedure = result.rows[0];
 
       // If routine_definition is NULL, try to get the procedure body with pg_get_functiondef
       let definition = procedure.definition;
-      
+
       try {
         // Get the OID for the procedure/function
-        const oidResult = await client.query(`
+        const oidResult = await client.query(
+          `
           SELECT p.oid, p.prosrc
           FROM pg_proc p
           JOIN pg_namespace n ON p.pronamespace = n.oid
           WHERE p.proname = $1
           AND n.nspname = $2
-        `, [procedureName, schemaToUse]);
-        
+        `,
+          [procedureName, schemaToUse]
+        );
+
         if (oidResult.rows.length > 0) {
           // If definition is still null, get the full definition
           if (!definition) {
             const oid = oidResult.rows[0].oid;
-            const defResult = await client.query(`SELECT pg_get_functiondef($1)`, [oid]);
+            const defResult = await client.query(
+              `SELECT pg_get_functiondef($1)`,
+              [oid]
+            );
             if (defResult.rows.length > 0) {
               definition = defResult.rows[0].pg_get_functiondef;
             } else {
@@ -332,14 +380,15 @@ export class PostgresConnector implements Connector {
         // Ignore errors trying to get definition - it's optional
         console.error(`Error getting procedure definition: ${err}`);
       }
-      
+
       return {
         procedure_name: procedure.procedure_name,
         procedure_type: procedure.procedure_type,
-        language: procedure.language || 'sql',
-        parameter_list: procedure.parameter_list || '',
-        return_type: procedure.return_type !== 'void' ? procedure.return_type : undefined,
-        definition: definition || undefined
+        language: procedure.language || "sql",
+        parameter_list: procedure.parameter_list || "",
+        return_type:
+          procedure.return_type !== "void" ? procedure.return_type : undefined,
+        definition: definition || undefined,
       };
     } finally {
       client.release();
@@ -348,9 +397,9 @@ export class PostgresConnector implements Connector {
 
   async executeQuery(query: string): Promise<QueryResult> {
     if (!this.pool) {
-      throw new Error('Not connected to database');
+      throw new Error("Not connected to database");
     }
-    
+
     const safetyCheck = this.validateQuery(query);
     if (!safetyCheck.isValid) {
       throw new Error(safetyCheck.message || "Query validation failed");
@@ -367,10 +416,12 @@ export class PostgresConnector implements Connector {
   validateQuery(query: string): { isValid: boolean; message?: string } {
     // Basic check to prevent non-SELECT queries
     const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery.startsWith('select')) {
+    if (
+      !allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))
+    ) {
       return {
         isValid: false,
-        message: "Only SELECT queries are allowed for security reasons."
+        message: "Only SELECT queries are allowed for security reasons.",
       };
     }
     return { isValid: true };

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -1,4 +1,4 @@
-import pg from "pg";
+import pg from 'pg';
 const { Pool } = pg;
 import {
   Connector,
@@ -8,8 +8,8 @@ import {
   TableColumn,
   TableIndex,
   StoredProcedure,
-} from "../interface.js";
-import { allowedKeywords } from "../../utils/allowed-keywords.js";
+} from '../interface.js';
+import { allowedKeywords } from '../../utils/allowed-keywords.js';
 
 /**
  * PostgreSQL DSN Parser
@@ -32,13 +32,13 @@ class PostgresDSNParser implements DSNParser {
         port: url.port ? parseInt(url.port) : 5432,
         database: url.pathname.substring(1), // Remove leading '/'
         user: url.username,
-        password: url.password ? decodeURIComponent(url.password) : "",
+        password: url.password ? decodeURIComponent(url.password) : '',
       };
 
       // Handle query parameters (like sslmode, etc.)
       url.searchParams.forEach((value, key) => {
-        if (key === "sslmode") {
-          config.ssl = value !== "disable";
+        if (key === 'sslmode') {
+          config.ssl = value !== 'disable';
         }
         // Add other parameters as needed
       });
@@ -46,21 +46,19 @@ class PostgresDSNParser implements DSNParser {
       return config;
     } catch (error) {
       throw new Error(
-        `Failed to parse PostgreSQL DSN: ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        `Failed to parse PostgreSQL DSN: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
 
   getSampleDSN(): string {
-    return "postgres://postgres:password@localhost:5432/postgres?sslmode=disable";
+    return 'postgres://postgres:password@localhost:5432/postgres?sslmode=disable';
   }
 
   isValidDSN(dsn: string): boolean {
     try {
       const url = new URL(dsn);
-      return url.protocol === "postgres:" || url.protocol === "postgresql:";
+      return url.protocol === 'postgres:' || url.protocol === 'postgresql:';
     } catch (error) {
       return false;
     }
@@ -71,8 +69,8 @@ class PostgresDSNParser implements DSNParser {
  * PostgreSQL Connector Implementation
  */
 export class PostgresConnector implements Connector {
-  id = "postgres";
-  name = "PostgreSQL";
+  id = 'postgres';
+  name = 'PostgreSQL';
   dsnParser = new PostgresDSNParser();
 
   private pool: pg.Pool | null = null;
@@ -84,10 +82,10 @@ export class PostgresConnector implements Connector {
 
       // Test the connection
       const client = await this.pool.connect();
-      console.error("Successfully connected to PostgreSQL database");
+      console.error('Successfully connected to PostgreSQL database');
       client.release();
     } catch (err) {
-      console.error("Failed to connect to PostgreSQL database:", err);
+      console.error('Failed to connect to PostgreSQL database:', err);
       throw err;
     }
   }
@@ -101,7 +99,7 @@ export class PostgresConnector implements Connector {
 
   async getSchemas(): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const client = await this.pool.connect();
@@ -121,14 +119,14 @@ export class PostgresConnector implements Connector {
 
   async getTables(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
       // 'public' is the standard default schema in PostgreSQL databases
-      const schemaToUse = schema || "public";
+      const schemaToUse = schema || 'public';
 
       const result = await client.query(
         `
@@ -148,13 +146,13 @@ export class PostgresConnector implements Connector {
 
   async tableExists(tableName: string, schema?: string): Promise<boolean> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
-      const schemaToUse = schema || "public";
+      const schemaToUse = schema || 'public';
 
       const result = await client.query(
         `
@@ -173,18 +171,15 @@ export class PostgresConnector implements Connector {
     }
   }
 
-  async getTableIndexes(
-    tableName: string,
-    schema?: string
-  ): Promise<TableIndex[]> {
+  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
-      const schemaToUse = schema || "public";
+      const schemaToUse = schema || 'public';
 
       // Query to get all indexes for the table
       const result = await client.query(
@@ -230,19 +225,16 @@ export class PostgresConnector implements Connector {
     }
   }
 
-  async getTableSchema(
-    tableName: string,
-    schema?: string
-  ): Promise<TableColumn[]> {
+  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
       // Tables are created in the 'public' schema by default unless otherwise specified
-      const schemaToUse = schema || "public";
+      const schemaToUse = schema || 'public';
 
       // Get table columns
       const result = await client.query(
@@ -268,13 +260,13 @@ export class PostgresConnector implements Connector {
 
   async getStoredProcedures(schema?: string): Promise<string[]> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
-      const schemaToUse = schema || "public";
+      const schemaToUse = schema || 'public';
 
       // Get stored procedures and functions from PostgreSQL
       const result = await client.query(
@@ -294,18 +286,15 @@ export class PostgresConnector implements Connector {
     }
   }
 
-  async getStoredProcedureDetail(
-    procedureName: string,
-    schema?: string
-  ): Promise<StoredProcedure> {
+  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const client = await this.pool.connect();
     try {
       // In PostgreSQL, use 'public' as the default schema if none specified
-      const schemaToUse = schema || "public";
+      const schemaToUse = schema || 'public';
 
       // Get stored procedure details from PostgreSQL
       const result = await client.query(
@@ -337,9 +326,7 @@ export class PostgresConnector implements Connector {
       );
 
       if (result.rows.length === 0) {
-        throw new Error(
-          `Stored procedure '${procedureName}' not found in schema '${schemaToUse}'`
-        );
+        throw new Error(`Stored procedure '${procedureName}' not found in schema '${schemaToUse}'`);
       }
 
       const procedure = result.rows[0];
@@ -364,10 +351,7 @@ export class PostgresConnector implements Connector {
           // If definition is still null, get the full definition
           if (!definition) {
             const oid = oidResult.rows[0].oid;
-            const defResult = await client.query(
-              `SELECT pg_get_functiondef($1)`,
-              [oid]
-            );
+            const defResult = await client.query(`SELECT pg_get_functiondef($1)`, [oid]);
             if (defResult.rows.length > 0) {
               definition = defResult.rows[0].pg_get_functiondef;
             } else {
@@ -384,10 +368,9 @@ export class PostgresConnector implements Connector {
       return {
         procedure_name: procedure.procedure_name,
         procedure_type: procedure.procedure_type,
-        language: procedure.language || "sql",
-        parameter_list: procedure.parameter_list || "",
-        return_type:
-          procedure.return_type !== "void" ? procedure.return_type : undefined,
+        language: procedure.language || 'sql',
+        parameter_list: procedure.parameter_list || '',
+        return_type: procedure.return_type !== 'void' ? procedure.return_type : undefined,
         definition: definition || undefined,
       };
     } finally {
@@ -397,12 +380,12 @@ export class PostgresConnector implements Connector {
 
   async executeQuery(query: string): Promise<QueryResult> {
     if (!this.pool) {
-      throw new Error("Not connected to database");
+      throw new Error('Not connected to database');
     }
 
     const safetyCheck = this.validateQuery(query);
     if (!safetyCheck.isValid) {
-      throw new Error(safetyCheck.message || "Query validation failed");
+      throw new Error(safetyCheck.message || 'Query validation failed');
     }
 
     const client = await this.pool.connect();
@@ -416,12 +399,10 @@ export class PostgresConnector implements Connector {
   validateQuery(query: string): { isValid: boolean; message?: string } {
     // Basic check to prevent non-SELECT queries
     const normalizedQuery = query.trim().toLowerCase();
-    if (
-      !allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))
-    ) {
+    if (!allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))) {
       return {
         isValid: false,
-        message: "Only SELECT queries are allowed for security reasons.",
+        message: 'Only SELECT queries are allowed for security reasons.',
       };
     }
     return { isValid: true };

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -45,9 +45,7 @@ class PostgresDSNParser implements DSNParser {
 
       return config;
     } catch (error) {
-      throw new Error(
-        `Failed to parse PostgreSQL DSN: ${error instanceof Error ? error.message : String(error)}`
-      );
+      throw new Error(`Failed to parse PostgreSQL DSN: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -7,7 +7,7 @@
  * 2. Or set DB_CONNECTOR_TYPE=sqlite for default in-memory database
  */
 
-import { allowedKeywords } from "../../utils/allowed-keywords.js";
+import { allowedKeywords } from '../../utils/allowed-keywords.js';
 import {
   Connector,
   ConnectorRegistry,
@@ -16,8 +16,8 @@ import {
   TableColumn,
   TableIndex,
   StoredProcedure,
-} from "../interface.js";
-import Database from "better-sqlite3";
+} from '../interface.js';
+import Database from 'better-sqlite3';
 
 /**
  * SQLite DSN Parser
@@ -38,13 +38,13 @@ class SQLiteDSNParser implements DSNParser {
       let dbPath: string;
 
       // Handle in-memory database
-      if (url.hostname === "" && url.pathname === ":memory:") {
-        dbPath = ":memory:";
+      if (url.hostname === '' && url.pathname === ':memory:') {
+        dbPath = ':memory:';
       }
       // Handle file paths
       else {
         // Get the path part, handling both relative and absolute paths
-        if (url.pathname.startsWith("//")) {
+        if (url.pathname.startsWith('//')) {
           // Absolute path: sqlite:///path/to/db.sqlite
           dbPath = url.pathname.substring(2); // Remove leading //
         } else {
@@ -56,21 +56,19 @@ class SQLiteDSNParser implements DSNParser {
       return { dbPath };
     } catch (error) {
       throw new Error(
-        `Failed to parse SQLite DSN: ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        `Failed to parse SQLite DSN: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
 
   getSampleDSN(): string {
-    return "sqlite:///path/to/database.db";
+    return 'sqlite:///path/to/database.db';
   }
 
   isValidDSN(dsn: string): boolean {
     try {
       const url = new URL(dsn);
-      return url.protocol === "sqlite:";
+      return url.protocol === 'sqlite:';
     } catch (error) {
       return false;
     }
@@ -90,12 +88,12 @@ interface SQLiteTableNameRow {
 }
 
 export class SQLiteConnector implements Connector {
-  id = "sqlite";
-  name = "SQLite";
+  id = 'sqlite';
+  name = 'SQLite';
   dsnParser = new SQLiteDSNParser();
 
   private db: Database.Database | null = null;
-  private dbPath: string = ":memory:"; // Default to in-memory database
+  private dbPath: string = ':memory:'; // Default to in-memory database
 
   async connect(dsn: string, initScript?: string): Promise<void> {
     const config = await this.dsnParser.parse(dsn);
@@ -103,15 +101,15 @@ export class SQLiteConnector implements Connector {
 
     try {
       this.db = new Database(this.dbPath);
-      console.error("Successfully connected to SQLite database");
+      console.error('Successfully connected to SQLite database');
 
       // If an initialization script is provided, run it
       if (initScript) {
         this.db.exec(initScript);
-        console.error("Successfully initialized database with script");
+        console.error('Successfully initialized database with script');
       }
     } catch (error) {
-      console.error("Failed to connect to SQLite database:", error);
+      console.error('Failed to connect to SQLite database:', error);
       throw error;
     }
   }
@@ -130,19 +128,19 @@ export class SQLiteConnector implements Connector {
 
   async getSchemas(): Promise<string[]> {
     if (!this.db) {
-      throw new Error("Not connected to SQLite database");
+      throw new Error('Not connected to SQLite database');
     }
 
     // SQLite doesn't have the concept of schemas like PostgreSQL or MySQL
     // It has a concept of "attached databases" where each database has a name
     // The default database is called 'main', and others can be attached with names
     // We return the database name or 'main' for in-memory databases as the "schema"
-    return [this.dbPath === ":memory:" ? "main" : this.dbPath];
+    return [this.dbPath === ':memory:' ? 'main' : this.dbPath];
   }
 
   async getTables(schema?: string): Promise<string[]> {
     if (!this.db) {
-      throw new Error("Not connected to SQLite database");
+      throw new Error('Not connected to SQLite database');
     }
 
     // In SQLite, schema parameter is ignored since SQLite doesn't have schemas like PostgreSQL
@@ -168,7 +166,7 @@ export class SQLiteConnector implements Connector {
 
   async tableExists(tableName: string, schema?: string): Promise<boolean> {
     if (!this.db) {
-      throw new Error("Not connected to SQLite database");
+      throw new Error('Not connected to SQLite database');
     }
 
     // In SQLite, schema parameter is ignored since there's only one schema per database file
@@ -189,12 +187,9 @@ export class SQLiteConnector implements Connector {
     }
   }
 
-  async getTableIndexes(
-    tableName: string,
-    schema?: string
-  ): Promise<TableIndex[]> {
+  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
     if (!this.db) {
-      throw new Error("Not connected to SQLite database");
+      throw new Error('Not connected to SQLite database');
     }
 
     // In SQLite, schema parameter is ignored (no schema concept)
@@ -222,9 +217,7 @@ export class SQLiteConnector implements Connector {
         .all() as SQLiteTableInfo[];
 
       // Find primary key columns
-      const pkColumns = tableInfo
-        .filter((col) => col.pk > 0)
-        .map((col) => col.name);
+      const pkColumns = tableInfo.filter((col) => col.pk > 0).map((col) => col.name);
 
       const results: TableIndex[] = [];
 
@@ -247,7 +240,7 @@ export class SQLiteConnector implements Connector {
       // Add primary key if it exists
       if (pkColumns.length > 0) {
         results.push({
-          index_name: "PRIMARY",
+          index_name: 'PRIMARY',
           column_names: pkColumns,
           is_unique: true,
           is_primary: true,
@@ -260,12 +253,9 @@ export class SQLiteConnector implements Connector {
     }
   }
 
-  async getTableSchema(
-    tableName: string,
-    schema?: string
-  ): Promise<TableColumn[]> {
+  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
     if (!this.db) {
-      throw new Error("Not connected to SQLite database");
+      throw new Error('Not connected to SQLite database');
     }
 
     // In SQLite, schema parameter is ignored for the following reasons:
@@ -273,15 +263,13 @@ export class SQLiteConnector implements Connector {
     // 2. Each SQLite database file is its own separate namespace
     // 3. The PRAGMA commands operate on the current database connection
     try {
-      const rows = this.db
-        .prepare(`PRAGMA table_info(${tableName})`)
-        .all() as SQLiteTableInfo[];
+      const rows = this.db.prepare(`PRAGMA table_info(${tableName})`).all() as SQLiteTableInfo[];
 
       // Convert SQLite schema format to our standard TableColumn format
       const columns = rows.map((row) => ({
         column_name: row.name,
         data_type: row.type,
-        is_nullable: row.notnull === 0 ? "YES" : "NO", // In SQLite, 0 means nullable
+        is_nullable: row.notnull === 0 ? 'YES' : 'NO', // In SQLite, 0 means nullable
         column_default: row.dflt_value,
       }));
 
@@ -293,7 +281,7 @@ export class SQLiteConnector implements Connector {
 
   async getStoredProcedures(schema?: string): Promise<string[]> {
     if (!this.db) {
-      throw new Error("Not connected to SQLite database");
+      throw new Error('Not connected to SQLite database');
     }
 
     // SQLite doesn't have built-in stored procedures like other databases.
@@ -309,12 +297,9 @@ export class SQLiteConnector implements Connector {
     return [];
   }
 
-  async getStoredProcedureDetail(
-    procedureName: string,
-    schema?: string
-  ): Promise<StoredProcedure> {
+  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
     if (!this.db) {
-      throw new Error("Not connected to SQLite database");
+      throw new Error('Not connected to SQLite database');
     }
 
     // SQLite doesn't have true stored procedures:
@@ -324,19 +309,19 @@ export class SQLiteConnector implements Connector {
 
     // Throw an error since SQLite doesn't support stored procedures
     throw new Error(
-      "SQLite does not support stored procedures. Functions are defined programmatically through the SQLite API, not stored in the database."
+      'SQLite does not support stored procedures. Functions are defined programmatically through the SQLite API, not stored in the database.'
     );
   }
 
   async executeQuery(query: string): Promise<QueryResult> {
     if (!this.db) {
-      throw new Error("Not connected to SQLite database");
+      throw new Error('Not connected to SQLite database');
     }
 
     // Validate query for safety
     const safetyCheck = this.validateQuery(query);
     if (!safetyCheck.isValid) {
-      throw new Error(safetyCheck.message || "Query validation failed");
+      throw new Error(safetyCheck.message || 'Query validation failed');
     }
 
     try {
@@ -350,12 +335,10 @@ export class SQLiteConnector implements Connector {
   validateQuery(query: string): { isValid: boolean; message?: string } {
     // Basic check to prevent non-SELECT queries
     const normalizedQuery = query.trim().toLowerCase();
-    if (
-      !allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))
-    ) {
+    if (!allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))) {
       return {
         isValid: false,
-        message: "Only SELECT queries are allowed for security reasons.",
+        message: 'Only SELECT queries are allowed for security reasons.',
       };
     }
     return { isValid: true };

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -55,9 +55,7 @@ class SQLiteDSNParser implements DSNParser {
 
       return { dbPath };
     } catch (error) {
-      throw new Error(
-        `Failed to parse SQLite DSN: ${error instanceof Error ? error.message : String(error)}`
-      );
+      throw new Error(`Failed to parse SQLite DSN: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
@@ -212,9 +210,7 @@ export class SQLiteConnector implements Connector {
         .all(tableName) as { index_name: string; is_unique: number }[];
 
       // Get the primary key info
-      const tableInfo = this.db
-        .prepare(`PRAGMA table_info(${tableName})`)
-        .all() as SQLiteTableInfo[];
+      const tableInfo = this.db.prepare(`PRAGMA table_info(${tableName})`).all() as SQLiteTableInfo[];
 
       // Find primary key columns
       const pkColumns = tableInfo.filter((col) => col.pk > 0).map((col) => col.name);
@@ -224,9 +220,9 @@ export class SQLiteConnector implements Connector {
       // Add regular indexes
       for (const indexInfo of indexInfoRows) {
         // Get the columns for this index
-        const indexDetailRows = this.db
-          .prepare(`PRAGMA index_info(${indexInfo.index_name})`)
-          .all() as { name: string }[];
+        const indexDetailRows = this.db.prepare(`PRAGMA index_info(${indexInfo.index_name})`).all() as {
+          name: string;
+        }[];
         const columnNames = indexDetailRows.map((row) => row.name);
 
         results.push({

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -1,18 +1,27 @@
 /**
  * SQLite Connector Implementation
- * 
+ *
  * Implements SQLite database connectivity for DBHub using better-sqlite3
  * To use this connector:
  * 1. Set DSN=sqlite:///path/to/database.db in your .env file
  * 2. Or set DB_CONNECTOR_TYPE=sqlite for default in-memory database
  */
 
-import { Connector, ConnectorRegistry, DSNParser, QueryResult, TableColumn, TableIndex, StoredProcedure } from '../interface.js';
-import Database from 'better-sqlite3';
+import { allowedKeywords } from "../../utils/allowed-keywords.js";
+import {
+  Connector,
+  ConnectorRegistry,
+  DSNParser,
+  QueryResult,
+  TableColumn,
+  TableIndex,
+  StoredProcedure,
+} from "../interface.js";
+import Database from "better-sqlite3";
 
 /**
  * SQLite DSN Parser
- * Handles DSN strings like: 
+ * Handles DSN strings like:
  * - sqlite:///path/to/database.db (absolute path)
  * - sqlite://./relative/path/to/database.db (relative path)
  * - sqlite::memory: (in-memory database)
@@ -27,15 +36,15 @@ class SQLiteDSNParser implements DSNParser {
     try {
       const url = new URL(dsn);
       let dbPath: string;
-      
+
       // Handle in-memory database
-      if (url.hostname === '' && url.pathname === ':memory:') {
-        dbPath = ':memory:';
-      } 
+      if (url.hostname === "" && url.pathname === ":memory:") {
+        dbPath = ":memory:";
+      }
       // Handle file paths
       else {
         // Get the path part, handling both relative and absolute paths
-        if (url.pathname.startsWith('//')) {
+        if (url.pathname.startsWith("//")) {
           // Absolute path: sqlite:///path/to/db.sqlite
           dbPath = url.pathname.substring(2); // Remove leading //
         } else {
@@ -43,21 +52,25 @@ class SQLiteDSNParser implements DSNParser {
           dbPath = url.pathname;
         }
       }
-      
+
       return { dbPath };
     } catch (error) {
-      throw new Error(`Failed to parse SQLite DSN: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to parse SQLite DSN: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 
   getSampleDSN(): string {
-    return 'sqlite:///path/to/database.db';
+    return "sqlite:///path/to/database.db";
   }
 
   isValidDSN(dsn: string): boolean {
     try {
       const url = new URL(dsn);
-      return url.protocol === 'sqlite:';
+      return url.protocol === "sqlite:";
     } catch (error) {
       return false;
     }
@@ -77,21 +90,21 @@ interface SQLiteTableNameRow {
 }
 
 export class SQLiteConnector implements Connector {
-  id = 'sqlite';
-  name = 'SQLite';
+  id = "sqlite";
+  name = "SQLite";
   dsnParser = new SQLiteDSNParser();
-  
+
   private db: Database.Database | null = null;
-  private dbPath: string = ':memory:'; // Default to in-memory database
+  private dbPath: string = ":memory:"; // Default to in-memory database
 
   async connect(dsn: string, initScript?: string): Promise<void> {
     const config = await this.dsnParser.parse(dsn);
     this.dbPath = config.dbPath;
-    
+
     try {
       this.db = new Database(this.dbPath);
       console.error("Successfully connected to SQLite database");
-      
+
       // If an initialization script is provided, run it
       if (initScript) {
         this.db.exec(initScript);
@@ -119,31 +132,35 @@ export class SQLiteConnector implements Connector {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
-    
+
     // SQLite doesn't have the concept of schemas like PostgreSQL or MySQL
     // It has a concept of "attached databases" where each database has a name
     // The default database is called 'main', and others can be attached with names
     // We return the database name or 'main' for in-memory databases as the "schema"
-    return [this.dbPath === ':memory:' ? 'main' : this.dbPath];
+    return [this.dbPath === ":memory:" ? "main" : this.dbPath];
   }
 
   async getTables(schema?: string): Promise<string[]> {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
-    
+
     // In SQLite, schema parameter is ignored since SQLite doesn't have schemas like PostgreSQL
     // SQLite has a single namespace for tables within a database file
     // You could use 'schema.table' syntax if you have attached databases, but we're
     // accessing the 'main' database by default
     try {
-      const rows = this.db.prepare(`
+      const rows = this.db
+        .prepare(
+          `
         SELECT name FROM sqlite_master 
         WHERE type='table' AND name NOT LIKE 'sqlite_%'
         ORDER BY name
-      `).all() as SQLiteTableNameRow[];
-      
-      return rows.map(row => row.name);
+      `
+        )
+        .all() as SQLiteTableNameRow[];
+
+      return rows.map((row) => row.name);
     } catch (error) {
       throw error;
     }
@@ -153,30 +170,39 @@ export class SQLiteConnector implements Connector {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
-    
+
     // In SQLite, schema parameter is ignored since there's only one schema per database file
     // All tables exist in a single namespace within the SQLite database
     try {
-      const row = this.db.prepare(`
+      const row = this.db
+        .prepare(
+          `
         SELECT name FROM sqlite_master 
         WHERE type='table' AND name = ?
-      `).get(tableName) as SQLiteTableNameRow | undefined;
-      
+      `
+        )
+        .get(tableName) as SQLiteTableNameRow | undefined;
+
       return !!row;
     } catch (error) {
       throw error;
     }
   }
 
-  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
+  async getTableIndexes(
+    tableName: string,
+    schema?: string
+  ): Promise<TableIndex[]> {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
-    
+
     // In SQLite, schema parameter is ignored (no schema concept)
     try {
       // Get all indexes for the specified table
-      const indexInfoRows = this.db.prepare(`
+      const indexInfoRows = this.db
+        .prepare(
+          `
         SELECT 
           name as index_name,
           CASE 
@@ -186,68 +212,79 @@ export class SQLiteConnector implements Connector {
         FROM sqlite_master 
         WHERE type = 'index' 
         AND tbl_name = ?
-      `).all(tableName) as { index_name: string, is_unique: number }[];
-      
+      `
+        )
+        .all(tableName) as { index_name: string; is_unique: number }[];
+
       // Get the primary key info
-      const tableInfo = this.db.prepare(`PRAGMA table_info(${tableName})`).all() as SQLiteTableInfo[];
-      
+      const tableInfo = this.db
+        .prepare(`PRAGMA table_info(${tableName})`)
+        .all() as SQLiteTableInfo[];
+
       // Find primary key columns
       const pkColumns = tableInfo
-        .filter(col => col.pk > 0)
-        .map(col => col.name);
-      
+        .filter((col) => col.pk > 0)
+        .map((col) => col.name);
+
       const results: TableIndex[] = [];
-      
+
       // Add regular indexes
       for (const indexInfo of indexInfoRows) {
         // Get the columns for this index
-        const indexDetailRows = this.db.prepare(`PRAGMA index_info(${indexInfo.index_name})`).all() as { name: string }[];
-        const columnNames = indexDetailRows.map(row => row.name);
-        
+        const indexDetailRows = this.db
+          .prepare(`PRAGMA index_info(${indexInfo.index_name})`)
+          .all() as { name: string }[];
+        const columnNames = indexDetailRows.map((row) => row.name);
+
         results.push({
           index_name: indexInfo.index_name,
           column_names: columnNames,
           is_unique: indexInfo.is_unique === 1,
-          is_primary: false
+          is_primary: false,
         });
       }
-      
+
       // Add primary key if it exists
       if (pkColumns.length > 0) {
         results.push({
-          index_name: 'PRIMARY',
+          index_name: "PRIMARY",
           column_names: pkColumns,
           is_unique: true,
-          is_primary: true
+          is_primary: true,
         });
       }
-      
+
       return results;
     } catch (error) {
       throw error;
     }
   }
 
-  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
+  async getTableSchema(
+    tableName: string,
+    schema?: string
+  ): Promise<TableColumn[]> {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
-    
+
     // In SQLite, schema parameter is ignored for the following reasons:
     // 1. SQLite doesn't have schemas in the same way as PostgreSQL or MySQL
     // 2. Each SQLite database file is its own separate namespace
     // 3. The PRAGMA commands operate on the current database connection
     try {
-      const rows = this.db.prepare(`PRAGMA table_info(${tableName})`).all() as SQLiteTableInfo[];
-      
+      const rows = this.db
+        .prepare(`PRAGMA table_info(${tableName})`)
+        .all() as SQLiteTableInfo[];
+
       // Convert SQLite schema format to our standard TableColumn format
-      const columns = rows.map(row => ({
+      const columns = rows.map((row) => ({
         column_name: row.name,
         data_type: row.type,
-        is_nullable: row.notnull === 0 ? 'YES' : 'NO', // In SQLite, 0 means nullable
-        column_default: row.dflt_value
+        is_nullable: row.notnull === 0 ? "YES" : "NO", // In SQLite, 0 means nullable
+        column_default: row.dflt_value,
       }));
-      
+
       return columns;
     } catch (error) {
       throw error;
@@ -258,7 +295,7 @@ export class SQLiteConnector implements Connector {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
-    
+
     // SQLite doesn't have built-in stored procedures like other databases.
     // While SQLite does support user-defined functions, these are registered through
     // the C/C++ API or language bindings and cannot be introspected through SQL.
@@ -272,25 +309,30 @@ export class SQLiteConnector implements Connector {
     return [];
   }
 
-  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
+  async getStoredProcedureDetail(
+    procedureName: string,
+    schema?: string
+  ): Promise<StoredProcedure> {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
-    
+
     // SQLite doesn't have true stored procedures:
     // 1. SQLite doesn't support the CREATE PROCEDURE syntax
     // 2. User-defined functions are created programmatically, not stored in the DB
     // 3. Cannot introspect program-defined functions through SQL
-    
+
     // Throw an error since SQLite doesn't support stored procedures
-    throw new Error("SQLite does not support stored procedures. Functions are defined programmatically through the SQLite API, not stored in the database.");
+    throw new Error(
+      "SQLite does not support stored procedures. Functions are defined programmatically through the SQLite API, not stored in the database."
+    );
   }
 
   async executeQuery(query: string): Promise<QueryResult> {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
-    
+
     // Validate query for safety
     const safetyCheck = this.validateQuery(query);
     if (!safetyCheck.isValid) {
@@ -308,10 +350,12 @@ export class SQLiteConnector implements Connector {
   validateQuery(query: string): { isValid: boolean; message?: string } {
     // Basic check to prevent non-SELECT queries
     const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery.startsWith('select')) {
+    if (
+      !allowedKeywords.some((keyword) => normalizedQuery.startsWith(keyword))
+    ) {
       return {
         isValid: false,
-        message: "Only SELECT queries are allowed for security reasons."
+        message: "Only SELECT queries are allowed for security reasons.",
       };
     }
     return { isValid: true };

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -1,4 +1,4 @@
-import sql from "mssql";
+import sql from 'mssql';
 import {
   Connector,
   ConnectorRegistry,
@@ -7,9 +7,9 @@ import {
   TableColumn,
   TableIndex,
   StoredProcedure,
-} from "../interface.js";
-import { DefaultAzureCredential } from "@azure/identity";
-import { allowedKeywords } from "../../utils/allowed-keywords.js";
+} from '../interface.js';
+import { DefaultAzureCredential } from '@azure/identity';
+import { allowedKeywords } from '../../utils/allowed-keywords.js';
 
 /**
  * SQL Server DSN parser
@@ -20,7 +20,7 @@ export class SQLServerDSNParser implements DSNParser {
     // Remove the protocol prefix
     if (!this.isValidDSN(dsn)) {
       throw new Error(
-        "Invalid SQL Server DSN format. Expected: sqlserver://username:password@host:port/database"
+        'Invalid SQL Server DSN format. Expected: sqlserver://username:password@host:port/database'
       );
     }
 
@@ -30,20 +30,20 @@ export class SQLServerDSNParser implements DSNParser {
     const port = url.port ? parseInt(url.port, 10) : 1433; // Default SQL Server port
     const database = url.pathname.substring(1); // Remove leading slash
     const user = url.username;
-    const password = url.password ? decodeURIComponent(url.password) : "";
+    const password = url.password ? decodeURIComponent(url.password) : '';
 
     // Parse additional options from query parameters
     const options: Record<string, any> = {};
     for (const [key, value] of url.searchParams.entries()) {
-      if (key === "encrypt") {
+      if (key === 'encrypt') {
         options.encrypt = value;
-      } else if (key === "trustServerCertificate") {
-        options.trustServerCertificate = value === "true";
-      } else if (key === "connectTimeout") {
+      } else if (key === 'trustServerCertificate') {
+        options.trustServerCertificate = value === 'true';
+      } else if (key === 'connectTimeout') {
         options.connectTimeout = parseInt(value, 10);
-      } else if (key === "requestTimeout") {
+      } else if (key === 'requestTimeout') {
         options.requestTimeout = parseInt(value, 10);
-      } else if (key === "authentication") {
+      } else if (key === 'authentication') {
         options.authentication = value;
       }
     }
@@ -64,26 +64,23 @@ export class SQLServerDSNParser implements DSNParser {
     };
 
     // Handle Azure Active Directory authentication with access token
-    if (options.authentication === "azure-active-directory-access-token") {
+    if (options.authentication === 'azure-active-directory-access-token') {
       try {
         // Create a credential instance
         const credential = new DefaultAzureCredential();
 
         // Get token for SQL Server resource
-        const token = await credential.getToken(
-          "https://database.windows.net/"
-        );
+        const token = await credential.getToken('https://database.windows.net/');
 
         // Set the token in the config
         config.authentication = {
-          type: "azure-active-directory-access-token",
+          type: 'azure-active-directory-access-token',
           options: {
             token: token.token,
           },
         };
       } catch (error: unknown) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
+        const errorMessage = error instanceof Error ? error.message : String(error);
         throw new Error(`Failed to get Azure AD token: ${errorMessage}`);
       }
     }
@@ -92,13 +89,13 @@ export class SQLServerDSNParser implements DSNParser {
   }
 
   getSampleDSN(): string {
-    return "sqlserver://username:password@localhost:1433/database?encrypt=true";
+    return 'sqlserver://username:password@localhost:1433/database?encrypt=true';
   }
 
   isValidDSN(dsn: string): boolean {
     try {
       const url = new URL(dsn);
-      return url.protocol === "sqlserver:";
+      return url.protocol === 'sqlserver:';
     } catch (e) {
       return false;
     }
@@ -109,8 +106,8 @@ export class SQLServerDSNParser implements DSNParser {
  * SQL Server connector
  */
 export class SQLServerConnector implements Connector {
-  id = "sqlserver";
-  name = "SQL Server";
+  id = 'sqlserver';
+  name = 'SQL Server';
   dsnParser = new SQLServerDSNParser();
 
   private connection?: sql.ConnectionPool;
@@ -139,7 +136,7 @@ export class SQLServerConnector implements Connector {
 
   async getSchemas(): Promise<string[]> {
     if (!this.connection) {
-      throw new Error("Not connected to SQL Server database");
+      throw new Error('Not connected to SQL Server database');
     }
 
     try {
@@ -149,9 +146,7 @@ export class SQLServerConnector implements Connector {
           ORDER BY SCHEMA_NAME
       `);
 
-      return result.recordset.map(
-        (row: { SCHEMA_NAME: any }) => row.SCHEMA_NAME
-      );
+      return result.recordset.map((row: { SCHEMA_NAME: any }) => row.SCHEMA_NAME);
     } catch (error) {
       throw new Error(`Failed to get schemas: ${(error as Error).message}`);
     }
@@ -159,17 +154,15 @@ export class SQLServerConnector implements Connector {
 
   async getTables(schema?: string): Promise<string[]> {
     if (!this.connection) {
-      throw new Error("Not connected to SQL Server database");
+      throw new Error('Not connected to SQL Server database');
     }
 
     try {
       // In SQL Server, use 'dbo' as the default schema if none specified
       // This is the default schema for SQL Server databases
-      const schemaToUse = schema || "dbo";
+      const schemaToUse = schema || 'dbo';
 
-      const request = this.connection
-        .request()
-        .input("schema", sql.VarChar, schemaToUse);
+      const request = this.connection.request().input('schema', sql.VarChar, schemaToUse);
 
       const query = `
           SELECT TABLE_NAME
@@ -188,17 +181,17 @@ export class SQLServerConnector implements Connector {
 
   async tableExists(tableName: string, schema?: string): Promise<boolean> {
     if (!this.connection) {
-      throw new Error("Not connected to SQL Server database");
+      throw new Error('Not connected to SQL Server database');
     }
 
     try {
       // In SQL Server, use 'dbo' as the default schema if none specified
-      const schemaToUse = schema || "dbo";
+      const schemaToUse = schema || 'dbo';
 
       const request = this.connection
         .request()
-        .input("tableName", sql.VarChar, tableName)
-        .input("schema", sql.VarChar, schemaToUse);
+        .input('tableName', sql.VarChar, tableName)
+        .input('schema', sql.VarChar, schemaToUse);
 
       const query = `
           SELECT COUNT(*) as count
@@ -211,28 +204,23 @@ export class SQLServerConnector implements Connector {
 
       return result.recordset[0].count > 0;
     } catch (error) {
-      throw new Error(
-        `Failed to check if table exists: ${(error as Error).message}`
-      );
+      throw new Error(`Failed to check if table exists: ${(error as Error).message}`);
     }
   }
 
-  async getTableIndexes(
-    tableName: string,
-    schema?: string
-  ): Promise<TableIndex[]> {
+  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
     if (!this.connection) {
-      throw new Error("Not connected to SQL Server database");
+      throw new Error('Not connected to SQL Server database');
     }
 
     try {
       // In SQL Server, use 'dbo' as the default schema if none specified
-      const schemaToUse = schema || "dbo";
+      const schemaToUse = schema || 'dbo';
 
       const request = this.connection
         .request()
-        .input("tableName", sql.VarChar, tableName)
-        .input("schema", sql.VarChar, schemaToUse);
+        .input('tableName', sql.VarChar, tableName)
+        .input('schema', sql.VarChar, schemaToUse);
 
       // This gets all indexes including primary keys
       const query = `
@@ -299,30 +287,23 @@ export class SQLServerConnector implements Connector {
 
       return indexes;
     } catch (error) {
-      throw new Error(
-        `Failed to get indexes for table ${tableName}: ${
-          (error as Error).message
-        }`
-      );
+      throw new Error(`Failed to get indexes for table ${tableName}: ${(error as Error).message}`);
     }
   }
 
-  async getTableSchema(
-    tableName: string,
-    schema?: string
-  ): Promise<TableColumn[]> {
+  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
     if (!this.connection) {
-      throw new Error("Not connected to SQL Server database");
+      throw new Error('Not connected to SQL Server database');
     }
 
     try {
       // In SQL Server, use 'dbo' as the default schema if none specified
-      const schemaToUse = schema || "dbo";
+      const schemaToUse = schema || 'dbo';
 
       const request = this.connection
         .request()
-        .input("tableName", sql.VarChar, tableName)
-        .input("schema", sql.VarChar, schemaToUse);
+        .input('tableName', sql.VarChar, tableName)
+        .input('schema', sql.VarChar, schemaToUse);
 
       const query = `
           SELECT COLUMN_NAME as    column_name,
@@ -339,26 +320,20 @@ export class SQLServerConnector implements Connector {
 
       return result.recordset;
     } catch (error) {
-      throw new Error(
-        `Failed to get schema for table ${tableName}: ${
-          (error as Error).message
-        }`
-      );
+      throw new Error(`Failed to get schema for table ${tableName}: ${(error as Error).message}`);
     }
   }
 
   async getStoredProcedures(schema?: string): Promise<string[]> {
     if (!this.connection) {
-      throw new Error("Not connected to SQL Server database");
+      throw new Error('Not connected to SQL Server database');
     }
 
     try {
       // In SQL Server, use 'dbo' as the default schema if none specified
-      const schemaToUse = schema || "dbo";
+      const schemaToUse = schema || 'dbo';
 
-      const request = this.connection
-        .request()
-        .input("schema", sql.VarChar, schemaToUse);
+      const request = this.connection.request().input('schema', sql.VarChar, schemaToUse);
 
       const query = `
           SELECT ROUTINE_NAME
@@ -369,32 +344,25 @@ export class SQLServerConnector implements Connector {
       `;
 
       const result = await request.query(query);
-      return result.recordset.map(
-        (row: { ROUTINE_NAME: any }) => row.ROUTINE_NAME
-      );
+      return result.recordset.map((row: { ROUTINE_NAME: any }) => row.ROUTINE_NAME);
     } catch (error) {
-      throw new Error(
-        `Failed to get stored procedures: ${(error as Error).message}`
-      );
+      throw new Error(`Failed to get stored procedures: ${(error as Error).message}`);
     }
   }
 
-  async getStoredProcedureDetail(
-    procedureName: string,
-    schema?: string
-  ): Promise<StoredProcedure> {
+  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
     if (!this.connection) {
-      throw new Error("Not connected to SQL Server database");
+      throw new Error('Not connected to SQL Server database');
     }
 
     try {
       // In SQL Server, use 'dbo' as the default schema if none specified
-      const schemaToUse = schema || "dbo";
+      const schemaToUse = schema || 'dbo';
 
       const request = this.connection
         .request()
-        .input("procedureName", sql.VarChar, procedureName)
-        .input("schema", sql.VarChar, schemaToUse);
+        .input('procedureName', sql.VarChar, procedureName)
+        .input('schema', sql.VarChar, schemaToUse);
 
       // First, get basic procedure information
       const routineQuery = `
@@ -409,9 +377,7 @@ export class SQLServerConnector implements Connector {
       const routineResult = await request.query(routineQuery);
 
       if (routineResult.recordset.length === 0) {
-        throw new Error(
-          `Stored procedure '${procedureName}' not found in schema '${schemaToUse}'`
-        );
+        throw new Error(`Stored procedure '${procedureName}' not found in schema '${schemaToUse}'`);
       }
 
       const routine = routineResult.recordset[0];
@@ -432,7 +398,7 @@ export class SQLServerConnector implements Connector {
       const parameterResult = await request.query(parameterQuery);
 
       // Format the parameter list
-      let parameterList = "";
+      let parameterList = '';
       if (parameterResult.recordset.length > 0) {
         parameterList = parameterResult.recordset
           .map(
@@ -443,13 +409,11 @@ export class SQLServerConnector implements Connector {
               DATA_TYPE: any;
             }) => {
               const lengthStr =
-                param.CHARACTER_MAXIMUM_LENGTH > 0
-                  ? `(${param.CHARACTER_MAXIMUM_LENGTH})`
-                  : "";
+                param.CHARACTER_MAXIMUM_LENGTH > 0 ? `(${param.CHARACTER_MAXIMUM_LENGTH})` : '';
               return `${param.PARAMETER_NAME} ${param.PARAMETER_MODE} ${param.DATA_TYPE}${lengthStr}`;
             }
           )
-          .join(", ");
+          .join(', ');
       }
 
       // Get the procedure definition from sys.sql_modules
@@ -471,31 +435,25 @@ export class SQLServerConnector implements Connector {
 
       return {
         procedure_name: routine.procedure_name,
-        procedure_type:
-          routine.ROUTINE_TYPE === "PROCEDURE" ? "procedure" : "function",
-        language: "sql", // SQL Server procedures are typically in T-SQL
+        procedure_type: routine.ROUTINE_TYPE === 'PROCEDURE' ? 'procedure' : 'function',
+        language: 'sql', // SQL Server procedures are typically in T-SQL
         parameter_list: parameterList,
-        return_type:
-          routine.ROUTINE_TYPE === "FUNCTION"
-            ? routine.return_data_type
-            : undefined,
+        return_type: routine.ROUTINE_TYPE === 'FUNCTION' ? routine.return_data_type : undefined,
         definition: definition,
       };
     } catch (error) {
-      throw new Error(
-        `Failed to get stored procedure details: ${(error as Error).message}`
-      );
+      throw new Error(`Failed to get stored procedure details: ${(error as Error).message}`);
     }
   }
 
   async executeQuery(query: string): Promise<QueryResult> {
     if (!this.connection) {
-      throw new Error("Not connected to SQL Server database");
+      throw new Error('Not connected to SQL Server database');
     }
 
     const safetyCheck = this.validateQuery(query);
     if (!safetyCheck.isValid) {
-      throw new Error(safetyCheck.message || "Query validation failed");
+      throw new Error(safetyCheck.message || 'Query validation failed');
     }
 
     try {
@@ -518,14 +476,10 @@ export class SQLServerConnector implements Connector {
   validateQuery(query: string): { isValid: boolean; message?: string } {
     // Basic check to prevent non-SELECT queries
     const normalizedQuery = query.trim().toLowerCase();
-    if (
-      !allowedKeywords.some((keyword: string) =>
-        normalizedQuery.startsWith(keyword)
-      )
-    ) {
+    if (!allowedKeywords.some((keyword: string) => normalizedQuery.startsWith(keyword))) {
       return {
         isValid: false,
-        message: "Only SELECT queries are allowed for security reasons.",
+        message: 'Only SELECT queries are allowed for security reasons.',
       };
     }
     return { isValid: true };

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -19,9 +19,7 @@ export class SQLServerDSNParser implements DSNParser {
   async parse(dsn: string): Promise<sql.config> {
     // Remove the protocol prefix
     if (!this.isValidDSN(dsn)) {
-      throw new Error(
-        'Invalid SQL Server DSN format. Expected: sqlserver://username:password@host:port/database'
-      );
+      throw new Error('Invalid SQL Server DSN format. Expected: sqlserver://username:password@host:port/database');
     }
 
     // Parse the DSN
@@ -402,14 +400,8 @@ export class SQLServerConnector implements Connector {
       if (parameterResult.recordset.length > 0) {
         parameterList = parameterResult.recordset
           .map(
-            (param: {
-              CHARACTER_MAXIMUM_LENGTH: number;
-              PARAMETER_NAME: any;
-              PARAMETER_MODE: any;
-              DATA_TYPE: any;
-            }) => {
-              const lengthStr =
-                param.CHARACTER_MAXIMUM_LENGTH > 0 ? `(${param.CHARACTER_MAXIMUM_LENGTH})` : '';
+            (param: { CHARACTER_MAXIMUM_LENGTH: number; PARAMETER_NAME: any; PARAMETER_MODE: any; DATA_TYPE: any }) => {
+              const lengthStr = param.CHARACTER_MAXIMUM_LENGTH > 0 ? `(${param.CHARACTER_MAXIMUM_LENGTH})` : '';
               return `${param.PARAMETER_NAME} ${param.PARAMETER_MODE} ${param.DATA_TYPE}${lengthStr}`;
             }
           )

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -1,14 +1,6 @@
 /**
  * List of allowed keywords for SQL queries
- * Not only SELECT queries are allowed, 
+ * Not only SELECT queries are allowed,
  * but also other queries that are not destructive
  */
-export const allowedKeywords = [
-  "select",
-  "with",
-  "show",
-  "describe",
-  "explain",
-  "analyze",
-  "desc",
-];
+export const allowedKeywords = ['select', 'with', 'show', 'describe', 'explain', 'analyze', 'desc'];

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -1,0 +1,14 @@
+/**
+ * List of allowed keywords for SQL queries
+ * Not only SELECT queries are allowed, 
+ * but also other queries that are not destructive
+ */
+export const allowedKeywords = [
+  "select",
+  "with",
+  "show",
+  "describe",
+  "explain",
+  "analyze",
+  "desc",
+];


### PR DESCRIPTION
- Introduced a new utility to define allowed SQL keywords for query validation.
- Updated all database connectors to utilize the allowed keywords for security checks, ensuring only non-destructive queries are permitted.
- Refactored existing query validation logic across connectors to enhance consistency and maintainability.