### PR TITLE
fix: disable SSE streaming in stateless HTTP transport mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ Key architectural patterns:
   - Location: `src/connectors/manager.ts`
 - **Transport Abstraction**: Support for both stdio (desktop tools) and HTTP (network clients)
   - HTTP transport endpoint: `/mcp` (aligns with official MCP SDK standard)
-  - Implemented in `src/server.ts` using `StreamableHTTPServerTransport`
+  - Implemented in `src/server.ts` using `StreamableHTTPServerTransport` with JSON responses
+  - Runs in stateless mode (no SSE support) - GET requests to `/mcp` return 405 Method Not Allowed
   - Tests in `src/__tests__/json-rpc-integration.test.ts`
 - **Resource/Tool/Prompt Handlers**: Clean separation of MCP protocol concerns
   - Tools accept optional `source_id` parameter for multi-database routing

--- a/src/__tests__/json-rpc-integration.test.ts
+++ b/src/__tests__/json-rpc-integration.test.ts
@@ -147,19 +147,8 @@ describe('JSON RPC Integration Tests', () => {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
-    // Handle different response types
-    const contentType = response.headers.get('content-type');
-    if (contentType?.includes('text/event-stream')) {
-      // Handle SSE response
-      const text = await response.text();
-      const lines = text.split('\n').filter(line => line.startsWith('data: '));
-      if (lines.length > 0) {
-        return JSON.parse(lines[0].substring(6)); // Remove 'data: ' prefix
-      }
-      throw new Error('No data in SSE response');
-    } else {
-      return await response.json();
-    }
+    // Server uses JSON responses in stateless mode (no SSE)
+    return await response.json();
   }
 
   describe('execute_sql JSON RPC calls', () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -203,6 +203,15 @@ See documentation for more details on configuring database connections.
       app.get("/api/sources/:sourceId", getSource);
 
       // Main endpoint for streamable HTTP transport
+      // SSE streaming (GET requests) is not supported in stateless mode
+      // Return 405 Method Not Allowed for GET requests to indicate this
+      app.get("/mcp", (req, res) => {
+        res.status(405).json({
+          error: 'Method Not Allowed',
+          message: 'SSE streaming is not supported in stateless mode. Use POST requests with JSON responses.'
+        });
+      });
+
       app.post("/mcp", async (req, res) => {
         try {
           // In stateless mode, create a new instance of transport and server for each request
@@ -210,7 +219,7 @@ See documentation for more details on configuring database connections.
           // when multiple clients connect concurrently.
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: undefined, // Disable session management for stateless mode
-            enableJsonResponse: false // Use SSE streaming
+            enableJsonResponse: true // Use JSON responses (SSE not supported in stateless mode)
           });
           const server = createServer();
 


### PR DESCRIPTION
Fixes #134 - LibreChat StreamableHTTPError: Failed to open SSE stream

Changes:
- Set enableJsonResponse to true for stateless mode compatibility
- Add GET handler to /mcp endpoint returning 405 Method Not Allowed
- Remove SSE response handling from integration tests
- Update documentation to reflect stateless/no-SSE configuration

Root cause: DBHub runs in stateless mode (sessionIdGenerator: undefined) which doesn't support SSE streaming. LibreChat was successfully initializing via POST but then trying to open GET requests for SSE streams, which were returning 404. Now properly returns 405 and uses JSON responses for all operations.
