### PR TITLE
feat: use mysql_clear_password for AWS IAM auth

### DIFF
--- a/src/connectors/__tests__/dsn-parser.test.ts
+++ b/src/connectors/__tests__/dsn-parser.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { MySQLConnector } from '../mysql/index.js';
+import { MariaDBConnector } from '../mariadb/index.js';
+
+describe('DSN Parser - AWS IAM Authentication', () => {
+  describe('MySQL', () => {
+    const connector = new MySQLConnector();
+    const parser = connector.dsnParser;
+
+    it('should detect AWS IAM token and configure cleartext plugin with SSL', async () => {
+      const awsToken = 'mydb.abc123.us-east-1.rds.amazonaws.com:3306/?Action=connect&DBUser=myuser&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/rds-db/aws4_request&X-Amz-Date=20240101T000000Z&X-Amz-SignedHeaders=host&X-Amz-Signature=abc123def456';
+      const dsn = `mysql://myuser:${encodeURIComponent(awsToken)}@mydb.abc123.us-east-1.rds.amazonaws.com:3306/mydb`;
+
+      const config = await parser.parse(dsn);
+
+      // Should have authPlugins configured with cleartext plugin
+      expect(config.authPlugins).toBeDefined();
+      expect(config.authPlugins?.mysql_clear_password).toBeDefined();
+
+      // Should auto-enable SSL for AWS IAM authentication
+      expect(config.ssl).toEqual({ rejectUnauthorized: false });
+
+      // Plugin should return password with null terminator
+      if (config.authPlugins?.mysql_clear_password) {
+        const pluginFunc = config.authPlugins.mysql_clear_password();
+        const result = pluginFunc();
+        expect(result).toBeInstanceOf(Buffer);
+        expect(result.toString()).toBe(awsToken + '\0');
+      }
+    });
+
+    it('should not configure cleartext plugin for normal passwords', async () => {
+      const dsn = 'mysql://myuser:regularpassword@localhost:3306/mydb';
+
+      const config = await parser.parse(dsn);
+
+      expect(config.authPlugins).toBeUndefined();
+      expect(config.ssl).toBeUndefined();
+    });
+  });
+
+  describe('MariaDB', () => {
+    const connector = new MariaDBConnector();
+    const parser = connector.dsnParser;
+
+    it('should detect AWS IAM token and auto-enable SSL', async () => {
+      const awsToken = 'mydb.abc123.us-east-1.rds.amazonaws.com:3306/?Action=connect&DBUser=myuser&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/rds-db/aws4_request&X-Amz-Date=20240101T000000Z&X-Amz-SignedHeaders=host&X-Amz-Signature=abc123def456';
+      const dsn = `mariadb://myuser:${encodeURIComponent(awsToken)}@mydb.abc123.us-east-1.rds.amazonaws.com:3306/mydb`;
+
+      const config = await parser.parse(dsn);
+
+      // SSL should be auto-enabled for AWS IAM auth
+      // MariaDB connector includes mysql_clear_password in default permitted plugins
+      expect(config.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    it('should not auto-enable SSL for normal passwords', async () => {
+      const dsn = 'mariadb://myuser:regularpassword@localhost:3306/mydb';
+
+      const config = await parser.parse(dsn);
+
+      expect(config.ssl).toBeUndefined();
+    });
+  });
+});

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -67,6 +67,17 @@ class MariadbDSNParser implements DSNParser {
         // Add other parameters as needed
       });
 
+      // Auto-detect AWS IAM authentication tokens and ensure SSL is enabled
+      // AWS RDS IAM tokens are ~800+ character strings containing "X-Amz-Credential"
+      // MariaDB connector includes mysql_clear_password in default permitted plugins,
+      // but AWS IAM authentication requires SSL
+      if (url.password && url.password.includes("X-Amz-Credential")) {
+        // AWS IAM authentication requires SSL, enable if not already configured
+        if (config.ssl === undefined) {
+          config.ssl = { rejectUnauthorized: false };
+        }
+      }
+
       return config;
     } catch (error) {
       throw new Error(


### PR DESCRIPTION
Fix #174 