### PR TITLE
feat: enhance Postgres SSL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ DBHub supports the following database connection string formats:
 
 If you see the error "NJS-138: connections to this database server version are not supported by node-oracledb in Thin mode", you need to use Thick mode as described below.
 
+#### PostgreSQL SSL
+
+By default, DBHub will validate the SSL certificate of the PostgreSQL server. If you want to allow self-signed certificates, you can set the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to `0`.
+
+```bash
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+npx @bytebase/dbhub --dsn "postgres://user:password@localhost:5432/dbname?sslmode=disable"
+```
+
 ##### Docker
 
 Use `bytebase/dbhub-oracle-thick` instead of `bytebase/dbhub` docker image.

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -43,6 +43,25 @@ class PostgresDSNParser implements DSNParser {
         // Add other parameters as needed
       });
 
+      // Allow for env variable to override sslmode
+      // NODE_TLS_REJECT_UNAUTHORIZED=0 disables SSL certificate validation
+      // NODE_TLS_REJECT_UNAUTHORIZED=1 enforces SSL certificate validation
+      // Default to 1 to main security
+      let {
+        NODE_TLS_REJECT_UNAUTHORIZED,
+      } = process.env;
+
+      if (!NODE_TLS_REJECT_UNAUTHORIZED) {
+        NODE_TLS_REJECT_UNAUTHORIZED = "1"; // Default to disallowing self-signed certs
+      }
+
+      // Configure SSL settings based on env var
+      // rejectUnauthorized: true = Validate SSL cert
+      // rejectUnauthorized: false = Allow self-signed/invalid certs
+      config.ssl = {
+        rejectUnauthorized: JSON.parse(NODE_TLS_REJECT_UNAUTHORIZED) == true,
+      };
+
       return config;
     } catch (error) {
       throw new Error(

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -38,29 +38,33 @@ class PostgresDSNParser implements DSNParser {
       // Handle query parameters (like sslmode, etc.)
       url.searchParams.forEach((value, key) => {
         if (key === "sslmode") {
-          config.ssl = value !== "disable";
+          if (value === "disable") {
+            config.ssl = false;
+          } else {
+            // Allow for env variable to override sslmode
+            // NODE_TLS_REJECT_UNAUTHORIZED=0 disables SSL certificate validation
+            // NODE_TLS_REJECT_UNAUTHORIZED=1 enforces SSL certificate validation
+            // Default to 1 to maintain security
+
+            let {
+              NODE_TLS_REJECT_UNAUTHORIZED,
+            } = process.env;
+
+            if (NODE_TLS_REJECT_UNAUTHORIZED === undefined) {
+              NODE_TLS_REJECT_UNAUTHORIZED = "1"; // Default to enforcing SSL cert validation
+            }
+
+            // Configure SSL settings based on env var
+            // rejectUnauthorized: true = Validate SSL cert
+            // rejectUnauthorized: false = Allow self-signed/invalid certs
+            config.ssl = {
+              rejectUnauthorized: JSON.parse(NODE_TLS_REJECT_UNAUTHORIZED) == true,
+            };
+          }
         }
         // Add other parameters as needed
       });
 
-      // Allow for env variable to override sslmode
-      // NODE_TLS_REJECT_UNAUTHORIZED=0 disables SSL certificate validation
-      // NODE_TLS_REJECT_UNAUTHORIZED=1 enforces SSL certificate validation
-      // Default to 1 to main security
-      let {
-        NODE_TLS_REJECT_UNAUTHORIZED,
-      } = process.env;
-
-      if (!NODE_TLS_REJECT_UNAUTHORIZED) {
-        NODE_TLS_REJECT_UNAUTHORIZED = "1"; // Default to disallowing self-signed certs
-      }
-
-      // Configure SSL settings based on env var
-      // rejectUnauthorized: true = Validate SSL cert
-      // rejectUnauthorized: false = Allow self-signed/invalid certs
-      config.ssl = {
-        rejectUnauthorized: JSON.parse(NODE_TLS_REJECT_UNAUTHORIZED) == true,
-      };
 
       return config;
     } catch (error) {


### PR DESCRIPTION
- Added support for environment variable NODE_TLS_REJECT_UNAUTHORIZED to control SSL certificate validation.
- Default behavior is set to enforce SSL validation for improved security.