### PR TITLE
refactor: create separate MCP tools per database source

### DIFF
--- a/src/tools/__tests__/execute-sql.test.ts
+++ b/src/tools/__tests__/execute-sql.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { executeSqlToolHandler } from '../execute-sql.js';
+import { createExecuteSqlToolHandler } from '../execute-sql.js';
 import { ConnectorManager } from '../../connectors/manager.js';
 import { isReadOnlyMode } from '../../config/env.js';
 import type { Connector, ConnectorType, SQLResult } from '../../connectors/interface.js';
@@ -52,7 +52,8 @@ describe('execute-sql tool', () => {
       const mockResult: SQLResult = { rows: [{ id: 1, name: 'test' }] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
-      const result = await executeSqlToolHandler({ sql: 'SELECT * FROM users' }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql: 'SELECT * FROM users' }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -64,7 +65,8 @@ describe('execute-sql tool', () => {
     it('should handle execution errors', async () => {
       vi.mocked(mockConnector.executeSQL).mockRejectedValue(new Error('Database error'));
 
-      const result = await executeSqlToolHandler({ sql: 'SELECT * FROM invalid_table' }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql: 'SELECT * FROM invalid_table' }, null);
 
       expect(result.isError).toBe(true);
       const parsedResult = parseToolResponse(result);
@@ -80,7 +82,8 @@ describe('execute-sql tool', () => {
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = 'SELECT * FROM users; SELECT * FROM roles;';
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -97,7 +100,8 @@ describe('execute-sql tool', () => {
       const mockResult: SQLResult = { rows: [{ id: 1 }] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
-      const result = await executeSqlToolHandler({ sql: 'SELECT * FROM users' }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql: 'SELECT * FROM users' }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -109,7 +113,8 @@ describe('execute-sql tool', () => {
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = 'SELECT * FROM users; SELECT * FROM roles;';
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -117,7 +122,8 @@ describe('execute-sql tool', () => {
     });
 
     it('should reject single INSERT statement in read-only mode', async () => {
-      const result = await executeSqlToolHandler({ sql: "INSERT INTO users (name) VALUES ('test')" }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql: "INSERT INTO users (name) VALUES ('test')" }, null);
 
       expect(result.isError).toBe(true);
       const parsedResult = parseToolResponse(result);
@@ -129,7 +135,8 @@ describe('execute-sql tool', () => {
 
     it('should reject multi-statement with any write operation in read-only mode', async () => {
       const sql = "SELECT * FROM users; INSERT INTO users (name) VALUES ('test'); SELECT COUNT(*) FROM users;";
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
 
       expect(result.isError).toBe(true);
       const parsedResult = parseToolResponse(result);
@@ -148,7 +155,8 @@ describe('execute-sql tool', () => {
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = '-- Fetch active users\nSELECT * FROM users WHERE active = TRUE';
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -161,7 +169,8 @@ describe('execute-sql tool', () => {
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = '/* This query fetches\n   all products */\nSELECT * FROM products';
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -174,7 +183,8 @@ describe('execute-sql tool', () => {
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = '-- First query\nSELECT * FROM users;\n/* Second query */\nSELECT * FROM roles;';
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -185,7 +195,8 @@ describe('execute-sql tool', () => {
       mockIsReadOnlyMode.mockReturnValue(true);
 
       const sql = '-- Insert new user\nINSERT INTO users (name) VALUES (\'test\')';
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
 
       expect(result.isError).toBe(true);
       const parsedResult = parseToolResponse(result);
@@ -200,7 +211,8 @@ describe('execute-sql tool', () => {
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = '-- Just a comment\n/* Another comment */';
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -213,7 +225,8 @@ describe('execute-sql tool', () => {
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = 'SELECT id, -- user id\n       name -- user name\nFROM users';
-      const result = await executeSqlToolHandler({ sql }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -227,7 +240,8 @@ describe('execute-sql tool', () => {
       const mockResult: SQLResult = { rows: [] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
-      const result = await executeSqlToolHandler({ sql: '' }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql: '' }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
@@ -238,7 +252,8 @@ describe('execute-sql tool', () => {
       const mockResult: SQLResult = { rows: [] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
-      const result = await executeSqlToolHandler({ sql: '   ;  ;  ; ' }, null);
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql: '   ;  ;  ; ' }, null);
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,20 +1,51 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { executeSqlToolHandler, executeSqlSchema } from "./execute-sql.js";
+import { createExecuteSqlToolHandler, executeSqlSchema } from "./execute-sql.js";
+import { ConnectorManager } from "../connectors/manager.js";
+import { normalizeSourceId } from "../utils/normalize-id.js";
+
 /**
  * Register all tool handlers with the MCP server
+ * Creates one execute_sql tool per configured database source
  * @param server - The MCP server instance
  * @param id - Optional ID to suffix tool names (for Cursor multi-instance support)
  */
 export function registerTools(server: McpServer, id?: string): void {
-  // Build tool name with optional suffix
-  const toolName = id ? `execute_sql_${id}` : "execute_sql";
+  // Get all configured source IDs
+  const sourceIds = ConnectorManager.getAvailableSourceIds();
 
-  // Tool to run a SQL query (read-only for safety)
-  server.tool(
-    toolName,
-    "Execute a SQL query on the current database",
-    executeSqlSchema,
-    executeSqlToolHandler
-  );
+  if (sourceIds.length === 0) {
+    throw new Error("No database sources configured");
+  }
 
+  // For single source: register as "execute_sql" (backward compatible)
+  // For multiple sources: register as "execute_sql_{source_id}" for each source
+  if (sourceIds.length === 1) {
+    const sourceId = sourceIds[0];
+    const toolName = id ? `execute_sql_${id}` : "execute_sql";
+    const sourceConfig = ConnectorManager.getSourceConfig(sourceId);
+    const dbType = sourceConfig?.type || "database";
+
+    server.tool(
+      toolName,
+      `Execute a SQL query on the ${dbType} database`,
+      executeSqlSchema,
+      createExecuteSqlToolHandler(sourceId)
+    );
+  } else {
+    // Multiple sources: create one tool per source
+    for (const sourceId of sourceIds) {
+      const normalizedId = normalizeSourceId(sourceId);
+      const toolName = id ? `execute_sql_${normalizedId}_${id}` : `execute_sql_${normalizedId}`;
+      const sourceConfig = ConnectorManager.getSourceConfig(sourceId);
+      const dbType = sourceConfig?.type || "database";
+      const isDefault = sourceIds[0] === sourceId;
+
+      server.tool(
+        toolName,
+        `Execute a SQL query on the '${sourceId}' ${dbType} database${isDefault ? " (default)" : ""}`,
+        executeSqlSchema,
+        createExecuteSqlToolHandler(sourceId)
+      );
+    }
+  }
 }

--- a/src/utils/__tests__/normalize-id.test.ts
+++ b/src/utils/__tests__/normalize-id.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeSourceId } from '../normalize-id.js';
+
+describe('normalizeSourceId', () => {
+  it('should keep alphanumeric characters unchanged', () => {
+    expect(normalizeSourceId('prod_db')).toBe('prod_db');
+    expect(normalizeSourceId('database123')).toBe('database123');
+    expect(normalizeSourceId('DB2024')).toBe('DB2024');
+  });
+
+  it('should convert hyphens to underscores', () => {
+    expect(normalizeSourceId('staging-db')).toBe('staging_db');
+    expect(normalizeSourceId('my-production-database')).toBe('my_production_database');
+  });
+
+  it('should convert dots to underscores', () => {
+    expect(normalizeSourceId('dev.db')).toBe('dev_db');
+    expect(normalizeSourceId('prod.mysql.instance')).toBe('prod_mysql_instance');
+  });
+
+  it('should convert multiple special characters', () => {
+    expect(normalizeSourceId('my@db#123')).toBe('my_db_123');
+    expect(normalizeSourceId('test!db$xyz%')).toBe('test_db_xyz_');
+  });
+
+  it('should convert spaces to underscores', () => {
+    expect(normalizeSourceId('production database')).toBe('production_database');
+    expect(normalizeSourceId('my db 2024')).toBe('my_db_2024');
+  });
+
+  it('should handle consecutive special characters', () => {
+    expect(normalizeSourceId('prod--db')).toBe('prod__db');
+    expect(normalizeSourceId('test...db')).toBe('test___db');
+  });
+
+  it('should handle edge cases', () => {
+    expect(normalizeSourceId('')).toBe('');
+    expect(normalizeSourceId('a')).toBe('a');
+    expect(normalizeSourceId('_')).toBe('_');
+    expect(normalizeSourceId('123')).toBe('123');
+  });
+
+  it('should handle unicode and special symbols', () => {
+    expect(normalizeSourceId('db-é-test')).toBe('db___test');
+    expect(normalizeSourceId('production™')).toBe('production_');
+    expect(normalizeSourceId('test★db')).toBe('test_db');
+  });
+
+  it('should work with real-world source IDs', () => {
+    expect(normalizeSourceId('prod-postgres-001')).toBe('prod_postgres_001');
+    expect(normalizeSourceId('staging.mysql.v2')).toBe('staging_mysql_v2');
+    expect(normalizeSourceId('dev_sqlite_local')).toBe('dev_sqlite_local');
+  });
+});

--- a/src/utils/normalize-id.ts
+++ b/src/utils/normalize-id.ts
@@ -1,0 +1,16 @@
+/**
+ * Normalize a source ID to create a valid tool name suffix
+ * Converts all non-alphanumeric characters to underscores
+ *
+ * Examples:
+ *   "prod_db" -> "prod_db"
+ *   "staging-db" -> "staging_db"
+ *   "dev.db" -> "dev_db"
+ *   "my@db#123" -> "my_db_123"
+ *
+ * @param id - The source ID to normalize
+ * @returns The normalized ID safe for use in tool names
+ */
+export function normalizeSourceId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9]/g, '_');
+}


### PR DESCRIPTION
Changes tool registration from a single execute_sql tool with source_id parameter to creating individual tools per configured database (e.g., execute_sql_prod_pg).

Key changes:
- Refactor executeSqlToolHandler to createExecuteSqlToolHandler factory function
- Each tool is bound to a specific source at registration time
- Single-source mode: register as "execute_sql" (backward compatible)
- Multi-source mode: register as "execute_sql_{normalized_id}" per source
- Add normalizeSourceId utility to convert source IDs to valid tool names
- Update all tests to use the factory function pattern

Benefits:
- Tools appear as distinct operations in MCP clients
- Better discoverability and documentation per database
- More intuitive UX for multi-database configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)