### PR TITLE
refactor: consolidate buildDSNFromSource calls into ConnectorManager

### DIFF
--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -4,6 +4,7 @@ import type { SSHTunnelConfig } from "../types/ssh.js";
 import type { SourceConfig } from "../types/config.js";
 import { buildDSNFromSource } from "../config/toml-loader.js";
 import { getDatabaseTypeFromDSN, getDefaultPortForType } from "../utils/dsn-obfuscate.js";
+import { redactDSN } from "../config/env.js";
 
 // Singleton instance for global access
 let managerInstance: ConnectorManager | null = null;
@@ -35,6 +36,8 @@ export class ConnectorManager {
       throw new Error("No sources provided");
     }
 
+    console.error(`Connecting to ${sources.length} database source(s)...`);
+
     // Connect to each source
     for (const source of sources) {
       await this.connectSource(source);
@@ -48,6 +51,7 @@ export class ConnectorManager {
     const sourceId = source.id;
     // Build DSN from source config
     const dsn = buildDSNFromSource(source);
+    console.error(`  - ${sourceId}: ${redactDSN(dsn)}`);
 
     // Setup SSH tunnel if needed
     let actualDSN = dsn;

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,8 +8,7 @@ import { fileURLToPath } from "url";
 
 import { ConnectorManager } from "./connectors/manager.js";
 import { ConnectorRegistry } from "./connectors/interface.js";
-import { resolveTransport, resolvePort, redactDSN, resolveSourceConfigs, isDemoMode } from "./config/env.js";
-import { buildDSNFromSource } from "./config/toml-loader.js";
+import { resolveTransport, resolvePort, resolveSourceConfigs, isDemoMode } from "./config/env.js";
 import { registerTools } from "./tools/index.js";
 import { listSources, getSource } from "./api/sources.js";
 import { listRequests } from "./api/requests.js";
@@ -91,11 +90,6 @@ See documentation for more details on configuring database connections.
     console.error(`Configuration source: ${sourceConfigsData.source}`);
 
     // Connect to database(s) - works uniformly for all modes (demo, single DSN, multi-source TOML)
-    console.error(`Connecting to ${sources.length} database source(s)...`);
-    for (const source of sources) {
-      const dsn = source.dsn || buildDSNFromSource(source);
-      console.error(`  - ${source.id}: ${redactDSN(dsn)}`);
-    }
     await connectorManager.connectWithSources(sources);
 
     // Initialize tool registry (manages both built-in and custom tools)


### PR DESCRIPTION
Move DSN building and connection logging from server.ts into ConnectorManager.connectWithSources() to eliminate duplicate calls.

🤖 Generated with [Claude Code](https://claude.ai/code)