### PR TITLE
fix: add postgres connector cloning for multi-source support

### DIFF
--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -100,6 +100,10 @@ export class PostgresConnector implements Connector {
 
   private pool: pg.Pool | null = null;
 
+  clone(): Connector {
+    return new PostgresConnector();
+  }
+
   async connect(dsn: string, initScript?: string, config?: ConnectorConfig): Promise<void> {
     try {
       const poolConfig = await this.dsnParser.parse(dsn, config);


### PR DESCRIPTION
Fix issue for postgres in PostgresConnector like SQLite issue https://github.com/bytebase/dbhub/issues/115

> When configuring multiple SQLite databases in dbhub.toml, all source_id values query the same physical database (the last one configured).