### PR TITLE
refactor: simplify tool registration and remove is_default

### DIFF
--- a/src/api/__tests__/sources.integration.test.ts
+++ b/src/api/__tests__/sources.integration.test.ts
@@ -80,15 +80,6 @@ describe('Data Sources API Integration Tests', () => {
       expect(ids).toEqual(['readonly_limited', 'writable_limited', 'writable_unlimited']);
     });
 
-    it('should mark first source as default', async () => {
-      const response = await fetch(`${BASE_URL}/api/sources`);
-      const sources = (await response.json()) as DataSource[];
-
-      expect(sources[0].is_default).toBe(true);
-      expect(sources[1].is_default).toBe(false);
-      expect(sources[2].is_default).toBe(false);
-    });
-
     it('should include database type for all sources', async () => {
       const response = await fetch(`${BASE_URL}/api/sources`);
       const sources = (await response.json()) as DataSource[];
@@ -203,20 +194,6 @@ describe('Data Sources API Integration Tests', () => {
       });
     });
 
-    it('should mark default source in tool description', async () => {
-      const response = await fetch(`${BASE_URL}/api/sources`);
-      const sources = (await response.json()) as DataSource[];
-
-      const defaultSource = sources.find(s => s.is_default);
-      expect(defaultSource).toBeDefined();
-      expect(defaultSource?.tools[0].description).toContain('(default)');
-
-      const nonDefaultSources = sources.filter(s => !s.is_default);
-      nonDefaultSources.forEach((source) => {
-        expect(source.tools[0].description).not.toContain('(default)');
-      });
-    });
-
     it('should include sql parameter in execute_sql tool', async () => {
       const response = await fetch(`${BASE_URL}/api/sources`);
       const sources = (await response.json()) as DataSource[];
@@ -241,18 +218,16 @@ describe('Data Sources API Integration Tests', () => {
       const source = (await response.json()) as DataSource;
       expect(source.id).toBe('readonly_limited');
       expect(source.type).toBe('sqlite');
-      expect(source.is_default).toBe(true);
       expect(source.readonly).toBe(true);
       expect(source.max_rows).toBe(100);
     });
 
-    it('should return correct data for non-default source', async () => {
+    it('should return correct data for another source', async () => {
       const response = await fetch(`${BASE_URL}/api/sources/writable_limited`);
       expect(response.status).toBe(200);
 
       const source = (await response.json()) as DataSource;
       expect(source.id).toBe('writable_limited');
-      expect(source.is_default).toBe(false);
       expect(source.readonly).toBe(false);
       expect(source.max_rows).toBe(500);
     });

--- a/src/api/openapi.d.ts
+++ b/src/api/openapi.d.ts
@@ -81,11 +81,6 @@ export interface components {
              */
             user?: string;
             /**
-             * @description Whether this is the default data source
-             * @example true
-             */
-            is_default: boolean;
-            /**
              * @description Whether the connection is restricted to read-only operations
              * @example true
              */
@@ -230,7 +225,6 @@ export interface operations {
                      *       "port": 5432,
                      *       "database": "production",
                      *       "user": "dbuser",
-                     *       "is_default": true,
                      *       "readonly": true,
                      *       "max_rows": 1000
                      *     }

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -36,7 +36,6 @@ paths:
                       port: 5432
                       database: production
                       user: dbuser
-                      is_default: true
                       readonly: true
                       max_rows: 1000
                     - id: staging_mysql
@@ -45,7 +44,6 @@ paths:
                       port: 3306
                       database: staging
                       user: root
-                      is_default: false
                       readonly: false
                 emptySources:
                   summary: No sources configured
@@ -78,7 +76,6 @@ paths:
                 port: 5432
                 database: production
                 user: dbuser
-                is_default: true
                 readonly: true
                 max_rows: 1000
         '404':
@@ -98,7 +95,6 @@ components:
       required:
         - id
         - type
-        - is_default
         - tools
       properties:
         id:
@@ -126,10 +122,6 @@ components:
           type: string
           description: Database username (not present for SQLite)
           example: dbuser
-        is_default:
-          type: boolean
-          description: Whether this is the default data source
-          example: true
         readonly:
           type: boolean
           description: Whether the connection is restricted to read-only operations


### PR DESCRIPTION
- Unify registerSearchObjectsTool/registerCustomTool to follow same interface as registerExecuteSqlTool (server, sourceId)
- Make getSearchObjectsMetadata consistent with getExecuteSqlMetadata (only takes sourceId, derives other values internally)
- Replace isDefault with isSingleSource for tool naming logic
- Remove is_default from API schema and all related code

🤖 Generated with [Claude Code](https://claude.com/claude-code)