### PR TITLE
fix: infer database type from DSN protocol in API sources endpoint

### DIFF
--- a/src/utils/dsn-obfuscate.ts
+++ b/src/utils/dsn-obfuscate.ts
@@ -1,4 +1,5 @@
 import type { SSHTunnelConfig } from '../types/ssh.js';
+import type { ConnectorType } from '../connectors/interface.js';
 
 /**
  * Obfuscates the password in a DSN string for logging purposes
@@ -83,4 +84,27 @@ export function obfuscateSSHConfig(config: SSHTunnelConfig): Partial<SSHTunnelCo
   }
   
   return obfuscated;
+}
+
+/**
+ * Extracts the database type from a DSN string
+ * @param dsn The DSN string to analyze
+ * @returns The database type or undefined if cannot be determined
+ */
+export function getDatabaseTypeFromDSN(dsn: string): ConnectorType | undefined {
+  if (!dsn) {
+    return undefined;
+  }
+
+  const protocol = dsn.split(':')[0];
+  const protocolToType: Record<string, ConnectorType> = {
+    'postgres': 'postgres',
+    'postgresql': 'postgres',
+    'mysql': 'mysql',
+    'mariadb': 'mariadb',
+    'sqlserver': 'sqlserver',
+    'sqlite': 'sqlite'
+  };
+
+  return protocolToType[protocol];
 }


### PR DESCRIPTION
Fix issue "missing required type field" with `dsn` in configuration file `dbhub.toml` https://github.com/bytebase/dbhub/issues/131

When using DSN-based configuration in TOML files without explicit 'type' fields, the /api/sources endpoint was failing with "missing required type field" errors. This fix allows the endpoint to work correctly with DSN-only configurations by extracting the database type from the protocol portion of the DSN string.

Changes:
- Add getDatabaseTypeFromDSN() utility function to dsn-obfuscate.ts
- Use centralized type inference in transformSourceConfig()
- Handle both 'postgres' and 'postgresql' protocols as PostgreSQL
- Maintain backward compatibility with explicit type configurations

Fixes API endpoint failure for DSN-only TOML configurations.