### PR TITLE
feat: implement tool extension architecture with per-tool configuration

### DIFF
--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -9,8 +9,6 @@
 [[sources]]
 id = "prod_pg"  # Required: Unique identifier
 dsn = "postgres://user:password@localhost:5432/production?sslmode=require"  # Required: Connection string
-readonly = false  # Optional: Limit to read-only operations (default: false)
-max_rows = 1000  # Optional: Maximum rows to return per query (default: unlimited)
 connection_timeout = 30  # Optional: Connection timeout in seconds (default: driver-specific)
 
 ## Example 2: MySQL with individual parameters
@@ -22,8 +20,6 @@ port = 3306  # Optional: Uses default if not specified (MySQL default: 3306)
 database = "staging"  # Required: Database name
 user = "root"  # Required: Database username
 password = "secret"  # Required: Database password
-readonly = false  # Optional: Limit to read-only operations (default: false)
-max_rows = 500  # Optional: Maximum rows to return per query (default: unlimited)
 connection_timeout = 60  # Optional: Connection timeout in seconds (useful for high-latency connections)
 
 ## Example 3: MariaDB with SSH tunnel
@@ -46,7 +42,6 @@ port = 1433  # Optional: Uses default if not specified (SQL Server default: 1433
 database = "analytics"  # Required: Database name
 user = "sa"  # Required: Database username
 password = "YourStrong@Passw0rd"  # Required: Database password
-max_rows = 2000  # Optional: Maximum rows to return per query (default: unlimited)
 connection_timeout = 30  # Optional: Connection establishment timeout in seconds (default: 15s)
 request_timeout = 120    # Optional: Query execution timeout in seconds (SQL Server only, default: 15s)
 # instanceName = "INSTANCE1"  # Optional: SQL Server named instance (e.g., SERVER\INSTANCE1)
@@ -56,7 +51,6 @@ request_timeout = 120    # Optional: Query execution timeout in seconds (SQL Ser
 id = "local_sqlite"  # Required: Unique identifier
 type = "sqlite"  # Required when using individual parameters
 database = "/path/to/database.db"  # Required: Path to SQLite database file
-readonly = true  # Optional: Limit to read-only operations (default: false)
 
 ## Example 6: SQLite in-memory (for testing)
 [[sources]]
@@ -88,10 +82,6 @@ dsn = "sqlite:///:memory:"  # Required: Connection string (in-memory database)
 # Connection parameters:
 #   - port: Database port (default: 5432 for postgres, 3306 for mysql/mariadb, 1433 for sqlserver)
 #   - instanceName: SQL Server named instance (sqlserver only, e.g., "INSTANCE1")
-#
-# Execution options:
-#   - readonly: Limit to read-only operations (default: false)
-#   - max_rows: Maximum rows to return per query (default: unlimited, e.g., 1000)
 #   - connection_timeout: Connection timeout in seconds (default: driver-specific, e.g., 30, 60)
 #   - request_timeout: Query execution timeout in seconds (SQL Server only, default: 15, e.g., 120)
 #
@@ -102,13 +92,13 @@ dsn = "sqlite:///:memory:"  # Required: Connection string (in-memory database)
 #   - ssh_key: Path to private key file (use ssh_key OR ssh_password, not both)
 #   - ssh_password: SSH password (use instead of ssh_key for password authentication)
 #   - ssh_passphrase: Passphrase for encrypted private key
-
+#
 # Default Port Numbers:
 # - PostgreSQL: 5432
 # - MySQL/MariaDB: 3306
 # - SQL Server: 1433
 # - SQLite: N/A (file-based)
-
+#
 # Usage Notes:
 # ------------
 # 1. The first [[sources]] entry is the default database
@@ -116,6 +106,44 @@ dsn = "sqlite:///:memory:"  # Required: Connection string (in-memory database)
 # 3. Paths starting with ~/ will be expanded to your home directory
 # 4. Passwords in DSN strings will be redacted in logs automatically
 # 5. For security, consider using environment variables for sensitive data
+
+# Built-in Tools Configuration
+# -----------------------------
+# Built-in tools (execute_sql, search_objects) are automatically enabled for all sources
+# unless explicitly configured here. Use [[tools]] entries to customize their behavior.
+#
+# Tool-Specific Options:
+# - execute_sql: Supports 'readonly' (boolean) and 'max_rows' (integer) options
+# - search_objects: No additional options available
+
+## Example: Restrict execute_sql to read-only with row limit on production
+[[tools]]
+name = "execute_sql"
+source = "prod_pg"
+readonly = true      # Only allow SELECT, SHOW, DESCRIBE, EXPLAIN (execute_sql only)
+max_rows = 1000      # Limit results to 1000 rows (execute_sql only)
+
+## Example: Enable search_objects for production (optional - enabled by default)
+[[tools]]
+name = "search_objects"
+source = "prod_pg"
+# Note: search_objects has no additional configuration options
+
+## Example: Unrestricted execute_sql for staging
+[[tools]]
+name = "execute_sql"
+source = "staging_mysql"
+# No readonly or max_rows = full access
+
+## Example: Enable both tools for analytics database
+[[tools]]
+name = "execute_sql"
+source = "analytics_sqlserver"
+max_rows = 2000  # Limit to 2000 rows, but allow writes
+
+[[tools]]
+name = "search_objects"
+source = "analytics_sqlserver"
 
 # Custom Tools
 # ------------
@@ -172,7 +200,7 @@ allowed_values = ["pending", "completed", "cancelled"]
 # [[tools]]
 # name = "daily_revenue"
 # description = "Get total revenue for a specific date range"
-# source = "analytics_db"
+# source = "analytics_sqlserver"
 # statement = "SELECT DATE(created_at) as date, SUM(amount) as revenue FROM orders WHERE DATE(created_at) BETWEEN $1 AND $2 GROUP BY DATE(created_at)"
 #
 # [[tools.parameters]]
@@ -187,15 +215,27 @@ allowed_values = ["pending", "completed", "cancelled"]
 # description = "End date in YYYY-MM-DD format"
 # required = true
 
-# Custom Tool Field Reference:
-# ----------------------------
+# Tool Configuration Reference:
+# -----------------------------
 #
-# REQUIRED FIELDS:
-# ----------------
-#   - name: Unique tool identifier (string)
-#   - description: Natural language description of what the tool does
-#   - source: ID of the database source to execute against (must exist in [[sources]])
-#   - statement: SQL query with parameter placeholders
+# BUILT-IN TOOLS (execute_sql, search_objects):
+# ----------------------------------------------
+# Convention: Detected by name
+#   - name: Tool name (must be "execute_sql" or "search_objects")
+#   - source: ID of the database source (must exist in [[sources]])
+#   - readonly: Limit execute_sql to read-only operations (default: false)
+#   - max_rows: Maximum rows to return from execute_sql (default: unlimited)
+#
+# Note: If no [[tools]] entries are defined for a source, both built-in tools
+# are automatically enabled with default settings (no readonly, no row limit).
+#
+# CUSTOM TOOLS:
+# -------------
+# Convention: Any name except "execute_sql" or "search_objects"
+#   - name: Unique tool identifier (cannot be "execute_sql" or "search_objects")
+#   - description: Natural language description of what the tool does [REQUIRED]
+#   - source: ID of the database source to execute against [REQUIRED]
+#   - statement: SQL query with parameter placeholders [REQUIRED]
 #     * PostgreSQL: Use $1, $2, $3 for parameters
 #     * MySQL/MariaDB: Use ?, ?, ? for parameters
 #     * SQL Server: Use @p1, @p2, @p3 for parameters
@@ -212,24 +252,23 @@ allowed_values = ["pending", "completed", "cancelled"]
 #
 # VALIDATION RULES:
 # -----------------
-#   1. Tool names cannot conflict with built-in tools (execute_sql, search_objects)
-#   2. Tool names must be unique across all custom tools
-#   3. Source ID must reference an existing [[sources]] entry
-#   4. Parameter count in SQL must match number of [[tools.parameters]] entries
-#   5. Parameter syntax must match the connector type:
-#      - PostgreSQL requires $1, $2, etc.
-#      - MySQL/MariaDB/SQLite require ?, ?, etc.
-#      - SQL Server requires @p1, @p2, etc.
+#   1. Built-in tools cannot have description, statement, or parameters fields
+#   2. Custom tools must have description and statement fields
+#   3. Custom tools cannot have readonly or max_rows fields
+#   4. Tool names must be unique per source (can reuse name for different sources)
+#   5. Source ID must reference an existing [[sources]] entry
+#   6. Parameter count in SQL must match number of [[tools.parameters]] entries
+#   7. Parameter syntax must match the connector type
 #
 # SECURITY:
 # ---------
-#   - Custom tools inherit the source's readonly and max_rows settings
 #   - Only parameterized queries are supported (no template interpolation)
 #   - All parameters are validated with Zod schemas at runtime
 #   - SQL injection prevention through native DB parameter binding
+#   - Built-in tool readonly mode enforced at SQL keyword level
 #
 # USAGE:
 # ------
 #   After defining tools in this file, they are automatically registered
-#   when the server starts. They appear in the MCP client's tool list alongside
-#   built-in tools like execute_sql and search_objects.
+#   when the server starts. They appear in the MCP client's tool list.
+#   Sources without [[tools]] entries get both built-in tools by default.

--- a/docs/config/multi-database.mdx
+++ b/docs/config/multi-database.mdx
@@ -12,21 +12,43 @@ Connect to multiple databases from a single DBHub instance using TOML configurat
 Create a `dbhub.toml` file:
 
 ```toml dbhub.toml
+# Database sources
 [[sources]]
 id = "production"
 dsn = "postgres://user:password@prod.example.com:5432/myapp"
-readonly = true
-max_rows = 1000
 
 [[sources]]
 id = "staging"
 dsn = "mysql://root:password@localhost:3306/myapp_staging"
-readonly = false
-max_rows = 5000
 
 [[sources]]
 id = "local"
 dsn = "sqlite:///./dev.db"
+
+# Tool configuration
+# Production: read-only execute_sql with row limit, plus search_objects
+[[tools]]
+name = "execute_sql"
+source = "production"
+readonly = true
+max_rows = 1000
+
+[[tools]]
+name = "search_objects"
+source = "production"
+
+# Staging: full access with higher row limit
+[[tools]]
+name = "execute_sql"
+source = "staging"
+max_rows = 5000
+
+[[tools]]
+name = "search_objects"
+source = "staging"
+
+# Local: default tools (both execute_sql and search_objects)
+# No [[tools]] entries = both tools enabled by default
 ```
 
 Start DBHub:
@@ -39,7 +61,7 @@ npx @bytebase/dbhub --transport http --port 8080
 npx @bytebase/dbhub --config=/path/to/config.toml
 ```
 
-See [Server Options](/config/server-options) for detailed option descriptions.
+See [Server Options](/config/server-options) for detailed option descriptions and [Tool Configuration](/tools/overview#tool-configuration) for controlling which tools are available per source.
 
 ## Examples
 
@@ -49,12 +71,24 @@ See [Server Options](/config/server-options) for detailed option descriptions.
     [[sources]]
     id = "production"
     dsn = "postgres://user:pass@prod.example.com:5432/myapp"
-    readonly = true
-    max_rows = 1000
 
     [[sources]]
     id = "staging"
     dsn = "mysql://root:pass@localhost:3306/myapp_staging"
+
+    # Production: read-only with row limit
+    [[tools]]
+    name = "execute_sql"
+    source = "production"
+    readonly = true
+    max_rows = 1000
+
+    [[tools]]
+    name = "search_objects"
+    source = "production"
+
+    # Staging: full access (default tools)
+    # No [[tools]] for staging = both tools enabled
     ```
   </Tab>
 
@@ -68,6 +102,10 @@ See [Server Options](/config/server-options) for detailed option descriptions.
     database = "myapp"
     user = "app_user"
     password = "p@ss:word"  # No URL encoding needed
+
+    [[tools]]
+    name = "execute_sql"
+    source = "production"
     readonly = true
     ```
   </Tab>
@@ -80,7 +118,15 @@ See [Server Options](/config/server-options) for detailed option descriptions.
     ssh_host = "bastion.example.com"
     ssh_user = "deploy"
     ssh_key = "~/.ssh/id_rsa"
+
+    [[tools]]
+    name = "execute_sql"
+    source = "production"
     readonly = true
+
+    [[tools]]
+    name = "search_objects"
+    source = "production"
     ```
   </Tab>
 </Tabs>

--- a/docs/config/server-options.mdx
+++ b/docs/config/server-options.mdx
@@ -118,32 +118,6 @@ title: "Server Options"
   ```
 </ParamField>
 
-## Execution Controls
-
-### readonly
-
-<ParamField path="--readonly" type="boolean" env="READONLY" default="false">
-  Restrict SQL execution to read-only operations.
-
-  ```bash
-  npx @bytebase/dbhub --readonly --dsn "postgres://user:password@localhost:5432/mydb"
-  ```
-
-  See [Read-Only Mode](/tools/execute-sql#read-only-mode) for details on allowed operations.
-</ParamField>
-
-### max-rows
-
-<ParamField path="--max-rows" type="number" env="MAX_ROWS">
-  Limit the number of rows returned from SELECT queries.
-
-  ```bash
-  npx @bytebase/dbhub --max-rows 1000 --dsn "..."
-  ```
-
-  See [Row Limiting](/tools/execute-sql#row-limiting) for details on how limits are applied.
-</ParamField>
-
 ## General
 
 ### transport
@@ -330,9 +304,8 @@ DBHub follows this priority order for configuration:
 **`--config` (TOML) is mutually exclusive with:**
 - `--dsn` - TOML configuration defines database connections directly
 - `--id` - TOML configuration defines source IDs directly in the file
-- `--readonly` - TOML configuration defines readonly mode per-source using `readonly = true`
 
-If using TOML config, remove these flags. If you need `--id`, `--dsn`, or `--readonly`, use command-line/environment configuration instead.
+If using TOML config, remove these flags. If you need `--id` or `--dsn`, use command-line/environment configuration instead.
 </Note>
 
 ## Quick Reference
@@ -348,8 +321,6 @@ If using TOML config, remove these flags. If you need `--id`, `--dsn`, or `--rea
 | - | `DB_NAME` | string | - | Database name or SQLite file path |
 | `--transport` | `TRANSPORT` | string | `stdio` | Transport mode: stdio or http |
 | `--port` | `PORT` | number | `8080` | HTTP server port |
-| `--readonly` | `READONLY` | boolean | `false` | Restrict to read-only operations |
-| `--max-rows` | `MAX_ROWS` | number | - | Limit SELECT query results |
 | `--demo` | - | boolean | `false` | Use sample employee database |
 | `--id` | `ID` | string | - | Instance identifier for tool names |
 | `--config` | - | string | `./dbhub.toml` | Path to TOML config file |

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -135,7 +135,7 @@ Try these example prompts in your AI tool:
     ```
 
     <Note>
-    This only works when DBHub is **not** started with the [--readonly](/config/server-options#readonly) flag.
+    This only works when the `execute_sql` tool is not configured with `readonly = true`. See [Read-Only Mode](/tools/execute-sql#read-only-mode).
     </Note>
   </Accordion>
 </AccordionGroup>

--- a/docs/tools/custom-tools.mdx
+++ b/docs/tools/custom-tools.mdx
@@ -32,7 +32,7 @@ description = "The unique user ID"
 
 ## Tool Configuration
 
-Each tool requires the following fields:
+Each custom tool requires the following fields:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -42,7 +42,7 @@ Each tool requires the following fields:
 | `statement` | string | Yes | SQL query with parameter placeholders |
 
 <Note>
-Tool names must be unique and cannot conflict with built-in tools (`execute_sql`, `search_objects`).
+Tool names must be unique and cannot conflict with built-in tools (`execute_sql`, `search_objects`). Custom tools cannot be named with these reserved names or their prefixed variants (e.g., `execute_sql_prod`).
 </Note>
 
 ## Specifying Parameters
@@ -169,25 +169,51 @@ allowed_values = ["pending", "processing", "shipped", "delivered"]
 
 ### Readonly Mode
 
-When a source is configured with `readonly = true`, tools targeting that source are restricted to read-only SQL operations. Only statements beginning with `SELECT`, `SHOW`, `DESCRIBE`, `EXPLAIN`, or `WITH` are allowed.
+Configure `readonly = true` on the `execute_sql` tool to restrict SQL execution to read-only operations:
 
 ```toml
 [[sources]]
 id = "prod_pg"
-readonly = true  # Restricts all tools to read-only operations
+dsn = "postgres://..."
+
+# Configure execute_sql as read-only
+[[tools]]
+name = "execute_sql"
+source = "prod_pg"
+readonly = true
+
+# Custom tools are unaffected by readonly setting
+[[tools]]
+name = "get_user_by_id"
+source = "prod_pg"
+description = "Get user details"
+statement = "SELECT * FROM users WHERE id = $1"
+[[tools.parameters]]
+name = "user_id"
+type = "integer"
+description = "User ID"
 ```
+
+<Note>
+The `readonly` setting only applies to the `execute_sql` tool. Custom tools are controlled by their SQL statement - DBHub analyzes the statement to determine if it's read-only.
+</Note>
 
 ### Max Rows Enforcement
 
-The `max_rows` configuration is always enforced as a hard limit. Even if a tool accepts a LIMIT parameter, the configured `max_rows` serves as a cap:
+Configure `max_rows` on the `execute_sql` tool to limit SELECT query results:
 
 ```toml
 [[sources]]
 id = "prod_pg"
-max_rows = 1000  # Users cannot exceed this limit
+dsn = "postgres://..."
+
+[[tools]]
+name = "execute_sql"
+source = "prod_pg"
+max_rows = 1000  # Hard limit on SELECT results
 ```
 
-For tools with parameterized LIMIT clauses, the query is automatically wrapped to enforce the limit:
+For custom tools with parameterized LIMIT clauses, the connector's row limiting still applies:
 
 ```sql
 -- Original query

--- a/docs/tools/execute-sql.mdx
+++ b/docs/tools/execute-sql.mdx
@@ -97,11 +97,25 @@ DROP TABLE IF EXISTS temp_data;
 
 ## Read-Only Mode
 
-Enable read-only mode to restrict SQL execution to safe, read-only operations:
+Restrict SQL execution to safe, read-only operations by configuring the `execute_sql` tool with `readonly = true`:
 
-```bash
+<CodeGroup>
+```toml TOML Configuration
+[[sources]]
+id = "production"
+dsn = "postgres://user:pass@localhost:5432/mydb"
+
+[[tools]]
+name = "execute_sql"
+source = "production"
+readonly = true
+```
+
+```bash Command Line (Deprecated)
+# This flag is deprecated - use TOML configuration instead
 npx @bytebase/dbhub --readonly --dsn "postgres://user:pass@localhost:5432/mydb"
 ```
+</CodeGroup>
 
 In read-only mode, only [allowed SQL keywords](https://github.com/bytebase/dbhub/blob/main/src/utils/allowed-keywords.ts) are permitted, including:
 
@@ -115,10 +129,67 @@ In read-only mode, only [allowed SQL keywords](https://github.com/bytebase/dbhub
 
 Limit the number of rows returned from SELECT queries to prevent accidentally retrieving too much data:
 
-```bash
+<CodeGroup>
+```toml TOML Configuration
+[[sources]]
+id = "production"
+dsn = "postgres://..."
+
+[[tools]]
+name = "execute_sql"
+source = "production"
+max_rows = 1000
+```
+
+```bash Command Line (Deprecated)
+# This flag is deprecated - use TOML configuration instead
 npx @bytebase/dbhub --max-rows 1000 --dsn "..."
 ```
+</CodeGroup>
 
 - Only applied to SELECT statements, not INSERT/UPDATE/DELETE
 - If your query already has a `LIMIT` or `TOP` clause, DBHub uses the smaller value
-- Can be configured per-database in [multi-database TOML configuration](/config/multi-database)
+- Can be configured per-tool in [multi-database TOML configuration](/config/multi-database)
+
+## Selective Tool Exposure
+
+Control which tools are available for each database source. By default, both `execute_sql` and `search_objects` are enabled. You can:
+
+- Disable built-in tools entirely
+- Configure specific tools with custom settings
+- Expose only custom tools for restricted access
+
+**Example: Disable execute_sql, keep search_objects:**
+
+```toml
+[[sources]]
+id = "production"
+dsn = "postgres://..."
+
+# Only enable search_objects - execute_sql will not be available
+[[tools]]
+name = "search_objects"
+source = "production"
+```
+
+**Example: Read-only execute_sql with row limit:**
+
+```toml
+[[sources]]
+id = "production"
+dsn = "postgres://..."
+
+[[tools]]
+name = "execute_sql"
+source = "production"
+readonly = true
+max_rows = 100
+
+[[tools]]
+name = "search_objects"
+source = "production"
+```
+
+<Note>
+If no `[[tools]]` entries are defined for a source, both `execute_sql` and `search_objects` are enabled by default for backward compatibility.
+</Note>

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -10,6 +10,118 @@ title: "Overview"
 | Search Objects | `search_objects` or `search_objects_{id}` | Search and list database objects (schemas, tables, columns, procedures, indexes) with pattern matching and token-efficient progressive disclosure |
 | Custom Tools | User-defined names | Define reusable, parameterized SQL operations in your `dbhub.toml` configuration file |
 
+## Tool Configuration
+
+By default, both `execute_sql` and `search_objects` are enabled for each database source. You can customize which tools are available using `[[tools]]` entries in your `dbhub.toml`:
+
+### Default Behavior
+
+If no `[[tools]]` entries are defined for a source, both `execute_sql` and `search_objects` are enabled by default:
+
+```toml
+[[sources]]
+id = "dev"
+dsn = "sqlite:///dev.db"
+# No [[tools]] entries = both execute_sql and search_objects enabled
+```
+
+### Selective Tool Exposure
+
+Control which tools are exposed for each database source:
+
+```toml
+[[sources]]
+id = "production"
+dsn = "postgres://..."
+
+# Only enable search_objects - execute_sql will NOT be available
+[[tools]]
+name = "search_objects"
+source = "production"
+```
+
+This is useful when you want to restrict AI models to read-only schema exploration without allowing SQL execution.
+
+### Per-Tool Settings
+
+Configure built-in tools with specific settings like `readonly` and `max_rows`:
+
+```toml
+[[sources]]
+id = "production"
+dsn = "postgres://..."
+
+[[tools]]
+name = "execute_sql"
+source = "production"
+readonly = true    # Only allow SELECT, SHOW, DESCRIBE, EXPLAIN
+max_rows = 100     # Limit query results
+
+[[tools]]
+name = "search_objects"
+source = "production"
+```
+
+See [execute_sql documentation](/tools/execute-sql) for details on `readonly` and `max_rows` settings.
+
+### Mixed Configuration
+
+Different sources can have different tool configurations:
+
+```toml
+[[sources]]
+id = "production"
+dsn = "postgres://..."
+
+[[sources]]
+id = "analytics"
+dsn = "postgres://..."
+
+# Production: only search_objects (no SQL execution)
+[[tools]]
+name = "search_objects"
+source = "production"
+
+# Analytics: full access with no row limit
+[[tools]]
+name = "execute_sql"
+source = "analytics"
+
+[[tools]]
+name = "search_objects"
+source = "analytics"
+```
+
+### Custom Tools
+
+You can also define custom tools alongside built-in tools:
+
+```toml
+[[sources]]
+id = "production"
+dsn = "postgres://..."
+
+# Built-in tools
+[[tools]]
+name = "search_objects"
+source = "production"
+
+# Custom tool - no execute_sql for unrestricted queries
+[[tools]]
+name = "get_active_users"
+source = "production"
+description = "Get list of active users"
+statement = "SELECT id, name, email FROM users WHERE status = 'active' LIMIT $1"
+
+[[tools.parameters]]
+name = "limit"
+type = "integer"
+description = "Maximum number of users to return"
+default = 10
+```
+
+This approach gives you fine-grained control: disable general SQL execution while providing specific, safe operations through custom tools.
+
 ## Tool Naming
 
 The tool name varies based on your configuration:

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { buildDSNFromEnvParams, resolveDSN, resolveId } from '../env.js';
+
+// Mock toml-loader to prevent it from loading dbhub.toml during tests
+vi.mock('../toml-loader.js', () => ({
+  loadTomlConfig: vi.fn(() => null),
+}));
 
 describe('Environment Configuration Tests', () => {
   // Store original env values to restore after tests

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -299,6 +299,10 @@ host = "localhost"
 [[sources]]
 id = "test"
 dsn = "postgres://user:pass@localhost:5432/db"
+
+[[tools]]
+name = "execute_sql"
+source = "test"
 max_rows = -100
 `;
       fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -107,6 +107,9 @@ export interface Connector {
   /** DSN parser for this connector */
   dsnParser: DSNParser;
 
+  /** Get the source ID for this connector instance (set by ConnectorManager) */
+  getId(): string;
+
   /** Create a new instance of this connector (for multi-source support). This method is required for all connectors. */
   clone(): Connector;
 

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -112,6 +112,9 @@ export class ConnectorManager {
     // All connectors support cloning for multi-source configurations
     const connector = connectorPrototype.clone();
 
+    // Attach source ID to connector instance for tool handlers
+    (connector as any).sourceId = sourceId;
+
     // Build config for database-specific options
     const config: ConnectorConfig = {};
     if (source.connection_timeout !== undefined) {

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -97,6 +97,12 @@ export class MariaDBConnector implements Connector {
   dsnParser = new MariadbDSNParser();
 
   private pool: mariadb.Pool | null = null;
+  // Source ID is set by ConnectorManager after cloning
+  private sourceId: string = "default";
+
+  getId(): string {
+    return this.sourceId;
+  }
 
   clone(): Connector {
     return new MariaDBConnector();

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -100,6 +100,12 @@ export class MySQLConnector implements Connector {
   dsnParser = new MySQLDSNParser();
 
   private pool: mysql.Pool | null = null;
+  // Source ID is set by ConnectorManager after cloning
+  private sourceId: string = "default";
+
+  getId(): string {
+    return this.sourceId;
+  }
 
   clone(): Connector {
     return new MySQLConnector();

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -100,6 +100,13 @@ export class PostgresConnector implements Connector {
 
   private pool: pg.Pool | null = null;
 
+  // Source ID is set by ConnectorManager after cloning
+  private sourceId: string = "default";
+
+  getId(): string {
+    return this.sourceId;
+  }
+
   clone(): Connector {
     return new PostgresConnector();
   }

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -110,6 +110,13 @@ export class SQLiteConnector implements Connector {
   private db: Database.Database | null = null;
   private dbPath: string = ":memory:"; // Default to in-memory database
 
+  // Source ID is set by ConnectorManager after cloning
+  private sourceId: string = "default";
+
+  getId(): string {
+    return this.sourceId;
+  }
+
   clone(): Connector {
     return new SQLiteConnector();
   }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -136,6 +136,12 @@ export class SQLServerConnector implements Connector {
 
   private connection?: sql.ConnectionPool;
   private config?: sql.config;
+  // Source ID is set by ConnectorManager after cloning
+  private sourceId: string = "default";
+
+  getId(): string {
+    return this.sourceId;
+  }
 
   clone(): Connector {
     return new SQLServerConnector();

--- a/src/tools/__tests__/search-objects.test.ts
+++ b/src/tools/__tests__/search-objects.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../connectors/manager.js');
 const createMockConnector = (id: ConnectorType = 'sqlite'): Connector => ({
   id,
   name: 'Mock Connector',
+  getId: () => 'default',
   dsnParser: {} as any,
   connect: vi.fn(),
   disconnect: vi.fn(),

--- a/src/tools/builtin-tools.ts
+++ b/src/tools/builtin-tools.ts
@@ -1,0 +1,12 @@
+/**
+ * Built-in tool constants
+ * Central location for built-in tool names used throughout the codebase
+ */
+
+export const BUILTIN_TOOL_EXECUTE_SQL = "execute_sql";
+export const BUILTIN_TOOL_SEARCH_OBJECTS = "search_objects";
+
+export const BUILTIN_TOOLS = [
+  BUILTIN_TOOL_EXECUTE_SQL,
+  BUILTIN_TOOL_SEARCH_OBJECTS,
+] as const;

--- a/src/tools/custom-tool-registry.ts
+++ b/src/tools/custom-tool-registry.ts
@@ -6,6 +6,7 @@
 import { ToolConfig } from "../types/config.js";
 import { ConnectorManager } from "../connectors/manager.js";
 import { validateParameters } from "../utils/parameter-mapper.js";
+import { BUILTIN_TOOLS } from "./builtin-tools.js";
 
 /**
  * Global registry of custom tools loaded from TOML configuration
@@ -78,15 +79,14 @@ class CustomToolRegistry {
     }
 
     // 3. Validate tool name doesn't conflict with built-in tools
-    const builtInToolPrefixes = ["execute_sql", "search_objects"];
-    for (const prefix of builtInToolPrefixes) {
+    for (const builtinName of BUILTIN_TOOLS) {
       if (
-        toolConfig.name === prefix ||
-        toolConfig.name.startsWith(`${prefix}_`)
+        toolConfig.name === builtinName ||
+        toolConfig.name.startsWith(`${builtinName}_`)
       ) {
         throw new Error(
           `Tool name '${toolConfig.name}' conflicts with built-in tool naming pattern. ` +
-            `Custom tools cannot use names starting with: ${builtInToolPrefixes.join(", ")}`
+            `Custom tools cannot use names starting with: ${BUILTIN_TOOLS.join(", ")}`
         );
       }
     }
@@ -99,8 +99,8 @@ class CustomToolRegistry {
     }
 
     // 5. Validate parameters match SQL statement
-    const sourceConfig = ConnectorManager.getSourceConfig(toolConfig.source);
-    const connectorType = sourceConfig?.type || "postgres"; // Default to postgres if type not specified
+    const sourceConfig = ConnectorManager.getSourceConfig(toolConfig.source)!;
+    const connectorType = sourceConfig.type;
 
     try {
       validateParameters(

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,0 +1,146 @@
+/**
+ * Tool Registry
+ * Manages tool enablement and configuration across multiple database sources
+ */
+
+import type { TomlConfig, ToolConfig, ExecuteSqlToolConfig, SearchObjectsToolConfig } from "../types/config.js";
+import { BUILTIN_TOOLS } from "./builtin-tools.js";
+
+/**
+ * Registry for managing tools across multiple database sources
+ * Handles both built-in tools (execute_sql, search_objects) and custom tools
+ */
+export class ToolRegistry {
+  private toolsBySource: Map<string, ToolConfig[]>;
+
+  constructor(config: TomlConfig) {
+    this.toolsBySource = this.buildRegistry(config);
+  }
+
+  /**
+   * Check if a tool name is a built-in tool
+   */
+  private isBuiltinTool(toolName: string): boolean {
+    return BUILTIN_TOOLS.includes(toolName);
+  }
+
+  /**
+   * Build the internal registry mapping sources to their enabled tools
+   */
+  private buildRegistry(config: TomlConfig): Map<string, ToolConfig[]> {
+    const registry = new Map<string, ToolConfig[]>();
+
+    // Group tools by source
+    for (const tool of config.tools || []) {
+      const existing = registry.get(tool.source) || [];
+      existing.push(tool);
+      registry.set(tool.source, existing);
+    }
+
+    // Backward compatibility: sources without tools get default built-ins
+    for (const source of config.sources) {
+      if (!registry.has(source.id)) {
+        const defaultTools: ToolConfig[] = BUILTIN_TOOLS.map((name) => {
+          // Create properly typed tool configs based on the tool name
+          if (name === 'execute_sql') {
+            return { name: 'execute_sql', source: source.id } satisfies ExecuteSqlToolConfig;
+          } else {
+            return { name: 'search_objects', source: source.id } satisfies SearchObjectsToolConfig;
+          }
+        });
+        registry.set(source.id, defaultTools);
+      }
+    }
+
+    return registry;
+  }
+
+  /**
+   * Get all tools enabled for a specific source
+   */
+  getToolsForSource(sourceId: string): ToolConfig[] {
+    return this.toolsBySource.get(sourceId) || [];
+  }
+
+  /**
+   * Get built-in tool configuration for a specific source
+   * Returns undefined if tool is not enabled or not a built-in
+   */
+  getBuiltinToolConfig(
+    toolName: string,
+    sourceId: string
+  ): ToolConfig | undefined {
+    if (!this.isBuiltinTool(toolName)) {
+      return undefined;
+    }
+    const tools = this.getToolsForSource(sourceId);
+    return tools.find((t) => t.name === toolName);
+  }
+
+  /**
+   * Get all unique tools across all sources (for tools/list response)
+   * Returns the union of all enabled tools
+   */
+  getAllTools(): ToolConfig[] {
+    const seen = new Set<string>();
+    const result: ToolConfig[] = [];
+
+    for (const tools of this.toolsBySource.values()) {
+      for (const tool of tools) {
+        if (!seen.has(tool.name)) {
+          seen.add(tool.name);
+          result.push(tool);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Get all custom tools (non-builtin) across all sources
+   */
+  getCustomTools(): ToolConfig[] {
+    return this.getAllTools().filter((tool) => !this.isBuiltinTool(tool.name));
+  }
+
+  /**
+   * Get all built-in tool names that are enabled across any source
+   */
+  getEnabledBuiltinToolNames(): string[] {
+    const enabledBuiltins = new Set<string>();
+
+    for (const tools of this.toolsBySource.values()) {
+      for (const tool of tools) {
+        if (this.isBuiltinTool(tool.name)) {
+          enabledBuiltins.add(tool.name);
+        }
+      }
+    }
+
+    return Array.from(enabledBuiltins);
+  }
+}
+
+// Global singleton instance
+let globalRegistry: ToolRegistry | null = null;
+
+/**
+ * Initialize the global tool registry
+ */
+export function initializeToolRegistry(config: TomlConfig): void {
+  globalRegistry = new ToolRegistry(config);
+}
+
+/**
+ * Get the global tool registry instance
+ * Throws if registry has not been initialized
+ */
+export function getToolRegistry(): ToolRegistry {
+  if (!globalRegistry) {
+    throw new Error(
+      "Tool registry not initialized. Call initializeToolRegistry first."
+    );
+  }
+  return globalRegistry;
+}

--- a/src/tools/search-objects.ts
+++ b/src/tools/search-objects.ts
@@ -450,6 +450,8 @@ export function createSearchDatabaseObjectsToolHandler(sourceId?: string) {
     try {
       const connector = ConnectorManager.getCurrentConnector(sourceId);
 
+      // Tool is already registered, so it's enabled (no need to check)
+
       // Validate schema if provided
       if (schema) {
         const schemas = await connector.getSchemas();

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -18,7 +18,7 @@ export interface SSHConfig {
  * Database connection parameters (alternative to DSN)
  */
 export interface ConnectionParams {
-  type?: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite";
+  type: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite";
   host?: string;
   port?: number;
   database?: string;
@@ -28,20 +28,9 @@ export interface ConnectionParams {
 }
 
 /**
- * Execution options per source
- */
-export interface ExecutionOptions {
-  readonly?: boolean;
-  max_rows?: number;
-}
-
-/**
  * Source configuration from [[sources]] array in TOML
  */
-export interface SourceConfig
-  extends ConnectionParams,
-    SSHConfig,
-    ExecutionOptions {
+export interface SourceConfig extends ConnectionParams, SSHConfig {
   id: string;
   dsn?: string;
   connection_timeout?: number; // Connection timeout in seconds
@@ -62,15 +51,38 @@ export interface ParameterConfig {
 }
 
 /**
- * Custom tool definition
+ * Built-in tool configuration for execute_sql
  */
-export interface ToolConfig {
-  name: string;
+export interface ExecuteSqlToolConfig {
+  name: "execute_sql"; // Must match BUILTIN_TOOL_EXECUTE_SQL from builtin-tools.ts
+  source: string;
+  readonly?: boolean;
+  max_rows?: number;
+}
+
+/**
+ * Built-in tool configuration for search_objects
+ */
+export interface SearchObjectsToolConfig {
+  name: "search_objects"; // Must match BUILTIN_TOOL_SEARCH_OBJECTS from builtin-tools.ts
+  source: string;
+}
+
+/**
+ * Custom tool configuration
+ */
+export interface CustomToolConfig {
+  name: string; // Must not be "execute_sql" or "search_objects"
+  source: string;
   description: string;
-  source: string; // Required: references a source ID
-  statement: string; // SQL query with parameters
+  statement: string;
   parameters?: ParameterConfig[];
 }
+
+/**
+ * Unified tool configuration (discriminated union)
+ */
+export type ToolConfig = ExecuteSqlToolConfig | SearchObjectsToolConfig | CustomToolConfig;
 
 /**
  * Complete TOML configuration file structure


### PR DESCRIPTION
This commit implements a comprehensive tool extension architecture that allows fine-grained control over which tools are available for each database source, with tool-specific configuration options.

Key Changes:

1. Tool Registry System:
   - Created new ToolRegistry class to manage tool enablement per source
   - Tools are only registered if explicitly enabled in configuration
   - Backward compatible: sources without [[tools]] get default built-ins

2. Per-Tool Configuration:
   - Moved readonly/max_rows from source-level to tool-level
   - Only execute_sql supports readonly and max_rows options
   - search_objects has no additional configuration options

3. Type Safety Improvements:
   - Redesigned ToolConfig as discriminated union: * ExecuteSqlToolConfig (with readonly/max_rows) * SearchObjectsToolConfig (no additional options) * CustomToolConfig (with description/statement/parameters)
   - Prevents invalid configuration combinations at type level

4. Removed Deprecated Flags:
   - --readonly and --max-rows CLI flags now fail immediately
   - READONLY and MAX_ROWS env vars now fail immediately
   - Clear error messages guide users to TOML configuration
   - Completely removed backward compatibility code

5. Code Quality:
   - Removed redundant isToolEnabledForSource runtime checks
   - Use uppercase constants (BUILTIN_TOOL_EXECUTE_SQL) instead of string literals
   - Simplified tool registration logic by iterating enabled tools
   - Made ConnectionParams.type required (was optional)

6. Documentation Updates:
   - Updated all docs to reflect tool-level configuration
   - Removed deprecated flags from server-options.mdx
   - Consolidated tool configuration docs in tools/overview.mdx
   - Added comprehensive examples in dbhub.toml.example

Example Configuration:
```toml
[[sources]]
id = "production"
dsn = "postgres://..."

[[tools]]
name = "execute_sql"
source = "production"
readonly = true
max_rows = 100

[[tools]]
name = "search_objects"
source = "production"
```

Breaking Changes:
- --readonly and --max-rows CLI flags are no longer supported
- READONLY and MAX_ROWS environment variables are no longer supported
- Users must migrate to TOML configuration with [[tools]] entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)