### PR TITLE
Add search_path support in TOML config for PostgreSQL

### DIFF
--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -32,6 +32,12 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # password = "p@ss:word/123"
 # sslmode = "disable"  # Optional: "disable" or "require"
 
+# Local PostgreSQL with custom schema (non-public schema)
+# [[sources]]
+# id = "local_pg_custom_schema"
+# dsn = "postgres://postgres:postgres@localhost:5432/myapp"
+# search_path = "myschema,public"  # Comma-separated list of schemas; first is the default for discovery
+
 # Development PostgreSQL (shared dev server)
 # [[sources]]
 # id = "dev_pg"
@@ -256,6 +262,7 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #   description = "..."        # Optional: human-readable description
 #   dsn = "..."                # Connection string (or use individual params below)
 #   lazy = true                # Defer connection until first query (default: false)
+#   search_path = "schema1,public"  # PostgreSQL only: comma-separated schemas
 #
 # DSN Formats:
 #   PostgreSQL:  postgres://user:pass@host:5432/database?sslmode=require

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -281,6 +281,27 @@ Sources define database connections. Each source represents a database that DBHu
   ```
 </ParamField>
 
+### search_path
+
+<ParamField path="search_path" type="string">
+  Comma-separated list of PostgreSQL schema names to set as the session `search_path`. The first schema in the list becomes the default schema for all discovery methods (`getTables`, `getTableSchema`, etc.).
+
+  **PostgreSQL only.**
+
+  ```toml
+  [[sources]]
+  id = "production"
+  dsn = "postgres://user:pass@localhost:5432/mydb"
+  search_path = "myschema,public"
+  ```
+
+  Without `search_path`, DBHub defaults to the `public` schema for all schema discovery operations.
+
+  <Note>
+  This option is **only available via TOML**. It is not supported as a DSN query parameter.
+  </Note>
+</ParamField>
+
 ### SSH Tunnel Options
 
 <ParamField path="ssh_*" type="group">
@@ -575,6 +596,7 @@ default = 10
 | `instanceName` | string | ❌ | SQL Server named instance |
 | `authentication` | string | ❌ | SQL Server auth method |
 | `domain` | string | ❌ | Windows domain (NTLM) |
+| `search_path` | string | ❌ | PostgreSQL schema search path (comma-separated) |
 | `ssh_host` | string | ❌ | SSH server hostname |
 | `ssh_port` | number | ❌ | SSH server port (default: 22) |
 | `ssh_user` | string | ❌ | SSH username |

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -349,6 +349,22 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
     }
   }
 
+  // Validate search_path (PostgreSQL only)
+  if (source.search_path !== undefined) {
+    if (source.type !== "postgres") {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has 'search_path' but it is only supported for PostgreSQL sources.`
+      );
+    }
+    if (typeof source.search_path !== "string" || source.search_path.trim().length === 0) {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has invalid search_path. ` +
+          `Must be a non-empty string of comma-separated schema names (e.g., "myschema,public").`
+      );
+    }
+
+  }
+
   // Reject readonly and max_rows at source level (they should be set on tools instead)
   if ((source as any).readonly !== undefined) {
     throw new Error(

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -66,7 +66,12 @@ export interface ConnectorConfig {
    * Note: Application-level validation is done via ExecuteOptions.readonly
    */
   readonly?: boolean;
-  // Future database-specific options can be added here as optional fields
+  /**
+   * PostgreSQL search_path setting.
+   * Comma-separated list of schema names (e.g., "myschema,public").
+   * Sets the session search_path and uses the first schema as default for discovery methods.
+   */
+  searchPath?: string;
 }
 
 /**

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -219,6 +219,10 @@ export class ConnectorManager {
     if (source.readonly !== undefined) {
       config.readonly = source.readonly;
     }
+    // Pass search_path for PostgreSQL
+    if (source.search_path) {
+      config.searchPath = source.search_path;
+    }
 
     // Connect to the database with config and optional init script
     await connector.connect(actualDSN, source.init_script, config);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -47,6 +47,7 @@ export interface SourceConfig extends ConnectionParams, SSHConfig {
   query_timeout?: number; // Query timeout in seconds (PostgreSQL, MySQL, MariaDB, SQL Server)
   init_script?: string; // Optional SQL script to run on connection (for demo mode or initialization)
   lazy?: boolean; // Defer connection until first query (default: false)
+  search_path?: string; // Comma-separated list of schemas for PostgreSQL search_path (e.g., "myschema,public")
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `search_path` field to TOML `[[sources]]` config for PostgreSQL, allowing comma-separated schema list (e.g., `search_path = "myschema,public"`)
- Sets PostgreSQL session `search_path` at connection time and uses the first schema as the default for all discovery methods (`getTables`, `getTableSchema`, etc.)
- Only supported for PostgreSQL sources; validated and rejected for other database types
- Properly quotes schema names via `quoteIdentifier` to support special characters, spaces, and case-sensitive names
- Resets `defaultSchema` on each `connect()` call to prevent stale state on connector re-use

Closes #243

## Changes

- `src/types/config.ts` — Add `search_path?` field to `SourceConfig`
- `src/connectors/interface.ts` — Add `searchPath?` to `ConnectorConfig`
- `src/connectors/manager.ts` — Pass `search_path` from source config to connector
- `src/connectors/postgres/index.ts` — Set session `search_path` via pool options with proper identifier quoting and space escaping; use first schema as default for discovery methods instead of hardcoded `"public"`; reset `defaultSchema` at start of `connect()`
- `src/config/toml-loader.ts` — Validate `search_path` is PostgreSQL-only and non-empty
- `docs/config/toml.mdx` — Add `search_path` section and quick reference entry
- `dbhub.toml.example` — Add documented example and quick reference
- `src/config/__tests__/toml-loader.test.ts` — 5 new validation tests
- `src/connectors/__tests__/postgres.integration.test.ts` — Integration tests for search_path including special character schema names

## Usage

```toml
[[sources]]
id = "my_pg"
dsn = "postgres://user:pass@localhost:5432/mydb"
search_path = "myschema,public"
```

## Test plan

- [x] Build passes (`pnpm run build`)
- [x] All 79 TOML loader unit tests pass (including 5 new search_path tests)
- [x] All other unit tests pass (no regressions)
- [x] Integration test with real PostgreSQL and non-public schema
- [x] Integration test with schema name containing spaces (`"My Schema"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)