### PR TITLE
Add support for `search_path` in PostgreSQL DSN and TOML config for non-public schemas      

### DIFF
--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -32,6 +32,22 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # password = "p@ss:word/123"
 # sslmode = "disable"  # Optional: "disable" or "require"
 
+# PostgreSQL with non-public schema (DSN format)
+# [[sources]]
+# id = "schema_pg"
+# dsn = "postgres://user:pass@localhost:5432/mydb?search_path=myschema"
+
+# PostgreSQL with non-public schema (individual parameters)
+# [[sources]]
+# id = "schema_pg"
+# type = "postgres"
+# host = "localhost"
+# database = "mydb"
+# user = "user"
+# password = "pass"
+# search_path = "myschema"          # Sets session search_path and default schema for discovery
+# # search_path = "myschema,public" # Comma-separated: first schema is used as discovery default
+
 # Development PostgreSQL (shared dev server)
 # [[sources]]
 # id = "dev_pg"
@@ -259,6 +275,7 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #
 # DSN Formats:
 #   PostgreSQL:  postgres://user:pass@host:5432/database?sslmode=require
+#   PostgreSQL:  postgres://user:pass@host:5432/database?search_path=myschema
 #   MySQL:       mysql://user:pass@host:3306/database
 #   MariaDB:     mariadb://user:pass@host:3306/database
 #   SQL Server:  sqlserver://user:pass@host:1433/database

--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -32,11 +32,6 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # password = "p@ss:word/123"
 # sslmode = "disable"  # Optional: "disable" or "require"
 
-# PostgreSQL with non-public schema (DSN format)
-# [[sources]]
-# id = "schema_pg"
-# dsn = "postgres://user:pass@localhost:5432/mydb?search_path=myschema"
-
 # PostgreSQL with non-public schema (individual parameters)
 # [[sources]]
 # id = "schema_pg"
@@ -275,7 +270,6 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #
 # DSN Formats:
 #   PostgreSQL:  postgres://user:pass@host:5432/database?sslmode=require
-#   PostgreSQL:  postgres://user:pass@host:5432/database?search_path=myschema
 #   MySQL:       mysql://user:pass@host:3306/database
 #   MariaDB:     mariadb://user:pass@host:3306/database
 #   SQL Server:  sqlserver://user:pass@host:1433/database

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { loadTomlConfig, buildDSNFromSource } from "../toml-loader.js";
-import type { SourceConfig } from "../../types/config.js";
-import fs from "fs";
-import path from "path";
-import os from "os";
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadTomlConfig, buildDSNFromSource } from '../toml-loader.js';
+import type { SourceConfig } from '../../types/config.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
-describe("TOML Configuration Tests", () => {
+describe('TOML Configuration Tests', () => {
   const originalCwd = process.cwd();
   const originalArgv = process.argv;
   let tempDir: string;
 
   beforeEach(() => {
     // Create a temporary directory for test config files
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dbhub-test-"));
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dbhub-test-'));
     process.chdir(tempDir);
     // Clear command line arguments
-    process.argv = ["node", "test"];
+    process.argv = ['node', 'test'];
   });
 
   afterEach(() => {
@@ -29,14 +29,14 @@ describe("TOML Configuration Tests", () => {
     process.argv = originalArgv;
   });
 
-  describe("loadTomlConfig", () => {
-    it("should load valid TOML config from dbhub.toml", () => {
+  describe('loadTomlConfig', () => {
+    it('should load valid TOML config from dbhub.toml', () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
@@ -44,71 +44,71 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       expect(result?.sources).toHaveLength(1);
       // DSN should be parsed to populate connection fields
       expect(result?.sources[0]).toEqual({
-        id: "test_db",
-        dsn: "postgres://user:pass@localhost:5432/testdb",
-        type: "postgres",
-        host: "localhost",
+        id: 'test_db',
+        dsn: 'postgres://user:pass@localhost:5432/testdb',
+        type: 'postgres',
+        host: 'localhost',
         port: 5432,
-        database: "testdb",
-        user: "user",
+        database: 'testdb',
+        user: 'user',
       });
-      expect(result?.source).toBe("dbhub.toml");
+      expect(result?.source).toBe('dbhub.toml');
     });
 
-    it("should parse DSN and populate connection fields for postgres", () => {
+    it('should parse DSN and populate connection fields for postgres', () => {
       const tomlContent = `
 [[sources]]
 id = "pg_dsn"
 dsn = "postgres://pguser:secret@db.example.com:5433/mydb"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources[0]).toMatchObject({
-        id: "pg_dsn",
-        type: "postgres",
-        host: "db.example.com",
+        id: 'pg_dsn',
+        type: 'postgres',
+        host: 'db.example.com',
         port: 5433,
-        database: "mydb",
-        user: "pguser",
+        database: 'mydb',
+        user: 'pguser',
       });
     });
 
-    it("should parse DSN and populate connection fields for mysql", () => {
+    it('should parse DSN and populate connection fields for mysql', () => {
       const tomlContent = `
 [[sources]]
 id = "mysql_dsn"
 dsn = "mysql://root:password@mysql.local:3307/appdb"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources[0]).toMatchObject({
-        id: "mysql_dsn",
-        type: "mysql",
-        host: "mysql.local",
+        id: 'mysql_dsn',
+        type: 'mysql',
+        host: 'mysql.local',
         port: 3307,
-        database: "appdb",
-        user: "root",
+        database: 'appdb',
+        user: 'root',
       });
     });
 
-    it("should parse DSN and populate connection fields for sqlite", () => {
+    it('should parse DSN and populate connection fields for sqlite', () => {
       const tomlContent = `
 [[sources]]
 id = "sqlite_dsn"
 dsn = "sqlite:///path/to/database.db"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources[0]).toMatchObject({
-        id: "sqlite_dsn",
-        type: "sqlite",
-        database: "/path/to/database.db",
+        id: 'sqlite_dsn',
+        type: 'sqlite',
+        database: '/path/to/database.db',
       });
       // SQLite should not have host/port/user
       expect(result?.sources[0].host).toBeUndefined();
@@ -116,7 +116,7 @@ dsn = "sqlite:///path/to/database.db"
       expect(result?.sources[0].user).toBeUndefined();
     });
 
-    it("should not override explicit connection params with DSN values", () => {
+    it('should not override explicit connection params with DSN values', () => {
       const tomlContent = `
 [[sources]]
 id = "explicit_override"
@@ -127,44 +127,44 @@ port = 9999
 database = "explicit_db"
 user = "explicit_user"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       // Explicit values should be preserved, not overwritten by DSN
       expect(result?.sources[0]).toMatchObject({
-        id: "explicit_override",
-        type: "postgres",
-        host: "explicit_host",
+        id: 'explicit_override',
+        type: 'postgres',
+        host: 'explicit_host',
         port: 9999,
-        database: "explicit_db",
-        user: "explicit_user",
+        database: 'explicit_db',
+        user: 'explicit_user',
       });
     });
 
-    it("should load config from custom path with --config flag", () => {
-      const customConfigPath = path.join(tempDir, "custom.toml");
+    it('should load config from custom path with --config flag', () => {
+      const customConfigPath = path.join(tempDir, 'custom.toml');
       const tomlContent = `
 [[sources]]
 id = "custom_db"
 dsn = "mysql://user:pass@localhost:3306/db"
 `;
       fs.writeFileSync(customConfigPath, tomlContent);
-      process.argv = ["node", "test", "--config", customConfigPath];
+      process.argv = ['node', 'test', '--config', customConfigPath];
 
       const result = loadTomlConfig();
 
       expect(result).toBeTruthy();
-      expect(result?.sources[0].id).toBe("custom_db");
-      expect(result?.source).toBe("custom.toml");
+      expect(result?.sources[0].id).toBe('custom_db');
+      expect(result?.source).toBe('custom.toml');
     });
 
-    it("should return null when no config file exists", () => {
+    it('should return null when no config file exists', () => {
       const result = loadTomlConfig();
       expect(result).toBeNull();
     });
 
-    it("should load multiple sources", () => {
+    it('should load multiple sources', () => {
       const tomlContent = `
 [[sources]]
 id = "db1"
@@ -179,17 +179,17 @@ id = "db3"
 type = "sqlite"
 database = "/tmp/test.db"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources).toHaveLength(3);
-      expect(result?.sources[0].id).toBe("db1");
-      expect(result?.sources[1].id).toBe("db2");
-      expect(result?.sources[2].id).toBe("db3");
+      expect(result?.sources[0].id).toBe('db1');
+      expect(result?.sources[1].id).toBe('db2');
+      expect(result?.sources[2].id).toBe('db3');
     });
 
-    it("should expand tilde in ssh_key paths", () => {
+    it('should expand tilde in ssh_key paths', () => {
       const tomlContent = `
 [[sources]]
 id = "remote_db"
@@ -198,45 +198,51 @@ ssh_host = "bastion.example.com"
 ssh_user = "ubuntu"
 ssh_key = "~/.ssh/id_rsa"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
-      expect(result?.sources[0].ssh_key).toBe(path.join(os.homedir(), ".ssh", "id_rsa"));
+      expect(result?.sources[0].ssh_key).toBe(
+        path.join(os.homedir(), '.ssh', 'id_rsa')
+      );
     });
 
-    it("should expand tilde in sqlite database paths", () => {
+    it('should expand tilde in sqlite database paths', () => {
       const tomlContent = `
 [[sources]]
 id = "local_db"
 type = "sqlite"
 database = "~/databases/test.db"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
-      expect(result?.sources[0].database).toBe(path.join(os.homedir(), "databases", "test.db"));
+      expect(result?.sources[0].database).toBe(
+        path.join(os.homedir(), 'databases', 'test.db')
+      );
     });
 
-    it("should throw error for missing sources array", () => {
+    it('should throw error for missing sources array', () => {
       const tomlContent = `
 [server]
 port = 8080
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("must contain a [[sources]] array");
+      expect(() => loadTomlConfig()).toThrow(
+        'must contain a [[sources]] array'
+      );
     });
 
-    it("should throw error for empty sources array", () => {
+    it('should throw error for empty sources array', () => {
       const tomlContent = `sources = []`;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("sources array cannot be empty");
+      expect(() => loadTomlConfig()).toThrow('sources array cannot be empty');
     });
 
-    it("should throw error for duplicate source IDs", () => {
+    it('should throw error for duplicate source IDs', () => {
       const tomlContent = `
 [[sources]]
 id = "duplicate"
@@ -246,45 +252,45 @@ dsn = "postgres://user:pass@localhost:5432/db1"
 id = "duplicate"
 dsn = "mysql://user:pass@localhost:3306/db2"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("duplicate source IDs found: duplicate");
+      expect(() => loadTomlConfig()).toThrow('duplicate source IDs found: duplicate');
     });
 
-    it("should throw error for source without id", () => {
+    it('should throw error for source without id', () => {
       const tomlContent = `
 [[sources]]
 dsn = "postgres://user:pass@localhost:5432/db"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       expect(() => loadTomlConfig()).toThrow("each source must have an 'id' field");
     });
 
-    it("should throw error for source without DSN or connection params", () => {
+    it('should throw error for source without DSN or connection params', () => {
       const tomlContent = `
 [[sources]]
 id = "invalid"
 readonly = true
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("must have either");
+      expect(() => loadTomlConfig()).toThrow('must have either');
     });
 
-    it("should throw error for invalid database type", () => {
+    it('should throw error for invalid database type', () => {
       const tomlContent = `
 [[sources]]
 id = "invalid"
 type = "oracle"
 host = "localhost"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       expect(() => loadTomlConfig()).toThrow("invalid type 'oracle'");
     });
 
-    it("should throw error for invalid max_rows", () => {
+    it('should throw error for invalid max_rows', () => {
       const tomlContent = `
 [[sources]]
 id = "test"
@@ -295,12 +301,12 @@ name = "execute_sql"
 source = "test"
 max_rows = -100
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("invalid max_rows");
+      expect(() => loadTomlConfig()).toThrow('invalid max_rows');
     });
 
-    it("should throw error for invalid ssh_port", () => {
+    it('should throw error for invalid ssh_port', () => {
       const tomlContent = `
 [[sources]]
 id = "test"
@@ -310,28 +316,26 @@ ssh_user = "ubuntu"
 ssh_key = "~/.ssh/id_rsa"
 ssh_port = 99999
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("invalid ssh_port");
+      expect(() => loadTomlConfig()).toThrow('invalid ssh_port');
     });
 
-    it("should throw error for non-existent config file specified by --config", () => {
-      process.argv = ["node", "test", "--config", "/nonexistent/path/config.toml"];
+    it('should throw error for non-existent config file specified by --config', () => {
+      process.argv = ['node', 'test', '--config', '/nonexistent/path/config.toml'];
 
-      expect(() => loadTomlConfig()).toThrow(
-        "Configuration file specified by --config flag not found"
-      );
+      expect(() => loadTomlConfig()).toThrow('Configuration file specified by --config flag not found');
     });
 
-    describe("connection_timeout validation", () => {
-      it("should accept valid connection_timeout", () => {
+    describe('connection_timeout validation', () => {
+      it('should accept valid connection_timeout', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = 60
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -339,38 +343,38 @@ connection_timeout = 60
         expect(result?.sources[0].connection_timeout).toBe(60);
       });
 
-      it("should throw error for negative connection_timeout", () => {
+      it('should throw error for negative connection_timeout', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = -30
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow("invalid connection_timeout");
+        expect(() => loadTomlConfig()).toThrow('invalid connection_timeout');
       });
 
-      it("should throw error for zero connection_timeout", () => {
+      it('should throw error for zero connection_timeout', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = 0
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow("invalid connection_timeout");
+        expect(() => loadTomlConfig()).toThrow('invalid connection_timeout');
       });
 
-      it("should accept large connection_timeout values", () => {
+      it('should accept large connection_timeout values', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = 300
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -378,13 +382,13 @@ connection_timeout = 300
         expect(result?.sources[0].connection_timeout).toBe(300);
       });
 
-      it("should work without connection_timeout (optional field)", () => {
+      it('should work without connection_timeout (optional field)', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -393,29 +397,29 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       });
     });
 
-    describe("description field", () => {
-      it("should parse description field", () => {
+    describe('description field', () => {
+      it('should parse description field', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 description = "Production read replica for analytics"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].description).toBe("Production read replica for analytics");
+        expect(result?.sources[0].description).toBe('Production read replica for analytics');
       });
 
-      it("should work without description (optional field)", () => {
+      it('should work without description (optional field)', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -424,7 +428,7 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       });
     });
 
-    describe("sslmode validation", () => {
+    describe('sslmode validation', () => {
       it('should accept sslmode = "disable"', () => {
         const tomlContent = `
 [[sources]]
@@ -436,12 +440,12 @@ user = "user"
 password = "pass"
 sslmode = "disable"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].sslmode).toBe("disable");
+        expect(result?.sources[0].sslmode).toBe('disable');
       });
 
       it('should accept sslmode = "require"', () => {
@@ -455,15 +459,15 @@ user = "user"
 password = "pass"
 sslmode = "require"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].sslmode).toBe("require");
+        expect(result?.sources[0].sslmode).toBe('require');
       });
 
-      it("should throw error for invalid sslmode value", () => {
+      it('should throw error for invalid sslmode value', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -474,12 +478,12 @@ user = "user"
 password = "pass"
 sslmode = "invalid"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("invalid sslmode 'invalid'");
       });
 
-      it("should throw error when sslmode is specified for SQLite", () => {
+      it('should throw error when sslmode is specified for SQLite', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -487,18 +491,18 @@ type = "sqlite"
 database = "/path/to/database.db"
 sslmode = "require"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("SQLite does not support SSL");
       });
 
-      it("should work without sslmode (optional field)", () => {
+      it('should work without sslmode (optional field)', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -507,7 +511,7 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       });
     });
 
-    describe("SQL Server authentication validation", () => {
+    describe('SQL Server authentication validation', () => {
       it('should accept authentication = "ntlm" with domain', () => {
         const tomlContent = `
 [[sources]]
@@ -520,13 +524,13 @@ password = "pass"
 authentication = "ntlm"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].authentication).toBe("ntlm");
-        expect(result?.sources[0].domain).toBe("MYDOMAIN");
+        expect(result?.sources[0].authentication).toBe('ntlm');
+        expect(result?.sources[0].domain).toBe('MYDOMAIN');
       });
 
       it('should accept authentication = "azure-active-directory-access-token" without password', () => {
@@ -539,16 +543,16 @@ database = "testdb"
 user = "admin@tenant.onmicrosoft.com"
 authentication = "azure-active-directory-access-token"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].authentication).toBe("azure-active-directory-access-token");
+        expect(result?.sources[0].authentication).toBe('azure-active-directory-access-token');
         expect(result?.sources[0].password).toBeUndefined();
       });
 
-      it("should throw error for invalid authentication value", () => {
+      it('should throw error for invalid authentication value', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -559,12 +563,12 @@ user = "user"
 password = "pass"
 authentication = "invalid"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("invalid authentication 'invalid'");
       });
 
-      it("should throw error when authentication is used with non-SQL Server database", () => {
+      it('should throw error when authentication is used with non-SQL Server database', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -575,12 +579,12 @@ user = "user"
 password = "pass"
 authentication = "ntlm"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("only supported for SQL Server");
       });
 
-      it("should throw error when NTLM authentication is missing domain", () => {
+      it('should throw error when NTLM authentication is missing domain', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -591,12 +595,12 @@ user = "user"
 password = "pass"
 authentication = "ntlm"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("'domain' is not specified");
       });
 
-      it("should throw error when domain is used without authentication", () => {
+      it('should throw error when domain is used without authentication', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -607,12 +611,12 @@ user = "user"
 password = "pass"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("authentication is not set");
       });
 
-      it("should throw error when domain is used with non-ntlm authentication", () => {
+      it('should throw error when domain is used with non-ntlm authentication', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -624,12 +628,12 @@ password = "pass"
 authentication = "azure-active-directory-access-token"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow('Domain is only valid with authentication = "ntlm"');
+        expect(() => loadTomlConfig()).toThrow("Domain is only valid with authentication = \"ntlm\"");
       });
 
-      it("should throw error when domain is used with non-SQL Server database", () => {
+      it('should throw error when domain is used with non-SQL Server database', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -640,12 +644,12 @@ user = "user"
 password = "pass"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("domain but it is only supported for SQL Server");
       });
 
-      it("should throw error when authentication is used with non-SQL Server DSN (no explicit type)", () => {
+      it('should throw error when authentication is used with non-SQL Server DSN (no explicit type)', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -653,12 +657,12 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
 authentication = "ntlm"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("only supported for SQL Server");
       });
 
-      it("should accept authentication with SQL Server DSN (no explicit type)", () => {
+      it('should accept authentication with SQL Server DSN (no explicit type)', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -666,25 +670,25 @@ dsn = "sqlserver://user:pass@localhost:1433/testdb"
 authentication = "ntlm"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].authentication).toBe("ntlm");
-        expect(result?.sources[0].domain).toBe("MYDOMAIN");
+        expect(result?.sources[0].authentication).toBe('ntlm');
+        expect(result?.sources[0].domain).toBe('MYDOMAIN');
       });
     });
 
-    describe("query_timeout validation", () => {
-      it("should accept valid query_timeout", () => {
+    describe('query_timeout validation', () => {
+      it('should accept valid query_timeout', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 query_timeout = 120
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -692,31 +696,31 @@ query_timeout = 120
         expect(result?.sources[0].query_timeout).toBe(120);
       });
 
-      it("should throw error for negative query_timeout", () => {
+      it('should throw error for negative query_timeout', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 query_timeout = -60
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow("invalid query_timeout");
+        expect(() => loadTomlConfig()).toThrow('invalid query_timeout');
       });
 
-      it("should throw error for zero query_timeout", () => {
+      it('should throw error for zero query_timeout', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 query_timeout = 0
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow("invalid query_timeout");
+        expect(() => loadTomlConfig()).toThrow('invalid query_timeout');
       });
 
-      it("should accept both connection_timeout and query_timeout", () => {
+      it('should accept both connection_timeout and query_timeout', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -724,7 +728,7 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = 30
 query_timeout = 120
 `;
-        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -735,245 +739,237 @@ query_timeout = 120
     });
   });
 
-  describe("buildDSNFromSource", () => {
-    it("should return DSN if already provided", () => {
+  describe('buildDSNFromSource', () => {
+    it('should return DSN if already provided', () => {
       const source: SourceConfig = {
-        id: "test",
-        dsn: "postgres://user:pass@localhost:5432/db",
+        id: 'test',
+        dsn: 'postgres://user:pass@localhost:5432/db',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("postgres://user:pass@localhost:5432/db");
+      expect(dsn).toBe('postgres://user:pass@localhost:5432/db');
     });
 
-    it("should build PostgreSQL DSN from individual params", () => {
+    it('should build PostgreSQL DSN from individual params', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "postgres",
-        host: "localhost",
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
         port: 5432,
-        database: "testdb",
-        user: "testuser",
-        password: "testpass",
+        database: 'testdb',
+        user: 'testuser',
+        password: 'testpass',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("postgres://testuser:testpass@localhost:5432/testdb");
+      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb');
     });
 
-    it("should build MySQL DSN with default port", () => {
+    it('should build MySQL DSN with default port', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "mysql",
-        host: "localhost",
-        database: "testdb",
-        user: "root",
-        password: "secret",
+        id: 'test',
+        type: 'mysql',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'root',
+        password: 'secret',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("mysql://root:secret@localhost:3306/testdb");
+      expect(dsn).toBe('mysql://root:secret@localhost:3306/testdb');
     });
 
-    it("should build MariaDB DSN with default port", () => {
+    it('should build MariaDB DSN with default port', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "mariadb",
-        host: "localhost",
-        database: "testdb",
-        user: "root",
-        password: "secret",
+        id: 'test',
+        type: 'mariadb',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'root',
+        password: 'secret',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("mariadb://root:secret@localhost:3306/testdb");
+      expect(dsn).toBe('mariadb://root:secret@localhost:3306/testdb');
     });
 
-    it("should build SQL Server DSN with default port", () => {
+    it('should build SQL Server DSN with default port', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "sqlserver",
-        host: "localhost",
-        database: "master",
-        user: "sa",
-        password: "StrongPass123",
+        id: 'test',
+        type: 'sqlserver',
+        host: 'localhost',
+        database: 'master',
+        user: 'sa',
+        password: 'StrongPass123',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("sqlserver://sa:StrongPass123@localhost:1433/master");
+      expect(dsn).toBe('sqlserver://sa:StrongPass123@localhost:1433/master');
     });
 
-    it("should build SQL Server DSN with instanceName", () => {
+    it('should build SQL Server DSN with instanceName', () => {
       const source: SourceConfig = {
-        id: "sqlserver_instance",
-        type: "sqlserver",
-        host: "localhost",
+        id: 'sqlserver_instance',
+        type: 'sqlserver',
+        host: 'localhost',
         port: 1433,
-        database: "testdb",
-        user: "sa",
-        password: "Pass123!",
-        instanceName: "ENV1",
+        database: 'testdb',
+        user: 'sa',
+        password: 'Pass123!',
+        instanceName: 'ENV1'
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("sqlserver://sa:Pass123!@localhost:1433/testdb?instanceName=ENV1");
+      expect(dsn).toBe('sqlserver://sa:Pass123!@localhost:1433/testdb?instanceName=ENV1');
     });
 
-    it("should build PostgreSQL DSN with sslmode", () => {
+    it('should build PostgreSQL DSN with sslmode', () => {
       const source: SourceConfig = {
-        id: "pg_ssl",
-        type: "postgres",
-        host: "localhost",
+        id: 'pg_ssl',
+        type: 'postgres',
+        host: 'localhost',
         port: 5432,
-        database: "testdb",
-        user: "user",
-        password: "pass",
-        sslmode: "require",
+        database: 'testdb',
+        user: 'user',
+        password: 'pass',
+        sslmode: 'require'
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("postgres://user:pass@localhost:5432/testdb?sslmode=require");
+      expect(dsn).toBe('postgres://user:pass@localhost:5432/testdb?sslmode=require');
     });
 
-    it("should build MySQL DSN with sslmode", () => {
+    it('should build MySQL DSN with sslmode', () => {
       const source: SourceConfig = {
-        id: "mysql_ssl",
-        type: "mysql",
-        host: "localhost",
-        database: "testdb",
-        user: "root",
-        password: "secret",
-        sslmode: "disable",
+        id: 'mysql_ssl',
+        type: 'mysql',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'root',
+        password: 'secret',
+        sslmode: 'disable'
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("mysql://root:secret@localhost:3306/testdb?sslmode=disable");
+      expect(dsn).toBe('mysql://root:secret@localhost:3306/testdb?sslmode=disable');
     });
 
-    it("should build SQL Server DSN with both instanceName and sslmode", () => {
+    it('should build SQL Server DSN with both instanceName and sslmode', () => {
       const source: SourceConfig = {
-        id: "sqlserver_full",
-        type: "sqlserver",
-        host: "localhost",
+        id: 'sqlserver_full',
+        type: 'sqlserver',
+        host: 'localhost',
         port: 1433,
-        database: "testdb",
-        user: "sa",
-        password: "Pass123!",
-        instanceName: "SQLEXPRESS",
-        sslmode: "require",
+        database: 'testdb',
+        user: 'sa',
+        password: 'Pass123!',
+        instanceName: 'SQLEXPRESS',
+        sslmode: 'require'
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe(
-        "sqlserver://sa:Pass123!@localhost:1433/testdb?instanceName=SQLEXPRESS&sslmode=require"
-      );
+      expect(dsn).toBe('sqlserver://sa:Pass123!@localhost:1433/testdb?instanceName=SQLEXPRESS&sslmode=require');
     });
 
-    it("should build SQL Server DSN with NTLM authentication", () => {
+    it('should build SQL Server DSN with NTLM authentication', () => {
       const source: SourceConfig = {
-        id: "sqlserver_ntlm",
-        type: "sqlserver",
-        host: "sqlserver.corp.local",
+        id: 'sqlserver_ntlm',
+        type: 'sqlserver',
+        host: 'sqlserver.corp.local',
         port: 1433,
-        database: "appdb",
-        user: "jsmith",
-        password: "secret",
-        authentication: "ntlm",
-        domain: "CORP",
+        database: 'appdb',
+        user: 'jsmith',
+        password: 'secret',
+        authentication: 'ntlm',
+        domain: 'CORP'
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe(
-        "sqlserver://jsmith:secret@sqlserver.corp.local:1433/appdb?authentication=ntlm&domain=CORP"
-      );
+      expect(dsn).toBe('sqlserver://jsmith:secret@sqlserver.corp.local:1433/appdb?authentication=ntlm&domain=CORP');
     });
 
-    it("should build SQL Server DSN with Azure AD authentication (no password required)", () => {
+    it('should build SQL Server DSN with Azure AD authentication (no password required)', () => {
       const source: SourceConfig = {
-        id: "sqlserver_azure",
-        type: "sqlserver",
-        host: "myserver.database.windows.net",
+        id: 'sqlserver_azure',
+        type: 'sqlserver',
+        host: 'myserver.database.windows.net',
         port: 1433,
-        database: "mydb",
-        user: "admin@tenant.onmicrosoft.com",
+        database: 'mydb',
+        user: 'admin@tenant.onmicrosoft.com',
         // No password - Azure AD access token auth doesn't require it
-        authentication: "azure-active-directory-access-token",
-        sslmode: "require",
+        authentication: 'azure-active-directory-access-token',
+        sslmode: 'require'
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe(
-        "sqlserver://admin%40tenant.onmicrosoft.com:@myserver.database.windows.net:1433/mydb?authentication=azure-active-directory-access-token&sslmode=require"
-      );
+      expect(dsn).toBe('sqlserver://admin%40tenant.onmicrosoft.com:@myserver.database.windows.net:1433/mydb?authentication=azure-active-directory-access-token&sslmode=require');
     });
 
-    it("should build SQL Server DSN with all parameters", () => {
+    it('should build SQL Server DSN with all parameters', () => {
       const source: SourceConfig = {
-        id: "sqlserver_all",
-        type: "sqlserver",
-        host: "sqlserver.corp.local",
+        id: 'sqlserver_all',
+        type: 'sqlserver',
+        host: 'sqlserver.corp.local',
         port: 1433,
-        database: "appdb",
-        user: "jsmith",
-        password: "secret",
-        instanceName: "PROD",
-        authentication: "ntlm",
-        domain: "CORP",
-        sslmode: "require",
+        database: 'appdb',
+        user: 'jsmith',
+        password: 'secret',
+        instanceName: 'PROD',
+        authentication: 'ntlm',
+        domain: 'CORP',
+        sslmode: 'require'
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe(
-        "sqlserver://jsmith:secret@sqlserver.corp.local:1433/appdb?instanceName=PROD&authentication=ntlm&domain=CORP&sslmode=require"
-      );
+      expect(dsn).toBe('sqlserver://jsmith:secret@sqlserver.corp.local:1433/appdb?instanceName=PROD&authentication=ntlm&domain=CORP&sslmode=require');
     });
 
-    it("should build SQLite DSN from database path", () => {
+    it('should build SQLite DSN from database path', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "sqlite",
-        database: "/path/to/database.db",
+        id: 'test',
+        type: 'sqlite',
+        database: '/path/to/database.db',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("sqlite:////path/to/database.db");
+      expect(dsn).toBe('sqlite:////path/to/database.db');
     });
 
-    it("should encode special characters in credentials", () => {
+    it('should encode special characters in credentials', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "postgres",
-        host: "localhost",
-        database: "db",
-        user: "user@domain.com",
-        password: "pass@word#123",
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
+        database: 'db',
+        user: 'user@domain.com',
+        password: 'pass@word#123',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("postgres://user%40domain.com:pass%40word%23123@localhost:5432/db");
+      expect(dsn).toBe('postgres://user%40domain.com:pass%40word%23123@localhost:5432/db');
     });
 
-    it("should throw error when type is missing", () => {
+    it('should throw error when type is missing', () => {
       const source: SourceConfig = {
-        id: "test",
-        host: "localhost",
-        database: "db",
-        user: "user",
-        password: "pass",
+        id: 'test',
+        host: 'localhost',
+        database: 'db',
+        user: 'user',
+        password: 'pass',
       };
 
       expect(() => buildDSNFromSource(source)).toThrow(
@@ -981,124 +977,128 @@ query_timeout = 120
       );
     });
 
-    it("should throw error when SQLite is missing database", () => {
+    it('should throw error when SQLite is missing database', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "sqlite",
+        id: 'test',
+        type: 'sqlite',
       };
 
-      expect(() => buildDSNFromSource(source)).toThrow("'database' field is required for SQLite");
+      expect(() => buildDSNFromSource(source)).toThrow(
+        "'database' field is required for SQLite"
+      );
     });
 
-    it("should throw error when required connection params are missing", () => {
+    it('should throw error when required connection params are missing', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "postgres",
-        host: "localhost",
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
         // Missing user, database
       };
 
-      expect(() => buildDSNFromSource(source)).toThrow("missing required connection parameters");
+      expect(() => buildDSNFromSource(source)).toThrow(
+        'missing required connection parameters'
+      );
     });
 
-    it("should throw error when password is missing for non-Azure-AD auth", () => {
+    it('should throw error when password is missing for non-Azure-AD auth', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "postgres",
-        host: "localhost",
-        database: "testdb",
-        user: "user",
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'user',
         // Missing password
       };
 
-      expect(() => buildDSNFromSource(source)).toThrow("password is required");
+      expect(() => buildDSNFromSource(source)).toThrow(
+        'password is required'
+      );
     });
 
-    it("should allow missing password for Azure AD access token auth", () => {
+    it('should allow missing password for Azure AD access token auth', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "sqlserver",
-        host: "server.database.windows.net",
-        database: "mydb",
-        user: "admin@tenant.onmicrosoft.com",
-        authentication: "azure-active-directory-access-token",
+        id: 'test',
+        type: 'sqlserver',
+        host: 'server.database.windows.net',
+        database: 'mydb',
+        user: 'admin@tenant.onmicrosoft.com',
+        authentication: 'azure-active-directory-access-token',
         // No password - allowed for Azure AD
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toContain("sqlserver://");
-      expect(dsn).toContain(":@"); // empty password
+      expect(dsn).toContain('sqlserver://');
+      expect(dsn).toContain(':@'); // empty password
     });
 
-    it("should use custom port when provided", () => {
+    it('should use custom port when provided', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "postgres",
-        host: "localhost",
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
         port: 9999,
-        database: "db",
-        user: "user",
-        password: "pass",
+        database: 'db',
+        user: 'user',
+        password: 'pass',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("postgres://user:pass@localhost:9999/db");
+      expect(dsn).toBe('postgres://user:pass@localhost:9999/db');
     });
 
-    it("should append search_path param for PostgreSQL sources", () => {
+    it('should append search_path param for PostgreSQL sources', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "postgres",
-        host: "localhost",
-        database: "testdb",
-        user: "testuser",
-        password: "testpass",
-        search_path: "myschema",
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'testuser',
+        password: 'testpass',
+        search_path: 'myschema',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe("postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema");
+      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema');
     });
 
-    it("should URL-encode comma-separated search_path values", () => {
+    it('should URL-encode comma-separated search_path values', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "postgres",
-        host: "localhost",
-        database: "testdb",
-        user: "testuser",
-        password: "testpass",
-        search_path: "myschema,public",
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'testuser',
+        password: 'testpass',
+        search_path: 'myschema,public',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe(
-        "postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema%2Cpublic"
-      );
+      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema%2Cpublic');
     });
 
-    it("should not add search_path param when not specified", () => {
+    it('should not add search_path param when not specified', () => {
       const source: SourceConfig = {
-        id: "test",
-        type: "postgres",
-        host: "localhost",
-        database: "testdb",
-        user: "testuser",
-        password: "testpass",
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'testuser',
+        password: 'testpass',
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).not.toContain("search_path");
+      expect(dsn).not.toContain('search_path');
     });
   });
 
-  describe("Integration scenarios", () => {
-    it("should handle complete multi-database config with SSH tunnels", () => {
+  describe('Integration scenarios', () => {
+    it('should handle complete multi-database config with SSH tunnels', () => {
       const tomlContent = `
 [[sources]]
 id = "prod_pg"
@@ -1122,7 +1122,7 @@ id = "local_sqlite"
 type = "sqlite"
 database = "~/databases/local.db"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
@@ -1131,39 +1131,43 @@ database = "~/databases/local.db"
 
       // Verify first source (with SSH) - DSN fields should be parsed
       expect(result?.sources[0]).toMatchObject({
-        id: "prod_pg",
-        dsn: "postgres://user:pass@10.0.0.5:5432/production",
-        type: "postgres",
-        host: "10.0.0.5",
+        id: 'prod_pg',
+        dsn: 'postgres://user:pass@10.0.0.5:5432/production',
+        type: 'postgres',
+        host: '10.0.0.5',
         port: 5432,
-        database: "production",
-        user: "user",
-        ssh_host: "bastion.example.com",
+        database: 'production',
+        user: 'user',
+        ssh_host: 'bastion.example.com',
         ssh_port: 22,
-        ssh_user: "ubuntu",
+        ssh_user: 'ubuntu',
       });
-      expect(result?.sources[0].ssh_key).toBe(path.join(os.homedir(), ".ssh", "prod_key"));
+      expect(result?.sources[0].ssh_key).toBe(
+        path.join(os.homedir(), '.ssh', 'prod_key')
+      );
 
       // Verify second source (MySQL with params)
       expect(result?.sources[1]).toEqual({
-        id: "staging_mysql",
-        type: "mysql",
-        host: "localhost",
+        id: 'staging_mysql',
+        type: 'mysql',
+        host: 'localhost',
         port: 3307,
-        database: "staging",
-        user: "devuser",
-        password: "devpass",
+        database: 'staging',
+        user: 'devuser',
+        password: 'devpass',
       });
 
       // Verify third source (SQLite)
       expect(result?.sources[2]).toMatchObject({
-        id: "local_sqlite",
-        type: "sqlite",
+        id: 'local_sqlite',
+        type: 'sqlite',
       });
-      expect(result?.sources[2].database).toBe(path.join(os.homedir(), "databases", "local.db"));
+      expect(result?.sources[2].database).toBe(
+        path.join(os.homedir(), 'databases', 'local.db')
+      );
     });
 
-    it("should handle config with all database types", () => {
+    it('should handle config with all database types', () => {
       const tomlContent = `
 [[sources]]
 id = "pg"
@@ -1202,17 +1206,17 @@ id = "sqlite"
 type = "sqlite"
 database = ":memory:"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources).toHaveLength(5);
-      expect(result?.sources.map((s) => s.id)).toEqual(["pg", "my", "maria", "mssql", "sqlite"]);
+      expect(result?.sources.map(s => s.id)).toEqual(['pg', 'my', 'maria', 'mssql', 'sqlite']);
     });
   });
 
-  describe("Custom Tool Configuration", () => {
-    it("should accept custom tool with readonly and max_rows", () => {
+  describe('Custom Tool Configuration', () => {
+    it('should accept custom tool with readonly and max_rows', () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1226,7 +1230,7 @@ statement = "SELECT * FROM users WHERE active = true"
 readonly = true
 max_rows = 100
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
@@ -1234,16 +1238,16 @@ max_rows = 100
       expect(result?.tools).toBeDefined();
       expect(result?.tools).toHaveLength(1);
       expect(result?.tools![0]).toMatchObject({
-        name: "get_active_users",
-        source: "test_db",
-        description: "Get all active users",
-        statement: "SELECT * FROM users WHERE active = true",
+        name: 'get_active_users',
+        source: 'test_db',
+        description: 'Get all active users',
+        statement: 'SELECT * FROM users WHERE active = true',
         readonly: true,
         max_rows: 100,
       });
     });
 
-    it("should accept custom tool with readonly only", () => {
+    it('should accept custom tool with readonly only', () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1256,19 +1260,19 @@ description = "List all departments"
 statement = "SELECT * FROM departments"
 readonly = true
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.tools).toHaveLength(1);
       expect(result?.tools![0]).toMatchObject({
-        name: "list_departments",
+        name: 'list_departments',
         readonly: true,
       });
       expect(result?.tools![0].max_rows).toBeUndefined();
     });
 
-    it("should accept custom tool with max_rows only", () => {
+    it('should accept custom tool with max_rows only', () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1281,19 +1285,19 @@ description = "Search application logs"
 statement = "SELECT * FROM logs WHERE level = 'ERROR'"
 max_rows = 500
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.tools).toHaveLength(1);
       expect(result?.tools![0]).toMatchObject({
-        name: "search_logs",
+        name: 'search_logs',
         max_rows: 500,
       });
       expect(result?.tools![0].readonly).toBeUndefined();
     });
 
-    it("should accept custom tool without readonly or max_rows", () => {
+    it('should accept custom tool without readonly or max_rows', () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1317,20 +1321,20 @@ type = "integer"
 description = "User ID"
 required = true
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.tools).toHaveLength(1);
       expect(result?.tools![0]).toMatchObject({
-        name: "update_status",
-        description: "Update user status",
+        name: 'update_status',
+        description: 'Update user status',
       });
       expect(result?.tools![0].readonly).toBeUndefined();
       expect(result?.tools![0].max_rows).toBeUndefined();
     });
 
-    it("should throw error for custom tool with invalid readonly type", () => {
+    it('should throw error for custom tool with invalid readonly type', () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1343,12 +1347,12 @@ description = "Test tool"
 statement = "SELECT 1"
 readonly = "yes"
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("invalid readonly");
+      expect(() => loadTomlConfig()).toThrow('invalid readonly');
     });
 
-    it("should throw error for custom tool with invalid max_rows", () => {
+    it('should throw error for custom tool with invalid max_rows', () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1361,12 +1365,12 @@ description = "Test tool"
 statement = "SELECT 1"
 max_rows = -50
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("invalid max_rows");
+      expect(() => loadTomlConfig()).toThrow('invalid max_rows');
     });
 
-    it("should throw error for custom tool with zero max_rows", () => {
+    it('should throw error for custom tool with zero max_rows', () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1379,9 +1383,9 @@ description = "Test tool"
 statement = "SELECT 1"
 max_rows = 0
 `;
-      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow("invalid max_rows");
+      expect(() => loadTomlConfig()).toThrow('invalid max_rows');
     });
   });
 });

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadTomlConfig, buildDSNFromSource } from '../toml-loader.js';
-import type { SourceConfig } from '../../types/config.js';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { loadTomlConfig, buildDSNFromSource } from "../toml-loader.js";
+import type { SourceConfig } from "../../types/config.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
 
-describe('TOML Configuration Tests', () => {
+describe("TOML Configuration Tests", () => {
   const originalCwd = process.cwd();
   const originalArgv = process.argv;
   let tempDir: string;
 
   beforeEach(() => {
     // Create a temporary directory for test config files
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dbhub-test-'));
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dbhub-test-"));
     process.chdir(tempDir);
     // Clear command line arguments
-    process.argv = ['node', 'test'];
+    process.argv = ["node", "test"];
   });
 
   afterEach(() => {
@@ -29,14 +29,14 @@ describe('TOML Configuration Tests', () => {
     process.argv = originalArgv;
   });
 
-  describe('loadTomlConfig', () => {
-    it('should load valid TOML config from dbhub.toml', () => {
+  describe("loadTomlConfig", () => {
+    it("should load valid TOML config from dbhub.toml", () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
@@ -44,71 +44,71 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       expect(result?.sources).toHaveLength(1);
       // DSN should be parsed to populate connection fields
       expect(result?.sources[0]).toEqual({
-        id: 'test_db',
-        dsn: 'postgres://user:pass@localhost:5432/testdb',
-        type: 'postgres',
-        host: 'localhost',
+        id: "test_db",
+        dsn: "postgres://user:pass@localhost:5432/testdb",
+        type: "postgres",
+        host: "localhost",
         port: 5432,
-        database: 'testdb',
-        user: 'user',
+        database: "testdb",
+        user: "user",
       });
-      expect(result?.source).toBe('dbhub.toml');
+      expect(result?.source).toBe("dbhub.toml");
     });
 
-    it('should parse DSN and populate connection fields for postgres', () => {
+    it("should parse DSN and populate connection fields for postgres", () => {
       const tomlContent = `
 [[sources]]
 id = "pg_dsn"
 dsn = "postgres://pguser:secret@db.example.com:5433/mydb"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources[0]).toMatchObject({
-        id: 'pg_dsn',
-        type: 'postgres',
-        host: 'db.example.com',
+        id: "pg_dsn",
+        type: "postgres",
+        host: "db.example.com",
         port: 5433,
-        database: 'mydb',
-        user: 'pguser',
+        database: "mydb",
+        user: "pguser",
       });
     });
 
-    it('should parse DSN and populate connection fields for mysql', () => {
+    it("should parse DSN and populate connection fields for mysql", () => {
       const tomlContent = `
 [[sources]]
 id = "mysql_dsn"
 dsn = "mysql://root:password@mysql.local:3307/appdb"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources[0]).toMatchObject({
-        id: 'mysql_dsn',
-        type: 'mysql',
-        host: 'mysql.local',
+        id: "mysql_dsn",
+        type: "mysql",
+        host: "mysql.local",
         port: 3307,
-        database: 'appdb',
-        user: 'root',
+        database: "appdb",
+        user: "root",
       });
     });
 
-    it('should parse DSN and populate connection fields for sqlite', () => {
+    it("should parse DSN and populate connection fields for sqlite", () => {
       const tomlContent = `
 [[sources]]
 id = "sqlite_dsn"
 dsn = "sqlite:///path/to/database.db"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources[0]).toMatchObject({
-        id: 'sqlite_dsn',
-        type: 'sqlite',
-        database: '/path/to/database.db',
+        id: "sqlite_dsn",
+        type: "sqlite",
+        database: "/path/to/database.db",
       });
       // SQLite should not have host/port/user
       expect(result?.sources[0].host).toBeUndefined();
@@ -116,7 +116,7 @@ dsn = "sqlite:///path/to/database.db"
       expect(result?.sources[0].user).toBeUndefined();
     });
 
-    it('should not override explicit connection params with DSN values', () => {
+    it("should not override explicit connection params with DSN values", () => {
       const tomlContent = `
 [[sources]]
 id = "explicit_override"
@@ -127,44 +127,44 @@ port = 9999
 database = "explicit_db"
 user = "explicit_user"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       // Explicit values should be preserved, not overwritten by DSN
       expect(result?.sources[0]).toMatchObject({
-        id: 'explicit_override',
-        type: 'postgres',
-        host: 'explicit_host',
+        id: "explicit_override",
+        type: "postgres",
+        host: "explicit_host",
         port: 9999,
-        database: 'explicit_db',
-        user: 'explicit_user',
+        database: "explicit_db",
+        user: "explicit_user",
       });
     });
 
-    it('should load config from custom path with --config flag', () => {
-      const customConfigPath = path.join(tempDir, 'custom.toml');
+    it("should load config from custom path with --config flag", () => {
+      const customConfigPath = path.join(tempDir, "custom.toml");
       const tomlContent = `
 [[sources]]
 id = "custom_db"
 dsn = "mysql://user:pass@localhost:3306/db"
 `;
       fs.writeFileSync(customConfigPath, tomlContent);
-      process.argv = ['node', 'test', '--config', customConfigPath];
+      process.argv = ["node", "test", "--config", customConfigPath];
 
       const result = loadTomlConfig();
 
       expect(result).toBeTruthy();
-      expect(result?.sources[0].id).toBe('custom_db');
-      expect(result?.source).toBe('custom.toml');
+      expect(result?.sources[0].id).toBe("custom_db");
+      expect(result?.source).toBe("custom.toml");
     });
 
-    it('should return null when no config file exists', () => {
+    it("should return null when no config file exists", () => {
       const result = loadTomlConfig();
       expect(result).toBeNull();
     });
 
-    it('should load multiple sources', () => {
+    it("should load multiple sources", () => {
       const tomlContent = `
 [[sources]]
 id = "db1"
@@ -179,17 +179,17 @@ id = "db3"
 type = "sqlite"
 database = "/tmp/test.db"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources).toHaveLength(3);
-      expect(result?.sources[0].id).toBe('db1');
-      expect(result?.sources[1].id).toBe('db2');
-      expect(result?.sources[2].id).toBe('db3');
+      expect(result?.sources[0].id).toBe("db1");
+      expect(result?.sources[1].id).toBe("db2");
+      expect(result?.sources[2].id).toBe("db3");
     });
 
-    it('should expand tilde in ssh_key paths', () => {
+    it("should expand tilde in ssh_key paths", () => {
       const tomlContent = `
 [[sources]]
 id = "remote_db"
@@ -198,51 +198,45 @@ ssh_host = "bastion.example.com"
 ssh_user = "ubuntu"
 ssh_key = "~/.ssh/id_rsa"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
-      expect(result?.sources[0].ssh_key).toBe(
-        path.join(os.homedir(), '.ssh', 'id_rsa')
-      );
+      expect(result?.sources[0].ssh_key).toBe(path.join(os.homedir(), ".ssh", "id_rsa"));
     });
 
-    it('should expand tilde in sqlite database paths', () => {
+    it("should expand tilde in sqlite database paths", () => {
       const tomlContent = `
 [[sources]]
 id = "local_db"
 type = "sqlite"
 database = "~/databases/test.db"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
-      expect(result?.sources[0].database).toBe(
-        path.join(os.homedir(), 'databases', 'test.db')
-      );
+      expect(result?.sources[0].database).toBe(path.join(os.homedir(), "databases", "test.db"));
     });
 
-    it('should throw error for missing sources array', () => {
+    it("should throw error for missing sources array", () => {
       const tomlContent = `
 [server]
 port = 8080
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow(
-        'must contain a [[sources]] array'
-      );
+      expect(() => loadTomlConfig()).toThrow("must contain a [[sources]] array");
     });
 
-    it('should throw error for empty sources array', () => {
+    it("should throw error for empty sources array", () => {
       const tomlContent = `sources = []`;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow('sources array cannot be empty');
+      expect(() => loadTomlConfig()).toThrow("sources array cannot be empty");
     });
 
-    it('should throw error for duplicate source IDs', () => {
+    it("should throw error for duplicate source IDs", () => {
       const tomlContent = `
 [[sources]]
 id = "duplicate"
@@ -252,45 +246,45 @@ dsn = "postgres://user:pass@localhost:5432/db1"
 id = "duplicate"
 dsn = "mysql://user:pass@localhost:3306/db2"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow('duplicate source IDs found: duplicate');
+      expect(() => loadTomlConfig()).toThrow("duplicate source IDs found: duplicate");
     });
 
-    it('should throw error for source without id', () => {
+    it("should throw error for source without id", () => {
       const tomlContent = `
 [[sources]]
 dsn = "postgres://user:pass@localhost:5432/db"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       expect(() => loadTomlConfig()).toThrow("each source must have an 'id' field");
     });
 
-    it('should throw error for source without DSN or connection params', () => {
+    it("should throw error for source without DSN or connection params", () => {
       const tomlContent = `
 [[sources]]
 id = "invalid"
 readonly = true
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow('must have either');
+      expect(() => loadTomlConfig()).toThrow("must have either");
     });
 
-    it('should throw error for invalid database type', () => {
+    it("should throw error for invalid database type", () => {
       const tomlContent = `
 [[sources]]
 id = "invalid"
 type = "oracle"
 host = "localhost"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       expect(() => loadTomlConfig()).toThrow("invalid type 'oracle'");
     });
 
-    it('should throw error for invalid max_rows', () => {
+    it("should throw error for invalid max_rows", () => {
       const tomlContent = `
 [[sources]]
 id = "test"
@@ -301,12 +295,12 @@ name = "execute_sql"
 source = "test"
 max_rows = -100
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow('invalid max_rows');
+      expect(() => loadTomlConfig()).toThrow("invalid max_rows");
     });
 
-    it('should throw error for invalid ssh_port', () => {
+    it("should throw error for invalid ssh_port", () => {
       const tomlContent = `
 [[sources]]
 id = "test"
@@ -316,26 +310,28 @@ ssh_user = "ubuntu"
 ssh_key = "~/.ssh/id_rsa"
 ssh_port = 99999
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow('invalid ssh_port');
+      expect(() => loadTomlConfig()).toThrow("invalid ssh_port");
     });
 
-    it('should throw error for non-existent config file specified by --config', () => {
-      process.argv = ['node', 'test', '--config', '/nonexistent/path/config.toml'];
+    it("should throw error for non-existent config file specified by --config", () => {
+      process.argv = ["node", "test", "--config", "/nonexistent/path/config.toml"];
 
-      expect(() => loadTomlConfig()).toThrow('Configuration file specified by --config flag not found');
+      expect(() => loadTomlConfig()).toThrow(
+        "Configuration file specified by --config flag not found"
+      );
     });
 
-    describe('connection_timeout validation', () => {
-      it('should accept valid connection_timeout', () => {
+    describe("connection_timeout validation", () => {
+      it("should accept valid connection_timeout", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = 60
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -343,38 +339,38 @@ connection_timeout = 60
         expect(result?.sources[0].connection_timeout).toBe(60);
       });
 
-      it('should throw error for negative connection_timeout', () => {
+      it("should throw error for negative connection_timeout", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = -30
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow('invalid connection_timeout');
+        expect(() => loadTomlConfig()).toThrow("invalid connection_timeout");
       });
 
-      it('should throw error for zero connection_timeout', () => {
+      it("should throw error for zero connection_timeout", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = 0
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow('invalid connection_timeout');
+        expect(() => loadTomlConfig()).toThrow("invalid connection_timeout");
       });
 
-      it('should accept large connection_timeout values', () => {
+      it("should accept large connection_timeout values", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = 300
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -382,13 +378,13 @@ connection_timeout = 300
         expect(result?.sources[0].connection_timeout).toBe(300);
       });
 
-      it('should work without connection_timeout (optional field)', () => {
+      it("should work without connection_timeout (optional field)", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -397,29 +393,29 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       });
     });
 
-    describe('description field', () => {
-      it('should parse description field', () => {
+    describe("description field", () => {
+      it("should parse description field", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 description = "Production read replica for analytics"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].description).toBe('Production read replica for analytics');
+        expect(result?.sources[0].description).toBe("Production read replica for analytics");
       });
 
-      it('should work without description (optional field)', () => {
+      it("should work without description (optional field)", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -428,7 +424,7 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       });
     });
 
-    describe('sslmode validation', () => {
+    describe("sslmode validation", () => {
       it('should accept sslmode = "disable"', () => {
         const tomlContent = `
 [[sources]]
@@ -440,12 +436,12 @@ user = "user"
 password = "pass"
 sslmode = "disable"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].sslmode).toBe('disable');
+        expect(result?.sources[0].sslmode).toBe("disable");
       });
 
       it('should accept sslmode = "require"', () => {
@@ -459,15 +455,15 @@ user = "user"
 password = "pass"
 sslmode = "require"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].sslmode).toBe('require');
+        expect(result?.sources[0].sslmode).toBe("require");
       });
 
-      it('should throw error for invalid sslmode value', () => {
+      it("should throw error for invalid sslmode value", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -478,12 +474,12 @@ user = "user"
 password = "pass"
 sslmode = "invalid"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("invalid sslmode 'invalid'");
       });
 
-      it('should throw error when sslmode is specified for SQLite', () => {
+      it("should throw error when sslmode is specified for SQLite", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -491,18 +487,18 @@ type = "sqlite"
 database = "/path/to/database.db"
 sslmode = "require"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("SQLite does not support SSL");
       });
 
-      it('should work without sslmode (optional field)', () => {
+      it("should work without sslmode (optional field)", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -511,7 +507,7 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       });
     });
 
-    describe('SQL Server authentication validation', () => {
+    describe("SQL Server authentication validation", () => {
       it('should accept authentication = "ntlm" with domain', () => {
         const tomlContent = `
 [[sources]]
@@ -524,13 +520,13 @@ password = "pass"
 authentication = "ntlm"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].authentication).toBe('ntlm');
-        expect(result?.sources[0].domain).toBe('MYDOMAIN');
+        expect(result?.sources[0].authentication).toBe("ntlm");
+        expect(result?.sources[0].domain).toBe("MYDOMAIN");
       });
 
       it('should accept authentication = "azure-active-directory-access-token" without password', () => {
@@ -543,16 +539,16 @@ database = "testdb"
 user = "admin@tenant.onmicrosoft.com"
 authentication = "azure-active-directory-access-token"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].authentication).toBe('azure-active-directory-access-token');
+        expect(result?.sources[0].authentication).toBe("azure-active-directory-access-token");
         expect(result?.sources[0].password).toBeUndefined();
       });
 
-      it('should throw error for invalid authentication value', () => {
+      it("should throw error for invalid authentication value", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -563,12 +559,12 @@ user = "user"
 password = "pass"
 authentication = "invalid"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("invalid authentication 'invalid'");
       });
 
-      it('should throw error when authentication is used with non-SQL Server database', () => {
+      it("should throw error when authentication is used with non-SQL Server database", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -579,12 +575,12 @@ user = "user"
 password = "pass"
 authentication = "ntlm"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("only supported for SQL Server");
       });
 
-      it('should throw error when NTLM authentication is missing domain', () => {
+      it("should throw error when NTLM authentication is missing domain", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -595,12 +591,12 @@ user = "user"
 password = "pass"
 authentication = "ntlm"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("'domain' is not specified");
       });
 
-      it('should throw error when domain is used without authentication', () => {
+      it("should throw error when domain is used without authentication", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -611,12 +607,12 @@ user = "user"
 password = "pass"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("authentication is not set");
       });
 
-      it('should throw error when domain is used with non-ntlm authentication', () => {
+      it("should throw error when domain is used with non-ntlm authentication", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -628,12 +624,12 @@ password = "pass"
 authentication = "azure-active-directory-access-token"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow("Domain is only valid with authentication = \"ntlm\"");
+        expect(() => loadTomlConfig()).toThrow('Domain is only valid with authentication = "ntlm"');
       });
 
-      it('should throw error when domain is used with non-SQL Server database', () => {
+      it("should throw error when domain is used with non-SQL Server database", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -644,12 +640,12 @@ user = "user"
 password = "pass"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("domain but it is only supported for SQL Server");
       });
 
-      it('should throw error when authentication is used with non-SQL Server DSN (no explicit type)', () => {
+      it("should throw error when authentication is used with non-SQL Server DSN (no explicit type)", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -657,12 +653,12 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
 authentication = "ntlm"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         expect(() => loadTomlConfig()).toThrow("only supported for SQL Server");
       });
 
-      it('should accept authentication with SQL Server DSN (no explicit type)', () => {
+      it("should accept authentication with SQL Server DSN (no explicit type)", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -670,25 +666,25 @@ dsn = "sqlserver://user:pass@localhost:1433/testdb"
 authentication = "ntlm"
 domain = "MYDOMAIN"
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
         expect(result).toBeTruthy();
-        expect(result?.sources[0].authentication).toBe('ntlm');
-        expect(result?.sources[0].domain).toBe('MYDOMAIN');
+        expect(result?.sources[0].authentication).toBe("ntlm");
+        expect(result?.sources[0].domain).toBe("MYDOMAIN");
       });
     });
 
-    describe('query_timeout validation', () => {
-      it('should accept valid query_timeout', () => {
+    describe("query_timeout validation", () => {
+      it("should accept valid query_timeout", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 query_timeout = 120
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -696,31 +692,31 @@ query_timeout = 120
         expect(result?.sources[0].query_timeout).toBe(120);
       });
 
-      it('should throw error for negative query_timeout', () => {
+      it("should throw error for negative query_timeout", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 query_timeout = -60
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow('invalid query_timeout');
+        expect(() => loadTomlConfig()).toThrow("invalid query_timeout");
       });
 
-      it('should throw error for zero query_timeout', () => {
+      it("should throw error for zero query_timeout", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
 dsn = "postgres://user:pass@localhost:5432/testdb"
 query_timeout = 0
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow('invalid query_timeout');
+        expect(() => loadTomlConfig()).toThrow("invalid query_timeout");
       });
 
-      it('should accept both connection_timeout and query_timeout', () => {
+      it("should accept both connection_timeout and query_timeout", () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -728,7 +724,7 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
 connection_timeout = 30
 query_timeout = 120
 `;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+        fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
         const result = loadTomlConfig();
 
@@ -739,237 +735,245 @@ query_timeout = 120
     });
   });
 
-  describe('buildDSNFromSource', () => {
-    it('should return DSN if already provided', () => {
+  describe("buildDSNFromSource", () => {
+    it("should return DSN if already provided", () => {
       const source: SourceConfig = {
-        id: 'test',
-        dsn: 'postgres://user:pass@localhost:5432/db',
+        id: "test",
+        dsn: "postgres://user:pass@localhost:5432/db",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('postgres://user:pass@localhost:5432/db');
+      expect(dsn).toBe("postgres://user:pass@localhost:5432/db");
     });
 
-    it('should build PostgreSQL DSN from individual params', () => {
+    it("should build PostgreSQL DSN from individual params", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        host: 'localhost',
+        id: "test",
+        type: "postgres",
+        host: "localhost",
         port: 5432,
-        database: 'testdb',
-        user: 'testuser',
-        password: 'testpass',
+        database: "testdb",
+        user: "testuser",
+        password: "testpass",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb');
+      expect(dsn).toBe("postgres://testuser:testpass@localhost:5432/testdb");
     });
 
-    it('should build MySQL DSN with default port', () => {
+    it("should build MySQL DSN with default port", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'mysql',
-        host: 'localhost',
-        database: 'testdb',
-        user: 'root',
-        password: 'secret',
+        id: "test",
+        type: "mysql",
+        host: "localhost",
+        database: "testdb",
+        user: "root",
+        password: "secret",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('mysql://root:secret@localhost:3306/testdb');
+      expect(dsn).toBe("mysql://root:secret@localhost:3306/testdb");
     });
 
-    it('should build MariaDB DSN with default port', () => {
+    it("should build MariaDB DSN with default port", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'mariadb',
-        host: 'localhost',
-        database: 'testdb',
-        user: 'root',
-        password: 'secret',
+        id: "test",
+        type: "mariadb",
+        host: "localhost",
+        database: "testdb",
+        user: "root",
+        password: "secret",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('mariadb://root:secret@localhost:3306/testdb');
+      expect(dsn).toBe("mariadb://root:secret@localhost:3306/testdb");
     });
 
-    it('should build SQL Server DSN with default port', () => {
+    it("should build SQL Server DSN with default port", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'sqlserver',
-        host: 'localhost',
-        database: 'master',
-        user: 'sa',
-        password: 'StrongPass123',
+        id: "test",
+        type: "sqlserver",
+        host: "localhost",
+        database: "master",
+        user: "sa",
+        password: "StrongPass123",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('sqlserver://sa:StrongPass123@localhost:1433/master');
+      expect(dsn).toBe("sqlserver://sa:StrongPass123@localhost:1433/master");
     });
 
-    it('should build SQL Server DSN with instanceName', () => {
+    it("should build SQL Server DSN with instanceName", () => {
       const source: SourceConfig = {
-        id: 'sqlserver_instance',
-        type: 'sqlserver',
-        host: 'localhost',
+        id: "sqlserver_instance",
+        type: "sqlserver",
+        host: "localhost",
         port: 1433,
-        database: 'testdb',
-        user: 'sa',
-        password: 'Pass123!',
-        instanceName: 'ENV1'
+        database: "testdb",
+        user: "sa",
+        password: "Pass123!",
+        instanceName: "ENV1",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('sqlserver://sa:Pass123!@localhost:1433/testdb?instanceName=ENV1');
+      expect(dsn).toBe("sqlserver://sa:Pass123!@localhost:1433/testdb?instanceName=ENV1");
     });
 
-    it('should build PostgreSQL DSN with sslmode', () => {
+    it("should build PostgreSQL DSN with sslmode", () => {
       const source: SourceConfig = {
-        id: 'pg_ssl',
-        type: 'postgres',
-        host: 'localhost',
+        id: "pg_ssl",
+        type: "postgres",
+        host: "localhost",
         port: 5432,
-        database: 'testdb',
-        user: 'user',
-        password: 'pass',
-        sslmode: 'require'
+        database: "testdb",
+        user: "user",
+        password: "pass",
+        sslmode: "require",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('postgres://user:pass@localhost:5432/testdb?sslmode=require');
+      expect(dsn).toBe("postgres://user:pass@localhost:5432/testdb?sslmode=require");
     });
 
-    it('should build MySQL DSN with sslmode', () => {
+    it("should build MySQL DSN with sslmode", () => {
       const source: SourceConfig = {
-        id: 'mysql_ssl',
-        type: 'mysql',
-        host: 'localhost',
-        database: 'testdb',
-        user: 'root',
-        password: 'secret',
-        sslmode: 'disable'
+        id: "mysql_ssl",
+        type: "mysql",
+        host: "localhost",
+        database: "testdb",
+        user: "root",
+        password: "secret",
+        sslmode: "disable",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('mysql://root:secret@localhost:3306/testdb?sslmode=disable');
+      expect(dsn).toBe("mysql://root:secret@localhost:3306/testdb?sslmode=disable");
     });
 
-    it('should build SQL Server DSN with both instanceName and sslmode', () => {
+    it("should build SQL Server DSN with both instanceName and sslmode", () => {
       const source: SourceConfig = {
-        id: 'sqlserver_full',
-        type: 'sqlserver',
-        host: 'localhost',
+        id: "sqlserver_full",
+        type: "sqlserver",
+        host: "localhost",
         port: 1433,
-        database: 'testdb',
-        user: 'sa',
-        password: 'Pass123!',
-        instanceName: 'SQLEXPRESS',
-        sslmode: 'require'
+        database: "testdb",
+        user: "sa",
+        password: "Pass123!",
+        instanceName: "SQLEXPRESS",
+        sslmode: "require",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('sqlserver://sa:Pass123!@localhost:1433/testdb?instanceName=SQLEXPRESS&sslmode=require');
+      expect(dsn).toBe(
+        "sqlserver://sa:Pass123!@localhost:1433/testdb?instanceName=SQLEXPRESS&sslmode=require"
+      );
     });
 
-    it('should build SQL Server DSN with NTLM authentication', () => {
+    it("should build SQL Server DSN with NTLM authentication", () => {
       const source: SourceConfig = {
-        id: 'sqlserver_ntlm',
-        type: 'sqlserver',
-        host: 'sqlserver.corp.local',
+        id: "sqlserver_ntlm",
+        type: "sqlserver",
+        host: "sqlserver.corp.local",
         port: 1433,
-        database: 'appdb',
-        user: 'jsmith',
-        password: 'secret',
-        authentication: 'ntlm',
-        domain: 'CORP'
+        database: "appdb",
+        user: "jsmith",
+        password: "secret",
+        authentication: "ntlm",
+        domain: "CORP",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('sqlserver://jsmith:secret@sqlserver.corp.local:1433/appdb?authentication=ntlm&domain=CORP');
+      expect(dsn).toBe(
+        "sqlserver://jsmith:secret@sqlserver.corp.local:1433/appdb?authentication=ntlm&domain=CORP"
+      );
     });
 
-    it('should build SQL Server DSN with Azure AD authentication (no password required)', () => {
+    it("should build SQL Server DSN with Azure AD authentication (no password required)", () => {
       const source: SourceConfig = {
-        id: 'sqlserver_azure',
-        type: 'sqlserver',
-        host: 'myserver.database.windows.net',
+        id: "sqlserver_azure",
+        type: "sqlserver",
+        host: "myserver.database.windows.net",
         port: 1433,
-        database: 'mydb',
-        user: 'admin@tenant.onmicrosoft.com',
+        database: "mydb",
+        user: "admin@tenant.onmicrosoft.com",
         // No password - Azure AD access token auth doesn't require it
-        authentication: 'azure-active-directory-access-token',
-        sslmode: 'require'
+        authentication: "azure-active-directory-access-token",
+        sslmode: "require",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('sqlserver://admin%40tenant.onmicrosoft.com:@myserver.database.windows.net:1433/mydb?authentication=azure-active-directory-access-token&sslmode=require');
+      expect(dsn).toBe(
+        "sqlserver://admin%40tenant.onmicrosoft.com:@myserver.database.windows.net:1433/mydb?authentication=azure-active-directory-access-token&sslmode=require"
+      );
     });
 
-    it('should build SQL Server DSN with all parameters', () => {
+    it("should build SQL Server DSN with all parameters", () => {
       const source: SourceConfig = {
-        id: 'sqlserver_all',
-        type: 'sqlserver',
-        host: 'sqlserver.corp.local',
+        id: "sqlserver_all",
+        type: "sqlserver",
+        host: "sqlserver.corp.local",
         port: 1433,
-        database: 'appdb',
-        user: 'jsmith',
-        password: 'secret',
-        instanceName: 'PROD',
-        authentication: 'ntlm',
-        domain: 'CORP',
-        sslmode: 'require'
+        database: "appdb",
+        user: "jsmith",
+        password: "secret",
+        instanceName: "PROD",
+        authentication: "ntlm",
+        domain: "CORP",
+        sslmode: "require",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('sqlserver://jsmith:secret@sqlserver.corp.local:1433/appdb?instanceName=PROD&authentication=ntlm&domain=CORP&sslmode=require');
+      expect(dsn).toBe(
+        "sqlserver://jsmith:secret@sqlserver.corp.local:1433/appdb?instanceName=PROD&authentication=ntlm&domain=CORP&sslmode=require"
+      );
     });
 
-    it('should build SQLite DSN from database path', () => {
+    it("should build SQLite DSN from database path", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'sqlite',
-        database: '/path/to/database.db',
+        id: "test",
+        type: "sqlite",
+        database: "/path/to/database.db",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('sqlite:////path/to/database.db');
+      expect(dsn).toBe("sqlite:////path/to/database.db");
     });
 
-    it('should encode special characters in credentials', () => {
+    it("should encode special characters in credentials", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        host: 'localhost',
-        database: 'db',
-        user: 'user@domain.com',
-        password: 'pass@word#123',
+        id: "test",
+        type: "postgres",
+        host: "localhost",
+        database: "db",
+        user: "user@domain.com",
+        password: "pass@word#123",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('postgres://user%40domain.com:pass%40word%23123@localhost:5432/db');
+      expect(dsn).toBe("postgres://user%40domain.com:pass%40word%23123@localhost:5432/db");
     });
 
-    it('should throw error when type is missing', () => {
+    it("should throw error when type is missing", () => {
       const source: SourceConfig = {
-        id: 'test',
-        host: 'localhost',
-        database: 'db',
-        user: 'user',
-        password: 'pass',
+        id: "test",
+        host: "localhost",
+        database: "db",
+        user: "user",
+        password: "pass",
       };
 
       expect(() => buildDSNFromSource(source)).toThrow(
@@ -977,150 +981,124 @@ query_timeout = 120
       );
     });
 
-    it('should throw error when SQLite is missing database', () => {
+    it("should throw error when SQLite is missing database", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'sqlite',
+        id: "test",
+        type: "sqlite",
       };
 
-      expect(() => buildDSNFromSource(source)).toThrow(
-        "'database' field is required for SQLite"
-      );
+      expect(() => buildDSNFromSource(source)).toThrow("'database' field is required for SQLite");
     });
 
-    it('should throw error when required connection params are missing', () => {
+    it("should throw error when required connection params are missing", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        host: 'localhost',
+        id: "test",
+        type: "postgres",
+        host: "localhost",
         // Missing user, database
       };
 
-      expect(() => buildDSNFromSource(source)).toThrow(
-        'missing required connection parameters'
-      );
+      expect(() => buildDSNFromSource(source)).toThrow("missing required connection parameters");
     });
 
-    it('should throw error when password is missing for non-Azure-AD auth', () => {
+    it("should throw error when password is missing for non-Azure-AD auth", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        host: 'localhost',
-        database: 'testdb',
-        user: 'user',
+        id: "test",
+        type: "postgres",
+        host: "localhost",
+        database: "testdb",
+        user: "user",
         // Missing password
       };
 
-      expect(() => buildDSNFromSource(source)).toThrow(
-        'password is required'
-      );
+      expect(() => buildDSNFromSource(source)).toThrow("password is required");
     });
 
-    it('should allow missing password for Azure AD access token auth', () => {
+    it("should allow missing password for Azure AD access token auth", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'sqlserver',
-        host: 'server.database.windows.net',
-        database: 'mydb',
-        user: 'admin@tenant.onmicrosoft.com',
-        authentication: 'azure-active-directory-access-token',
+        id: "test",
+        type: "sqlserver",
+        host: "server.database.windows.net",
+        database: "mydb",
+        user: "admin@tenant.onmicrosoft.com",
+        authentication: "azure-active-directory-access-token",
         // No password - allowed for Azure AD
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toContain('sqlserver://');
-      expect(dsn).toContain(':@'); // empty password
+      expect(dsn).toContain("sqlserver://");
+      expect(dsn).toContain(":@"); // empty password
     });
 
-    it('should use custom port when provided', () => {
+    it("should use custom port when provided", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        host: 'localhost',
+        id: "test",
+        type: "postgres",
+        host: "localhost",
         port: 9999,
-        database: 'db',
-        user: 'user',
-        password: 'pass',
+        database: "db",
+        user: "user",
+        password: "pass",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('postgres://user:pass@localhost:9999/db');
+      expect(dsn).toBe("postgres://user:pass@localhost:9999/db");
     });
 
-    it('should append search_path param for PostgreSQL sources', () => {
+    it("should append search_path param for PostgreSQL sources", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        host: 'localhost',
-        database: 'testdb',
-        user: 'testuser',
-        password: 'testpass',
-        search_path: 'myschema',
+        id: "test",
+        type: "postgres",
+        host: "localhost",
+        database: "testdb",
+        user: "testuser",
+        password: "testpass",
+        search_path: "myschema",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema');
+      expect(dsn).toBe("postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema");
     });
 
-    it('should URL-encode comma-separated search_path values', () => {
+    it("should URL-encode comma-separated search_path values", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        host: 'localhost',
-        database: 'testdb',
-        user: 'testuser',
-        password: 'testpass',
-        search_path: 'myschema,public',
+        id: "test",
+        type: "postgres",
+        host: "localhost",
+        database: "testdb",
+        user: "testuser",
+        password: "testpass",
+        search_path: "myschema,public",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema%2Cpublic');
+      expect(dsn).toBe(
+        "postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema%2Cpublic"
+      );
     });
 
-    it('should not add search_path param when not specified', () => {
+    it("should not add search_path param when not specified", () => {
       const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        host: 'localhost',
-        database: 'testdb',
-        user: 'testuser',
-        password: 'testpass',
+        id: "test",
+        type: "postgres",
+        host: "localhost",
+        database: "testdb",
+        user: "testuser",
+        password: "testpass",
       };
 
       const dsn = buildDSNFromSource(source);
 
-      expect(dsn).not.toContain('search_path');
-    });
-
-    it('should append search_path param when DSN is directly provided', () => {
-      const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        dsn: 'postgres://testuser:testpass@localhost:5432/testdb',
-        search_path: 'myschema',
-      };
-      const dsn = buildDSNFromSource(source);
-      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema');
-    });
-
-    it('should append search_path param to DSN that already has query params', () => {
-      const source: SourceConfig = {
-        id: 'test',
-        type: 'postgres',
-        dsn: 'postgres://testuser:testpass@localhost:5432/testdb?sslmode=require',
-        search_path: 'myschema',
-      };
-      const dsn = buildDSNFromSource(source);
-      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?sslmode=require&search_path=myschema');
+      expect(dsn).not.toContain("search_path");
     });
   });
 
-  describe('Integration scenarios', () => {
-    it('should handle complete multi-database config with SSH tunnels', () => {
+  describe("Integration scenarios", () => {
+    it("should handle complete multi-database config with SSH tunnels", () => {
       const tomlContent = `
 [[sources]]
 id = "prod_pg"
@@ -1144,7 +1122,7 @@ id = "local_sqlite"
 type = "sqlite"
 database = "~/databases/local.db"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
@@ -1153,43 +1131,39 @@ database = "~/databases/local.db"
 
       // Verify first source (with SSH) - DSN fields should be parsed
       expect(result?.sources[0]).toMatchObject({
-        id: 'prod_pg',
-        dsn: 'postgres://user:pass@10.0.0.5:5432/production',
-        type: 'postgres',
-        host: '10.0.0.5',
+        id: "prod_pg",
+        dsn: "postgres://user:pass@10.0.0.5:5432/production",
+        type: "postgres",
+        host: "10.0.0.5",
         port: 5432,
-        database: 'production',
-        user: 'user',
-        ssh_host: 'bastion.example.com',
+        database: "production",
+        user: "user",
+        ssh_host: "bastion.example.com",
         ssh_port: 22,
-        ssh_user: 'ubuntu',
+        ssh_user: "ubuntu",
       });
-      expect(result?.sources[0].ssh_key).toBe(
-        path.join(os.homedir(), '.ssh', 'prod_key')
-      );
+      expect(result?.sources[0].ssh_key).toBe(path.join(os.homedir(), ".ssh", "prod_key"));
 
       // Verify second source (MySQL with params)
       expect(result?.sources[1]).toEqual({
-        id: 'staging_mysql',
-        type: 'mysql',
-        host: 'localhost',
+        id: "staging_mysql",
+        type: "mysql",
+        host: "localhost",
         port: 3307,
-        database: 'staging',
-        user: 'devuser',
-        password: 'devpass',
+        database: "staging",
+        user: "devuser",
+        password: "devpass",
       });
 
       // Verify third source (SQLite)
       expect(result?.sources[2]).toMatchObject({
-        id: 'local_sqlite',
-        type: 'sqlite',
+        id: "local_sqlite",
+        type: "sqlite",
       });
-      expect(result?.sources[2].database).toBe(
-        path.join(os.homedir(), 'databases', 'local.db')
-      );
+      expect(result?.sources[2].database).toBe(path.join(os.homedir(), "databases", "local.db"));
     });
 
-    it('should handle config with all database types', () => {
+    it("should handle config with all database types", () => {
       const tomlContent = `
 [[sources]]
 id = "pg"
@@ -1228,17 +1202,17 @@ id = "sqlite"
 type = "sqlite"
 database = ":memory:"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.sources).toHaveLength(5);
-      expect(result?.sources.map(s => s.id)).toEqual(['pg', 'my', 'maria', 'mssql', 'sqlite']);
+      expect(result?.sources.map((s) => s.id)).toEqual(["pg", "my", "maria", "mssql", "sqlite"]);
     });
   });
 
-  describe('Custom Tool Configuration', () => {
-    it('should accept custom tool with readonly and max_rows', () => {
+  describe("Custom Tool Configuration", () => {
+    it("should accept custom tool with readonly and max_rows", () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1252,7 +1226,7 @@ statement = "SELECT * FROM users WHERE active = true"
 readonly = true
 max_rows = 100
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
@@ -1260,16 +1234,16 @@ max_rows = 100
       expect(result?.tools).toBeDefined();
       expect(result?.tools).toHaveLength(1);
       expect(result?.tools![0]).toMatchObject({
-        name: 'get_active_users',
-        source: 'test_db',
-        description: 'Get all active users',
-        statement: 'SELECT * FROM users WHERE active = true',
+        name: "get_active_users",
+        source: "test_db",
+        description: "Get all active users",
+        statement: "SELECT * FROM users WHERE active = true",
         readonly: true,
         max_rows: 100,
       });
     });
 
-    it('should accept custom tool with readonly only', () => {
+    it("should accept custom tool with readonly only", () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1282,19 +1256,19 @@ description = "List all departments"
 statement = "SELECT * FROM departments"
 readonly = true
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.tools).toHaveLength(1);
       expect(result?.tools![0]).toMatchObject({
-        name: 'list_departments',
+        name: "list_departments",
         readonly: true,
       });
       expect(result?.tools![0].max_rows).toBeUndefined();
     });
 
-    it('should accept custom tool with max_rows only', () => {
+    it("should accept custom tool with max_rows only", () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1307,19 +1281,19 @@ description = "Search application logs"
 statement = "SELECT * FROM logs WHERE level = 'ERROR'"
 max_rows = 500
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.tools).toHaveLength(1);
       expect(result?.tools![0]).toMatchObject({
-        name: 'search_logs',
+        name: "search_logs",
         max_rows: 500,
       });
       expect(result?.tools![0].readonly).toBeUndefined();
     });
 
-    it('should accept custom tool without readonly or max_rows', () => {
+    it("should accept custom tool without readonly or max_rows", () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1343,20 +1317,20 @@ type = "integer"
 description = "User ID"
 required = true
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
       const result = loadTomlConfig();
 
       expect(result?.tools).toHaveLength(1);
       expect(result?.tools![0]).toMatchObject({
-        name: 'update_status',
-        description: 'Update user status',
+        name: "update_status",
+        description: "Update user status",
       });
       expect(result?.tools![0].readonly).toBeUndefined();
       expect(result?.tools![0].max_rows).toBeUndefined();
     });
 
-    it('should throw error for custom tool with invalid readonly type', () => {
+    it("should throw error for custom tool with invalid readonly type", () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1369,12 +1343,12 @@ description = "Test tool"
 statement = "SELECT 1"
 readonly = "yes"
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow('invalid readonly');
+      expect(() => loadTomlConfig()).toThrow("invalid readonly");
     });
 
-    it('should throw error for custom tool with invalid max_rows', () => {
+    it("should throw error for custom tool with invalid max_rows", () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1387,12 +1361,12 @@ description = "Test tool"
 statement = "SELECT 1"
 max_rows = -50
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow('invalid max_rows');
+      expect(() => loadTomlConfig()).toThrow("invalid max_rows");
     });
 
-    it('should throw error for custom tool with zero max_rows', () => {
+    it("should throw error for custom tool with zero max_rows", () => {
       const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1405,9 +1379,9 @@ description = "Test tool"
 statement = "SELECT 1"
 max_rows = 0
 `;
-      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      fs.writeFileSync(path.join(tempDir, "dbhub.toml"), tomlContent);
 
-      expect(() => loadTomlConfig()).toThrow('invalid max_rows');
+      expect(() => loadTomlConfig()).toThrow("invalid max_rows");
     });
   });
 });

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1048,6 +1048,75 @@ query_timeout = 120
 
       expect(dsn).toBe('postgres://user:pass@localhost:9999/db');
     });
+
+    it('should append search_path param for PostgreSQL sources', () => {
+      const source: SourceConfig = {
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'testuser',
+        password: 'testpass',
+        search_path: 'myschema',
+      };
+
+      const dsn = buildDSNFromSource(source);
+
+      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema');
+    });
+
+    it('should URL-encode comma-separated search_path values', () => {
+      const source: SourceConfig = {
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'testuser',
+        password: 'testpass',
+        search_path: 'myschema,public',
+      };
+
+      const dsn = buildDSNFromSource(source);
+
+      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema%2Cpublic');
+    });
+
+    it('should not add search_path param when not specified', () => {
+      const source: SourceConfig = {
+        id: 'test',
+        type: 'postgres',
+        host: 'localhost',
+        database: 'testdb',
+        user: 'testuser',
+        password: 'testpass',
+      };
+
+      const dsn = buildDSNFromSource(source);
+
+      expect(dsn).not.toContain('search_path');
+    });
+
+    it('should append search_path param when DSN is directly provided', () => {
+      const source: SourceConfig = {
+        id: 'test',
+        type: 'postgres',
+        dsn: 'postgres://testuser:testpass@localhost:5432/testdb',
+        search_path: 'myschema',
+      };
+      const dsn = buildDSNFromSource(source);
+      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?search_path=myschema');
+    });
+
+    it('should append search_path param to DSN that already has query params', () => {
+      const source: SourceConfig = {
+        id: 'test',
+        type: 'postgres',
+        dsn: 'postgres://testuser:testpass@localhost:5432/testdb?sslmode=require',
+        search_path: 'myschema',
+      };
+      const dsn = buildDSNFromSource(source);
+      expect(dsn).toBe('postgres://testuser:testpass@localhost:5432/testdb?sslmode=require&search_path=myschema');
+    });
   });
 
   describe('Integration scenarios', () => {

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -5,14 +5,21 @@ import toml from "@iarna/toml";
 import type { SourceConfig, TomlConfig, ToolConfig } from "../types/config.js";
 import { parseCommandLineArgs } from "./env.js";
 import { parseConnectionInfoFromDSN, getDefaultPortForType } from "../utils/dsn-obfuscate.js";
-import { BUILTIN_TOOLS, BUILTIN_TOOL_EXECUTE_SQL, BUILTIN_TOOL_SEARCH_OBJECTS } from "../tools/builtin-tools.js";
-import { SafeURL } from "../utils/safe-url.js";
+import {
+  BUILTIN_TOOLS,
+  BUILTIN_TOOL_EXECUTE_SQL,
+  BUILTIN_TOOL_SEARCH_OBJECTS,
+} from "../tools/builtin-tools.js";
 
 /**
  * Load and parse TOML configuration file
  * Returns the parsed sources array, tools array, and the source of the config file
  */
-export function loadTomlConfig(): { sources: SourceConfig[]; tools?: TomlConfig['tools']; source: string } | null {
+export function loadTomlConfig(): {
+  sources: SourceConfig[];
+  tools?: TomlConfig["tools"];
+  source: string;
+} | null {
   const configPath = resolveTomlConfigPath();
   if (!configPath) {
     return null;
@@ -41,9 +48,7 @@ export function loadTomlConfig(): { sources: SourceConfig[]; tools?: TomlConfig[
     };
   } catch (error) {
     if (error instanceof Error) {
-      throw new Error(
-        `Failed to load TOML configuration from ${configPath}: ${error.message}`
-      );
+      throw new Error(`Failed to load TOML configuration from ${configPath}: ${error.message}`);
     }
     throw error;
   }
@@ -60,9 +65,7 @@ function resolveTomlConfigPath(): string | null {
   if (args.config) {
     const configPath = expandHomeDir(args.config);
     if (!fs.existsSync(configPath)) {
-      throw new Error(
-        `Configuration file specified by --config flag not found: ${configPath}`
-      );
+      throw new Error(`Configuration file specified by --config flag not found: ${configPath}`);
     }
     return configPath;
   }
@@ -147,9 +150,7 @@ function validateToolsConfig(
 
   for (const tool of tools) {
     if (!tool.name) {
-      throw new Error(
-        `Configuration file ${configPath}: all tools must have a 'name' field`
-      );
+      throw new Error(`Configuration file ${configPath}: all tools must have a 'name' field`);
     }
 
     if (!tool.source) {
@@ -269,11 +270,7 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
 
   // Validate SSH port if provided
   if (source.ssh_port !== undefined) {
-    if (
-      typeof source.ssh_port !== "number" ||
-      source.ssh_port <= 0 ||
-      source.ssh_port > 65535
-    ) {
+    if (typeof source.ssh_port !== "number" || source.ssh_port <= 0 || source.ssh_port > 65535) {
       throw new Error(
         `Configuration file ${configPath}: source '${source.id}' has invalid ssh_port. ` +
           `Must be between 1 and 65535.`
@@ -368,10 +365,7 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
 /**
  * Process source configurations (expand paths, populate fields from DSN)
  */
-function processSourceConfigs(
-  sources: SourceConfig[],
-  configPath: string
-): SourceConfig[] {
+function processSourceConfigs(sources: SourceConfig[], configPath: string): SourceConfig[] {
   return sources.map((source) => {
     const processed = { ...source };
 
@@ -433,33 +427,20 @@ function expandHomeDir(filePath: string): string {
  * Similar to buildDSNFromEnvParams in env.ts but for TOML sources
  */
 export function buildDSNFromSource(source: SourceConfig): string {
-  // If DSN is already provided, use it (but still apply search_path if set)
+  // If DSN is already provided, use it directly
   if (source.dsn) {
-    let dsn = source.dsn;
-    const isPostgres = source.type === 'postgres' || dsn.startsWith('postgres://') || dsn.startsWith('postgresql://');
-    if (isPostgres && source.search_path) {
-      const url = new SafeURL(dsn);
-      if (!url.getSearchParam('search_path')) {
-        const separator = dsn.includes('?') ? '&' : '?';
-        dsn += `${separator}search_path=${encodeURIComponent(source.search_path)}`;
-      }
-    }
-    return dsn;
+    return source.dsn;
   }
 
   // Validate required fields
   if (!source.type) {
-    throw new Error(
-      `Source '${source.id}': 'type' field is required when 'dsn' is not provided`
-    );
+    throw new Error(`Source '${source.id}': 'type' field is required when 'dsn' is not provided`);
   }
 
   // Handle SQLite
   if (source.type === "sqlite") {
     if (!source.database) {
-      throw new Error(
-        `Source '${source.id}': 'database' field is required for SQLite`
-      );
+      throw new Error(`Source '${source.id}': 'database' field is required for SQLite`);
     }
     return `sqlite:///${source.database}`;
   }
@@ -512,7 +493,7 @@ export function buildDSNFromSource(source: SourceConfig): string {
   }
 
   // Add PostgreSQL-specific parameters
-  if (source.type === 'postgres') {
+  if (source.type === "postgres") {
     if (source.search_path) {
       queryParams.push(`search_path=${encodeURIComponent(source.search_path)}`);
     }

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -462,6 +462,113 @@ describe('PostgreSQL Connector Integration Tests', () => {
 
   });
 
+  describe('search_path support', () => {
+    it('should discover tables in non-public schema by default when search_path is set', async () => {
+      // Create a non-public schema with a table
+      await postgresTest.connector.executeSQL('CREATE SCHEMA IF NOT EXISTS notpublic', {});
+      await postgresTest.connector.executeSQL(`
+        CREATE TABLE IF NOT EXISTS notpublic.widgets (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100) NOT NULL
+        )
+      `, {});
+
+      const baseUri = postgresTest.connectionString;
+      const uriWithSearchPath = baseUri.includes('?')
+        ? `${baseUri}&search_path=notpublic`
+        : `${baseUri}?search_path=notpublic`;
+
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(uriWithSearchPath);
+
+        // getTables() without explicit schema should use notpublic (the defaultSchema)
+        const tables = await connector.getTables();
+        expect(tables).toContain('widgets');
+        // Should NOT contain tables from public schema
+        expect(tables).not.toContain('users');
+        expect(tables).not.toContain('orders');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should use first schema from comma-separated search_path as discovery default', async () => {
+      await postgresTest.connector.executeSQL('CREATE SCHEMA IF NOT EXISTS notpublic', {});
+      await postgresTest.connector.executeSQL(`
+        CREATE TABLE IF NOT EXISTS notpublic.widgets (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100) NOT NULL
+        )
+      `, {});
+
+      const baseUri = postgresTest.connectionString;
+      const uriWithSearchPath = baseUri.includes('?')
+        ? `${baseUri}&search_path=notpublic,public`
+        : `${baseUri}?search_path=notpublic,public`;
+
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(uriWithSearchPath);
+
+        // First schema in the list (notpublic) should be the default
+        const tables = await connector.getTables();
+        expect(tables).toContain('widgets');
+        expect(tables).not.toContain('users');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should allow explicit schema parameter to override defaultSchema', async () => {
+      await postgresTest.connector.executeSQL('CREATE SCHEMA IF NOT EXISTS notpublic', {});
+      await postgresTest.connector.executeSQL(`
+        CREATE TABLE IF NOT EXISTS notpublic.widgets (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100) NOT NULL
+        )
+      `, {});
+
+      const baseUri = postgresTest.connectionString;
+      const uriWithSearchPath = baseUri.includes('?')
+        ? `${baseUri}&search_path=notpublic`
+        : `${baseUri}?search_path=notpublic`;
+
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(uriWithSearchPath);
+
+        // Explicit schema='public' should override defaultSchema
+        const publicTables = await connector.getTables('public');
+        expect(publicTables).toContain('users');
+        expect(publicTables).toContain('orders');
+        expect(publicTables).not.toContain('widgets');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should set search_path session variable after connecting', async () => {
+      await postgresTest.connector.executeSQL('CREATE SCHEMA IF NOT EXISTS notpublic', {});
+
+      const baseUri = postgresTest.connectionString;
+      const uriWithSearchPath = baseUri.includes('?')
+        ? `${baseUri}&search_path=notpublic`
+        : `${baseUri}?search_path=notpublic`;
+
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(uriWithSearchPath);
+
+        const result = await connector.executeSQL('SHOW search_path', {});
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0].search_path).toContain('notpublic');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+  });
+
   describe('SDK-Level Readonly Mode Tests', () => {
     it('should set default_transaction_read_only at connection level', async () => {
       const readonlyConnector = new PostgresConnector();

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -45,7 +45,7 @@ class PostgresDSNParser implements DSNParser {
       const poolConfig: pg.PoolConfig = {
         host: url.hostname,
         port: url.port ? parseInt(url.port) : 5432,
-        database: url.pathname ? url.pathname.substring(1) : '', // Remove leading '/' if exists
+        database: url.pathname ? url.pathname.substring(1) : "", // Remove leading '/' if exists
         user: url.username,
         password: url.password,
       };
@@ -90,7 +90,7 @@ class PostgresDSNParser implements DSNParser {
 
   isValidDSN(dsn: string): boolean {
     try {
-      return dsn.startsWith('postgres://') || dsn.startsWith('postgresql://');
+      return dsn.startsWith("postgres://") || dsn.startsWith("postgresql://");
     } catch (error) {
       return false;
     }
@@ -106,7 +106,7 @@ export class PostgresConnector implements Connector {
   dsnParser = new PostgresDSNParser();
 
   private pool: pg.Pool | null = null;
-  private defaultSchema = 'public';
+  private defaultSchema = "public";
 
   // Source ID is set by ConnectorManager after cloning
   private sourceId: string = "default";
@@ -123,23 +123,43 @@ export class PostgresConnector implements Connector {
     try {
       const poolConfig = await this.dsnParser.parse(dsn, config);
 
-      // Extract search_path to configure pg session and schema discovery defaults
+      // Extract search_path to set discovery default and configure each pg session safely
       const parsedUrl = new SafeURL(dsn);
-      const searchPath = parsedUrl.getSearchParam('search_path');
+      const searchPath = parsedUrl.getSearchParam("search_path");
       if (searchPath) {
-        poolConfig.options = (poolConfig.options || '') + ` -c search_path=${searchPath}`;
         // Use the first concrete schema (skip $user special token) as the discovery default
-        const firstSchema = searchPath.split(',').map((s) => s.trim())
-          .find((s) => s !== '$user' && s !== '"$user"');
-        this.defaultSchema = firstSchema || 'public';
+        const firstSchema = searchPath
+          .split(",")
+          .map((s) => s.trim())
+          .find((s) => s !== "$user" && s !== '"$user"');
+        this.defaultSchema = firstSchema || "public";
       }
 
       // SDK-level readonly enforcement: Set default_transaction_read_only for the entire connection
       if (config?.readonly) {
-        poolConfig.options = (poolConfig.options || '') + ' -c default_transaction_read_only=on';
+        poolConfig.options = (poolConfig.options || "") + " -c default_transaction_read_only=on";
       }
 
       this.pool = new Pool(poolConfig);
+
+      // Set search_path safely via a query on each new connection.
+      // We use pg.escapeIdentifier on each schema name to prevent injection,
+      // since SET does not support parameterized values.
+      // The $user special token is passed through unescaped as PostgreSQL requires it unquoted.
+      if (searchPath) {
+        const escapedSchemas = searchPath
+          .split(",")
+          .map((s) => {
+            const name = s.trim();
+            return name === "$user" ? name : pg.escapeIdentifier(name);
+          })
+          .join(", ");
+        this.pool.on("connect", (client) => {
+          client
+            .query(`SET search_path TO ${escapedSchemas}`)
+            .catch((err: Error) => console.error("Failed to set search_path:", err));
+        });
+      }
 
       // Test the connection
       const client = await this.pool.connect();
@@ -438,7 +458,6 @@ export class PostgresConnector implements Connector {
     }
   }
 
-
   async executeSQL(sql: string, options: ExecuteOptions, parameters?: any[]): Promise<SQLResult> {
     if (!this.pool) {
       throw new Error("Not connected to database");
@@ -447,9 +466,10 @@ export class PostgresConnector implements Connector {
     const client = await this.pool.connect();
     try {
       // Check if this is a multi-statement query
-      const statements = sql.split(';')
-        .map(statement => statement.trim())
-        .filter(statement => statement.length > 0);
+      const statements = sql
+        .split(";")
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0);
 
       if (statements.length === 1) {
         // Single statement - apply maxRows if applicable
@@ -482,7 +502,7 @@ export class PostgresConnector implements Connector {
         let totalRowCount = 0;
 
         // Execute within a transaction to ensure session consistency
-        await client.query('BEGIN');
+        await client.query("BEGIN");
         try {
           for (let statement of statements) {
             // Apply maxRows limit to SELECT queries if specified
@@ -498,9 +518,9 @@ export class PostgresConnector implements Connector {
               totalRowCount += result.rowCount;
             }
           }
-          await client.query('COMMIT');
+          await client.query("COMMIT");
         } catch (error) {
-          await client.query('ROLLBACK');
+          await client.query("ROLLBACK");
           throw error;
         }
 

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -120,6 +120,8 @@ export class PostgresConnector implements Connector {
   }
 
   async connect(dsn: string, initScript?: string, config?: ConnectorConfig): Promise<void> {
+    // Reset to default so reconnects without search_path don't inherit stale state
+    this.defaultSchema = "public";
     try {
       const poolConfig = await this.dsnParser.parse(dsn, config);
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -34,6 +34,8 @@ export interface ConnectionParams {
   // SQL Server authentication options
   authentication?: "ntlm" | "azure-active-directory-access-token";
   domain?: string; // Required for NTLM authentication
+  // PostgreSQL-specific options
+  search_path?: string; // Schema search path (e.g., "myschema" or "myschema,public")
 }
 
 /**


### PR DESCRIPTION
Fixes #243

  - Fixes a bug where `search_path` set in TOML config was silently ignored when a `dsn` field was also present — `buildDSNFromSource()` returned early without
  applying the param
  - Appends `search_path` as a query param to the DSN for all PostgreSQL connection methods
  - Guards against duplicate `search_path` params

  ## Changes

  - **`src/config/toml-loader.ts`**: Fixed early return in `buildDSNFromSource()` to apply `search_path` when both `dsn` and `search_path` are set in a TOML
  source
  - **`src/config/__tests__/toml-loader.test.ts`**: Added 2 unit tests covering DSN-only and DSN+existing-params cases
  - **`src/connectors/postgres/index.ts`**: Reads `search_path` from DSN param and sets it on the session via `SET search_path TO ...`
  - **`src/types/config.ts`**: Added `search_path?: string` to `ConnectionParams`
  - **`dbhub.toml.example`**: Added commented examples for both DSN and individual-parameter `search_path` usage

  ## Use cases supported

  | Method | Example |
  |--------|---------|
  | CLI | `--dsn postgres://...?search_path=myschema` |
  | ENV | `DSN=postgres://...?search_path=myschema` |
  | TOML (dsn field) | `dsn = "postgres://..."` + `search_path = "myschema"` |
  | TOML (individual params) | `type = "postgres"` + `search_path = "myschema"` |

  ## Test plan

  - [x] `pnpm test src/config/__tests__/toml-loader.test.ts` — 79 tests pass (2 new)
  - [ ] `pnpm test:integration src/connectors/__tests__/postgres.integration.test.ts` — requires Docker