### PR TITLE
feat: return affected row count for INSERT/UPDATE/DELETE

### DIFF
--- a/frontend/src/api/tools.ts
+++ b/frontend/src/api/tools.ts
@@ -75,7 +75,8 @@ export async function executeTool(
 
   const rows = toolResult.data.rows;
   if (rows.length === 0) {
-    return { columns: [], rows: [], rowCount: 0 };
+    // For INSERT/UPDATE/DELETE, rows is empty but count reflects affected rows
+    return { columns: [], rows: [], rowCount: toolResult.data.count };
   }
 
   const columns = Object.keys(rows[0]);

--- a/frontend/src/components/tool/ResultsTable.tsx
+++ b/frontend/src/components/tool/ResultsTable.tsx
@@ -108,11 +108,15 @@ export function ResultsTable({ result, error, isLoading, executedSql, executionT
     );
   }
 
-  // No results
+  // No rows returned - could be empty SELECT or successful INSERT/UPDATE/DELETE
   if (result.rows.length === 0) {
     return (
       <div className="border border-border rounded-lg bg-card p-8 text-center">
-        <p className="text-muted-foreground text-sm">No results returned</p>
+        <p className="text-muted-foreground text-sm">
+          {result.rowCount > 0
+            ? `${result.rowCount} row${result.rowCount !== 1 ? 's' : ''} affected`
+            : 'No results returned'}
+        </p>
       </div>
     );
   }

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -9,7 +9,7 @@ export type ConnectorType = "postgres" | "mysql" | "mariadb" | "sqlite" | "sqlse
  */
 export interface SQLResult {
   rows: any[];
-  [key: string]: any;
+  rowCount: number;
 }
 
 export interface TableColumn {

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -14,7 +14,7 @@ import {
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
-import { parseQueryResults } from "../../utils/multi-statement-result-parser.js";
+import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
 
 /**
  * MariaDB DSN Parser
@@ -542,7 +542,8 @@ export class MariaDBConnector implements Connector {
 
       // Parse results using shared utility that handles both single and multi-statement queries
       const rows = parseQueryResults(results);
-      return { rows };
+      const rowCount = extractAffectedRows(results);
+      return { rows, rowCount };
     } catch (error) {
       console.error("Error executing query:", error);
       throw error;

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -14,7 +14,7 @@ import {
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
-import { parseQueryResults } from "../../utils/multi-statement-result-parser.js";
+import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
 
 /**
  * MySQL DSN Parser
@@ -553,7 +553,8 @@ export class MySQLConnector implements Connector {
 
       // Parse results using shared utility that handles both single and multi-statement queries
       const rows = parseQueryResults(firstResult);
-      return { rows };
+      const rowCount = extractAffectedRows(firstResult);
+      return { rows, rowCount };
     } catch (error) {
       console.error("Error executing query:", error);
       throw error;

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -556,12 +556,6 @@ export class SQLServerConnector implements Connector {
 
       return {
         rows: result.recordset || [],
-        fields:
-          result.recordset && result.recordset.length > 0
-            ? Object.keys(result.recordset[0]).map((key) => ({
-                name: key,
-              }))
-            : [],
         rowCount: result.rowsAffected[0] || 0,
       };
     } catch (error) {

--- a/src/tools/__tests__/execute-sql.test.ts
+++ b/src/tools/__tests__/execute-sql.test.ts
@@ -53,7 +53,7 @@ describe('execute-sql tool', () => {
 
   describe('basic execution', () => {
     it('should execute SELECT and return rows', async () => {
-      const mockResult: SQLResult = { rows: [{ id: 1, name: 'test' }] };
+      const mockResult: SQLResult = { rows: [{ id: 1, name: 'test' }], rowCount: 1 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('test_source');
@@ -67,7 +67,7 @@ describe('execute-sql tool', () => {
     });
 
     it('should pass multi-statement SQL directly to connector', async () => {
-      const mockResult: SQLResult = { rows: [{ id: 1 }] };
+      const mockResult: SQLResult = { rows: [{ id: 1 }], rowCount: 1 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = 'SELECT * FROM users; SELECT * FROM roles;';
@@ -102,7 +102,7 @@ describe('execute-sql tool', () => {
     });
 
     it('should allow SELECT statements', async () => {
-      const mockResult: SQLResult = { rows: [{ id: 1 }] };
+      const mockResult: SQLResult = { rows: [{ id: 1 }], rowCount: 1 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('test_source');
@@ -114,7 +114,7 @@ describe('execute-sql tool', () => {
     });
 
     it('should allow multiple read-only statements', async () => {
-      const mockResult: SQLResult = { rows: [] };
+      const mockResult: SQLResult = { rows: [], rowCount: 0 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = 'SELECT * FROM users; SELECT * FROM roles;';
@@ -173,7 +173,7 @@ describe('execute-sql tool', () => {
       mockGetToolRegistry.mockReturnValue({
         getBuiltinToolConfig: vi.fn().mockReturnValue(toolConfig),
       } as any);
-      const mockResult: SQLResult = { rows: [] };
+      const mockResult: SQLResult = { rows: [], rowCount: 0 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('writable_source');
@@ -208,7 +208,7 @@ describe('execute-sql tool', () => {
       ['inline comments', 'SELECT id, -- user id\n       name FROM users'],
       ['only comments', '-- Just a comment\n/* Another */'],
     ])('should allow SELECT with %s', async (_, sql) => {
-      const mockResult: SQLResult = { rows: [] };
+      const mockResult: SQLResult = { rows: [], rowCount: 0 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('test_source');
@@ -231,7 +231,7 @@ describe('execute-sql tool', () => {
       ['empty string', ''],
       ['only semicolons and whitespace', '   ;  ;  ; '],
     ])('should handle %s', async (_, sql) => {
-      const mockResult: SQLResult = { rows: [] };
+      const mockResult: SQLResult = { rows: [], rowCount: 0 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('test_source');

--- a/src/tools/custom-tool-handler.ts
+++ b/src/tools/custom-tool-handler.ts
@@ -199,7 +199,7 @@ export function createCustomToolHandler(toolConfig: ToolConfig) {
       // 7. Build response data
       const responseData = {
         rows: result.rows,
-        count: result.rows.length,
+        count: result.rowCount,
         source_id: toolConfig.source,
       };
 

--- a/src/tools/execute-sql.ts
+++ b/src/tools/execute-sql.ts
@@ -78,7 +78,7 @@ export function createExecuteSqlToolHandler(sourceId?: string) {
       // Build response data
       const responseData = {
         rows: result.rows,
-        count: result.rows.length,
+        count: result.rowCount,
         source_id: effectiveSourceId,
       };
 

--- a/src/utils/multi-statement-result-parser.ts
+++ b/src/utils/multi-statement-result-parser.ts
@@ -69,6 +69,43 @@ export function extractRowsFromMultiStatement(results: any): any[] {
 }
 
 /**
+ * Extracts total affected rows from query results.
+ *
+ * For INSERT/UPDATE/DELETE operations, returns the sum of affectedRows.
+ * For SELECT operations, returns the number of rows.
+ *
+ * @param results - Raw results from the database driver
+ * @returns Total number of affected/returned rows
+ */
+export function extractAffectedRows(results: any): number {
+  // Handle metadata object (single INSERT/UPDATE/DELETE)
+  if (isMetadataObject(results)) {
+    return results.affectedRows || 0;
+  }
+
+  // Handle non-array results
+  if (!Array.isArray(results)) {
+    return 0;
+  }
+
+  // Check if this is a multi-statement result
+  if (isMultiStatementResult(results)) {
+    let totalAffected = 0;
+    for (const result of results) {
+      if (isMetadataObject(result)) {
+        totalAffected += result.affectedRows || 0;
+      } else if (Array.isArray(result)) {
+        totalAffected += result.length;
+      }
+    }
+    return totalAffected;
+  }
+
+  // Single statement result - results is the rows array directly
+  return results.length;
+}
+
+/**
  * Parses database query results, handling both single and multi-statement queries.
  *
  * This function unifies the result parsing logic for MariaDB and MySQL2 drivers,


### PR DESCRIPTION
- Add rowCount to all database connectors (PostgreSQL, MySQL, MariaDB, SQLite, SQL Server)
- Add extractAffectedRows utility for MySQL/MariaDB result parsing
- Update execute-sql and custom-tool-handler to use rowCount for count field
- Frontend now displays "N rows affected" for write operations instead of "No results returned"

🤖 Generated with [Claude Code](https://claude.com/claude-code)