### PR TITLE
fix: use namespace import for mariadb to fix Node.js v24 ESM compatibility

### DIFF
--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -1,4 +1,4 @@
-import mariadb from "mariadb";
+import * as mariadb from "mariadb";
 import {
   Connector,
   ConnectorType,


### PR DESCRIPTION
## Summary
- Fixes `SyntaxError: The requested module 'mariadb' does not provide an export named 'default'` on Node.js v24.x
- Changes `import mariadb from "mariadb"` to `import * as mariadb from "mariadb"` in the MariaDB connector
- The `mariadb` npm package is CommonJS-only and lacks ESM export declarations (`"type"` and `"exports"` fields), causing Node.js v24's stricter ESM/CJS interop to reject the default import

Fixes #241

## Test plan
- [x] Build succeeds (`pnpm run build`)
- [x] All unit tests pass
- [x] MariaDB integration tests pass (32 tests)
- [x] Compiled output in `dist/index.js` uses `import * as mariadb from "mariadb"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)