### PR TITLE
feat: include table and column comments in schema context for LLMs

### DIFF
--- a/docs/tools/search-objects.mdx
+++ b/docs/tools/search-objects.mdx
@@ -48,7 +48,8 @@ Search and list database objects (schemas, tables, columns, procedures, indexes)
       "name": "users",
       "schema": "public",
       "column_count": 8,
-      "row_count": 1523
+      "row_count": 1523,
+      "comment": "Application users"
     }
   ]
 }
@@ -61,7 +62,27 @@ Search and list database objects (schemas, tables, columns, procedures, indexes)
   "detail_level": "full"
 }
 
-// Returns complete table structure with all columns and indexes
+// Returns complete table structure with columns, indexes, and comments:
+{
+  "count": 1,
+  "results": [
+    {
+      "name": "users",
+      "schema": "public",
+      "column_count": 3,
+      "row_count": 1523,
+      "comment": "Application users",
+      "columns": [
+        { "name": "id", "type": "integer", "nullable": false, "default": null },
+        { "name": "name", "type": "varchar", "nullable": false, "default": null, "description": "Full name of the user" },
+        { "name": "email", "type": "varchar", "nullable": false, "default": null, "description": "Unique email address" }
+      ],
+      "indexes": [
+        { "name": "users_pkey", "columns": ["id"], "unique": true, "primary": true }
+      ]
+    }
+  ]
+}
 ```
 </CodeGroup>
 
@@ -128,6 +149,22 @@ This tool can reduce token usage by 90-99% compared to listing all objects:
 <Tip>
 Always start with `detail_level: "names"` and only request `"summary"` or `"full"` when you need additional information. This minimizes token usage while exploring the database.
 </Tip>
+
+## Table and Column Comments
+
+When using `detail_level: "summary"` or `"full"`, the tool includes database comments/descriptions if they exist. This helps LLMs understand the purpose of tables and columns, especially in complex or legacy databases.
+
+- **Table comments** appear as the `comment` field on table results (summary and full levels)
+- **Column descriptions** appear as the `description` field on each column (full level only)
+- Fields are omitted when no comment is set, keeping responses token-efficient
+
+| Database   | Table Comments | Column Comments |
+|------------|---------------|-----------------|
+| PostgreSQL | `COMMENT ON TABLE` | `COMMENT ON COLUMN` |
+| MySQL      | `ALTER TABLE ... COMMENT` | `ALTER TABLE ... MODIFY COLUMN ... COMMENT` |
+| MariaDB    | `ALTER TABLE ... COMMENT` | `ALTER TABLE ... MODIFY COLUMN ... COMMENT` |
+| SQL Server | `sp_addextendedproperty` (MS_Description) | `sp_addextendedproperty` (MS_Description) |
+| SQLite     | Not supported | Not supported |
 
 ## Usage Patterns
 

--- a/src/connectors/__tests__/mariadb.integration.test.ts
+++ b/src/connectors/__tests__/mariadb.integration.test.ts
@@ -21,7 +21,8 @@ class MariaDBIntegrationTest extends IntegrationTestBase<MariaDBTestContainer> {
     const config: DatabaseTestConfig = {
       expectedSchemas: ['testdb', 'information_schema'],
       expectedTables: ['users', 'orders', 'products'],
-      supportsStoredProcedures: false // Disabled due to container privilege restrictions
+      supportsStoredProcedures: false, // Disabled due to container privilege restrictions
+      supportsComments: true,
     };
     super(config);
   }
@@ -127,9 +128,14 @@ class MariaDBIntegrationTest extends IntegrationTestBase<MariaDBTestContainer> {
       )
     `, {});
 
+    // Add table and column comments
+    await connector.executeSQL(`ALTER TABLE users COMMENT = 'Application users'`, {});
+    await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN name VARCHAR(100) NOT NULL COMMENT 'Full name of the user'`, {});
+    await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN email VARCHAR(100) NOT NULL COMMENT 'Unique email address'`, {});
+
     // Insert test data
     await connector.executeSQL(`
-      INSERT IGNORE INTO users (name, email, age) VALUES 
+      INSERT IGNORE INTO users (name, email, age) VALUES
       ('John Doe', 'john@example.com', 30),
       ('Jane Smith', 'jane@example.com', 25),
       ('Bob Johnson', 'bob@example.com', 35)

--- a/src/connectors/__tests__/mariadb.integration.test.ts
+++ b/src/connectors/__tests__/mariadb.integration.test.ts
@@ -131,7 +131,7 @@ class MariaDBIntegrationTest extends IntegrationTestBase<MariaDBTestContainer> {
     // Add table and column comments
     await connector.executeSQL(`ALTER TABLE users COMMENT = 'Application users'`, {});
     await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN name VARCHAR(100) NOT NULL COMMENT 'Full name of the user'`, {});
-    await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN email VARCHAR(100) NOT NULL COMMENT 'Unique email address'`, {});
+    await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN email VARCHAR(100) UNIQUE NOT NULL COMMENT 'Unique email address'`, {});
 
     // Insert test data
     await connector.executeSQL(`

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -125,7 +125,7 @@ class MySQLIntegrationTest extends IntegrationTestBase<MySQLTestContainer> {
     // Add table and column comments
     await connector.executeSQL(`ALTER TABLE users COMMENT = 'Application users'`, {});
     await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN name VARCHAR(100) NOT NULL COMMENT 'Full name of the user'`, {});
-    await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN email VARCHAR(100) NOT NULL COMMENT 'Unique email address'`, {});
+    await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN email VARCHAR(100) UNIQUE NOT NULL COMMENT 'Unique email address'`, {});
 
     // Insert test data
     await connector.executeSQL(`

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -21,7 +21,8 @@ class MySQLIntegrationTest extends IntegrationTestBase<MySQLTestContainer> {
     const config: DatabaseTestConfig = {
       expectedSchemas: ['testdb', 'information_schema'],
       expectedTables: ['users', 'orders', 'products'],
-      supportsStoredProcedures: false // Disabled due to container privilege restrictions
+      supportsStoredProcedures: false, // Disabled due to container privilege restrictions
+      supportsComments: true,
     };
     super(config);
   }
@@ -121,9 +122,14 @@ class MySQLIntegrationTest extends IntegrationTestBase<MySQLTestContainer> {
       )
     `, {});
 
+    // Add table and column comments
+    await connector.executeSQL(`ALTER TABLE users COMMENT = 'Application users'`, {});
+    await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN name VARCHAR(100) NOT NULL COMMENT 'Full name of the user'`, {});
+    await connector.executeSQL(`ALTER TABLE users MODIFY COLUMN email VARCHAR(100) NOT NULL COMMENT 'Unique email address'`, {});
+
     // Insert test data
     await connector.executeSQL(`
-      INSERT IGNORE INTO users (name, email, age) VALUES 
+      INSERT IGNORE INTO users (name, email, age) VALUES
       ('John Doe', 'john@example.com', 30),
       ('Jane Smith', 'jane@example.com', 25),
       ('Bob Johnson', 'bob@example.com', 35)

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -24,7 +24,8 @@ class PostgreSQLIntegrationTest extends IntegrationTestBase<PostgreSQLTestContai
       expectedTestSchemaTable: 'products',
       testSchema: 'test_schema',
       supportsStoredProcedures: true,
-      expectedStoredProcedures: ['get_user_count', 'calculate_total_age']
+      expectedStoredProcedures: ['get_user_count', 'calculate_total_age'],
+      supportsComments: true,
     };
     super(config);
   }
@@ -124,9 +125,14 @@ class PostgreSQLIntegrationTest extends IntegrationTestBase<PostgreSQLTestContai
       )
     `, {});
 
+    // Add table and column comments
+    await connector.executeSQL(`COMMENT ON TABLE users IS 'Application users'`, {});
+    await connector.executeSQL(`COMMENT ON COLUMN users.name IS 'Full name of the user'`, {});
+    await connector.executeSQL(`COMMENT ON COLUMN users.email IS 'Unique email address'`, {});
+
     // Insert test data
     await connector.executeSQL(`
-      INSERT INTO users (name, email, age) VALUES 
+      INSERT INTO users (name, email, age) VALUES
       ('John Doe', 'john@example.com', 30),
       ('Jane Smith', 'jane@example.com', 25),
       ('Bob Johnson', 'bob@example.com', 35)

--- a/src/connectors/__tests__/shared/integration-test-base.ts
+++ b/src/connectors/__tests__/shared/integration-test-base.ts
@@ -8,6 +8,7 @@ export interface DatabaseTestConfig {
   testSchema?: string;
   supportsStoredProcedures?: boolean;
   expectedStoredProcedures?: string[];
+  supportsComments?: boolean;
 }
 
 export interface TestContainer {
@@ -84,11 +85,13 @@ export abstract class IntegrationTestBase<TContainer extends TestContainer> {
       this.createSchemaTests();
       this.createTableTests();
       this.createSQLExecutionTests();
-      
+
       if (this.config.supportsStoredProcedures) {
         this.createStoredProcedureTests();
       }
-      
+
+      this.createCommentTests();
+
       this.createErrorHandlingTests();
     });
   }
@@ -234,6 +237,54 @@ export abstract class IntegrationTestBase<TContainer extends TestContainer> {
           const procedure = await this.connector.getStoredProcedureDetail(procedureName);
           expect(procedure.procedure_name).toBe(procedureName);
           expect(procedure.procedure_type).toMatch(/function|procedure/);
+        });
+      }
+    });
+  }
+
+  createCommentTests(): void {
+    describe('Table and Column Comments', () => {
+      it('should include description field in table schema columns', async () => {
+        const schema = await this.connector.getTableSchema('users');
+        expect(schema.length).toBeGreaterThan(0);
+
+        // Every column should have the description field (even if null)
+        for (const col of schema) {
+          expect(col).toHaveProperty('description');
+        }
+
+        if (this.config.supportsComments) {
+          // Databases with comments should return the descriptions we set
+          const nameColumn = schema.find(col => col.column_name === 'name');
+          expect(nameColumn?.description).toBe('Full name of the user');
+
+          const emailColumn = schema.find(col => col.column_name === 'email');
+          expect(emailColumn?.description).toBe('Unique email address');
+
+          // Columns without comments should have null description
+          const ageColumn = schema.find(col => col.column_name === 'age');
+          expect(ageColumn?.description).toBeNull();
+        } else {
+          // Databases without comment support (SQLite) should return null
+          for (const col of schema) {
+            expect(col.description).toBeNull();
+          }
+        }
+      });
+
+      if (this.config.supportsComments) {
+        it('should return table comment via getTableComment', async () => {
+          if (this.connector.getTableComment) {
+            const comment = await this.connector.getTableComment('users');
+            expect(comment).toBe('Application users');
+          }
+        });
+
+        it('should return null for table without comment', async () => {
+          if (this.connector.getTableComment) {
+            const comment = await this.connector.getTableComment('orders');
+            expect(comment).toBeNull();
+          }
         });
       }
     });

--- a/src/connectors/__tests__/shared/integration-test-base.ts
+++ b/src/connectors/__tests__/shared/integration-test-base.ts
@@ -274,17 +274,15 @@ export abstract class IntegrationTestBase<TContainer extends TestContainer> {
 
       if (this.config.supportsComments) {
         it('should return table comment via getTableComment', async () => {
-          if (this.connector.getTableComment) {
-            const comment = await this.connector.getTableComment('users');
-            expect(comment).toBe('Application users');
-          }
+          expect(this.connector.getTableComment).toBeDefined();
+          const comment = await this.connector.getTableComment!('users');
+          expect(comment).toBe('Application users');
         });
 
         it('should return null for table without comment', async () => {
-          if (this.connector.getTableComment) {
-            const comment = await this.connector.getTableComment('orders');
-            expect(comment).toBeNull();
-          }
+          expect(this.connector.getTableComment).toBeDefined();
+          const comment = await this.connector.getTableComment!('orders');
+          expect(comment).toBeNull();
         });
       }
     });

--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -36,7 +36,8 @@ class SQLServerIntegrationTest extends IntegrationTestBase<SQLServerTestContaine
       expectedSchemas: ['dbo', 'INFORMATION_SCHEMA'],
       expectedTables: ['users', 'orders', 'products'],
       supportsStoredProcedures: true,
-      expectedStoredProcedures: ['GetUserCount', 'CalculateTotalAge']
+      expectedStoredProcedures: ['GetUserCount', 'CalculateTotalAge'],
+      supportsComments: true,
     };
     super(config);
   }
@@ -85,9 +86,34 @@ class SQLServerIntegrationTest extends IntegrationTestBase<SQLServerTestContaine
       )
     `, {});
 
+    // Add table and column comments via extended properties
+    await connector.executeSQL(`
+      EXEC sp_addextendedproperty
+        @name = N'MS_Description',
+        @value = N'Application users',
+        @level0type = N'SCHEMA', @level0name = N'dbo',
+        @level1type = N'TABLE',  @level1name = N'users'
+    `, {});
+    await connector.executeSQL(`
+      EXEC sp_addextendedproperty
+        @name = N'MS_Description',
+        @value = N'Full name of the user',
+        @level0type = N'SCHEMA', @level0name = N'dbo',
+        @level1type = N'TABLE',  @level1name = N'users',
+        @level2type = N'COLUMN', @level2name = N'name'
+    `, {});
+    await connector.executeSQL(`
+      EXEC sp_addextendedproperty
+        @name = N'MS_Description',
+        @value = N'Unique email address',
+        @level0type = N'SCHEMA', @level0name = N'dbo',
+        @level1type = N'TABLE',  @level1name = N'users',
+        @level2type = N'COLUMN', @level2name = N'email'
+    `, {});
+
     // Insert test data
     await connector.executeSQL(`
-      INSERT INTO users (name, email, age) VALUES 
+      INSERT INTO users (name, email, age) VALUES
       ('John Doe', 'john@example.com', 30),
       ('Jane Smith', 'jane@example.com', 25),
       ('Bob Johnson', 'bob@example.com', 35)

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -17,6 +17,7 @@ export interface TableColumn {
   data_type: string;
   is_nullable: string;
   column_default: string | null;
+  description: string | null;
 }
 
 export interface TableIndex {
@@ -189,6 +190,13 @@ export interface Connector {
    * Optional — connectors that don't implement this fall back to COUNT(*) in search-objects.
    */
   getTableRowCount?(tableName: string, schema?: string): Promise<number | null>;
+
+  /**
+   * Get the comment/description for a table.
+   * Optional — connectors that don't support table comments (e.g. SQLite) may omit this.
+   * @returns The table comment string, or null if no comment is set
+   */
+  getTableComment?(tableName: string, schema?: string): Promise<string | null>;
 
   /** Execute a SQL query with execution options and optional parameters */
   executeSQL(sql: string, options: ExecuteOptions, parameters?: any[]): Promise<SQLResult>;

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -331,6 +331,7 @@ export class MariaDBConnector implements Connector {
         queryParams
       ) as any[];
 
+      // Normalize empty string comments to null for token-efficient output
       return rows.map((row: any) => ({
         ...row,
         description: row.description || null,

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -321,14 +321,15 @@ export class MySQLConnector implements Connector {
 
       const queryParams = schema ? [schema, tableName] : [tableName];
 
-      // Get table columns
+      // Get table columns with comments
       const [rows] = (await this.pool.query(
         `
-        SELECT 
-          COLUMN_NAME as column_name, 
-          DATA_TYPE as data_type, 
+        SELECT
+          COLUMN_NAME as column_name,
+          DATA_TYPE as data_type,
           IS_NULLABLE as is_nullable,
-          COLUMN_DEFAULT as column_default
+          COLUMN_DEFAULT as column_default,
+          COLUMN_COMMENT as description
         FROM INFORMATION_SCHEMA.COLUMNS
         ${schemaClause}
         AND TABLE_NAME = ?
@@ -337,10 +338,41 @@ export class MySQLConnector implements Connector {
         queryParams
       )) as [any[], any];
 
-      return rows;
+      return rows.map((row: any) => ({
+        ...row,
+        description: row.description || null,
+      }));
     } catch (error) {
       console.error("Error getting table schema:", error);
       throw error;
+    }
+  }
+
+  async getTableComment(tableName: string, schema?: string): Promise<string | null> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+
+    try {
+      const schemaClause = schema ? "WHERE TABLE_SCHEMA = ?" : "WHERE TABLE_SCHEMA = DATABASE()";
+      const queryParams = schema ? [schema, tableName] : [tableName];
+
+      const [rows] = (await this.pool.query(
+        `
+        SELECT TABLE_COMMENT
+        FROM INFORMATION_SCHEMA.TABLES
+        ${schemaClause}
+        AND TABLE_NAME = ?
+      `,
+        queryParams
+      )) as [any[], any];
+
+      if (rows.length > 0) {
+        return rows[0].TABLE_COMMENT || null;
+      }
+      return null;
+    } catch (error) {
+      return null;
     }
   }
 

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -338,6 +338,7 @@ export class MySQLConnector implements Connector {
         queryParams
       )) as [any[], any];
 
+      // Normalize empty string comments to null for token-efficient output
       return rows.map((row: any) => ({
         ...row,
         description: row.description || null,

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -329,12 +329,14 @@ export class SQLiteConnector implements Connector {
       const rows = this.db.prepare(`PRAGMA table_info(${quotedTableName})`).all() as SQLiteTableInfo[];
 
       // Convert SQLite schema format to our standard TableColumn format
+      // SQLite does not support column comments, so description is always null
       const columns = rows.map((row) => ({
         column_name: row.name,
         data_type: row.type,
         // In SQLite, primary key columns are automatically NOT NULL even if notnull=0
         is_nullable: (row.notnull === 1 || row.pk > 0) ? "NO" : "YES",
         column_default: row.dflt_value,
+        description: null,
       }));
 
       return columns;

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -381,6 +381,7 @@ export class SQLServerConnector implements Connector {
 
       const result = await request.query(query);
 
+      // Normalize empty string comments to null for token-efficient output
       return result.recordset.map((row: any) => ({
         ...row,
         description: row.description || null,

--- a/src/tools/__tests__/search-objects.test.ts
+++ b/src/tools/__tests__/search-objects.test.ts
@@ -187,8 +187,8 @@ describe('search_database_objects tool', () => {
 
     it('should return summary with metadata', async () => {
       const mockColumns: TableColumn[] = [
-        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
-        { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null },
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+        { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: null },
       ];
 
       vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
@@ -215,7 +215,7 @@ describe('search_database_objects tool', () => {
 
     it('should return full details with columns and indexes', async () => {
       const mockColumns: TableColumn[] = [
-        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
       ];
 
       const mockIndexes: TableIndex[] = [
@@ -269,7 +269,7 @@ describe('search_database_objects tool', () => {
       vi.mocked(mockConnector.getSchemas).mockResolvedValue(['public']);
       vi.mocked(mockConnector.getTables).mockResolvedValue(['users']);
       vi.mocked(mockConnector.getTableSchema).mockResolvedValue([
-        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
       ]);
     });
 
@@ -350,14 +350,14 @@ describe('search_database_objects tool', () => {
 
     it('should search columns across tables', async () => {
       const usersColumns: TableColumn[] = [
-        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
-        { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null },
-        { column_name: 'email', data_type: 'TEXT', is_nullable: 'YES', column_default: null },
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+        { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: null },
+        { column_name: 'email', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: null },
       ];
 
       const ordersColumns: TableColumn[] = [
-        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
-        { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+        { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
       ];
 
       vi.mocked(mockConnector.getTableSchema).mockImplementation(async (table) => {
@@ -387,7 +387,7 @@ describe('search_database_objects tool', () => {
 
     it('should return column details in summary level', async () => {
       const columns: TableColumn[] = [
-        { column_name: 'email', data_type: 'VARCHAR(255)', is_nullable: 'YES', column_default: null },
+        { column_name: 'email', data_type: 'VARCHAR(255)', is_nullable: 'YES', column_default: null, description: null },
       ];
 
       vi.mocked(mockConnector.getTableSchema).mockResolvedValue(columns);
@@ -569,13 +569,13 @@ describe('search_database_objects tool', () => {
 
       it('should filter columns by table when table parameter is provided', async () => {
         const usersColumns: TableColumn[] = [
-          { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
-          { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null },
+          { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+          { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: null },
         ];
 
         const ordersColumns: TableColumn[] = [
-          { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
-          { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
+          { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+          { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
         ];
 
         vi.mocked(mockConnector.getTableSchema).mockImplementation(async (table) => {
@@ -628,9 +628,9 @@ describe('search_database_objects tool', () => {
 
       it('should work with column pattern when table filter is applied', async () => {
         const usersColumns: TableColumn[] = [
-          { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null },
-          { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null },
-          { column_name: 'email', data_type: 'TEXT', is_nullable: 'YES', column_default: null },
+          { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+          { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: null },
+          { column_name: 'email', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: null },
         ];
 
         vi.mocked(mockConnector.getTableSchema).mockResolvedValue(usersColumns);

--- a/src/tools/__tests__/search-objects.test.ts
+++ b/src/tools/__tests__/search-objects.test.ts
@@ -262,6 +262,90 @@ describe('search_database_objects tool', () => {
         ],
       });
     });
+
+    it('should include table comment in summary when getTableComment returns a value', async () => {
+      const mockColumns: TableColumn[] = [
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+      ];
+
+      vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 10 }] });
+      mockConnector.getTableComment = vi.fn().mockResolvedValue('Application users');
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'table',
+          pattern: 'users',
+          detail_level: 'summary',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results[0].comment).toBe('Application users');
+    });
+
+    it('should omit table comment in summary when getTableComment returns null', async () => {
+      const mockColumns: TableColumn[] = [
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+      ];
+
+      vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 10 }] });
+      mockConnector.getTableComment = vi.fn().mockResolvedValue(null);
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'table',
+          pattern: 'users',
+          detail_level: 'summary',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results[0].comment).toBeUndefined();
+    });
+
+    it('should include column descriptions in full detail when present', async () => {
+      const mockColumns: TableColumn[] = [
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+        { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: 'Full name of the user' },
+        { column_name: 'email', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: 'Unique email address' },
+      ];
+
+      const mockIndexes: TableIndex[] = [];
+
+      vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
+      vi.mocked(mockConnector.getTableIndexes).mockResolvedValue(mockIndexes);
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 50 }] });
+      mockConnector.getTableComment = vi.fn().mockResolvedValue('Application users');
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'table',
+          pattern: 'users',
+          detail_level: 'full',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      const tableResult = parsed.data.results[0];
+
+      // Table comment should be present
+      expect(tableResult.comment).toBe('Application users');
+
+      // Column without description should not have the field
+      expect(tableResult.columns[0].description).toBeUndefined();
+
+      // Columns with descriptions should include them
+      expect(tableResult.columns[1].description).toBe('Full name of the user');
+      expect(tableResult.columns[2].description).toBe('Unique email address');
+    });
   });
 
   describe('getTableRowCount dispatch', () => {


### PR DESCRIPTION
## Summary

Closes #249

- Adds `description` field to `TableColumn` interface and optional `getTableComment()` method to `Connector` interface
- Each database connector now fetches column and table comments using native catalog queries (PostgreSQL: `pg_description`, MySQL/MariaDB: `COLUMN_COMMENT`/`TABLE_COMMENT`, SQL Server: `sys.extended_properties`, SQLite: returns null)
- The `search_objects` tool now includes `comment` on tables and `description` on columns at summary/full detail levels, giving LLMs richer schema context for query generation

## Test Plan

- [x] `pnpm run build` — TypeScript compiles successfully
- [x] All unit tests pass (420 tests across 15 non-Docker test suites)
- [x] SQLite integration tests pass including new comment assertion tests (38 tests)
- [x] `search-objects` unit tests pass (28 tests)
- [ ] `pnpm test:integration` — Docker-based integration tests with Testcontainers (PostgreSQL, MySQL, MariaDB, SQL Server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)