### PR TITLE
feat: add function as searchable object type in search_objects

### DIFF
--- a/docs/tools/search-objects.mdx
+++ b/docs/tools/search-objects.mdx
@@ -2,11 +2,11 @@
 title: "search_objects"
 ---
 
-Search and list database objects (schemas, tables, columns, procedures, indexes) with pattern matching. This unified tool supports both targeted searches and browsing all objects, implementing progressive disclosure to minimize token usage.
+Search and list database objects (schemas, tables, columns, procedures, functions, indexes) with pattern matching. This unified tool supports both targeted searches and browsing all objects, implementing progressive disclosure to minimize token usage.
 
 ## Parameters
 
-- `object_type` (required): Type of object to search - `"schema"`, `"table"`, `"column"`, `"procedure"`, or `"index"`
+- `object_type` (required): Type of object to search - `"schema"`, `"table"`, `"column"`, `"procedure"`, `"function"`, or `"index"`
 - `pattern` (optional): Search pattern using SQL LIKE syntax (`%` for wildcard, `_` for single character). Defaults to `"%"` (match all)
 - `schema` (optional): Filter results to a specific schema
 - `detail_level` (optional): Level of detail - `"names"` (default), `"summary"`, or `"full"`
@@ -117,6 +117,14 @@ Search and list database objects (schemas, tables, columns, procedures, indexes)
 ```json List all schemas with metadata
 {
   "object_type": "schema",
+  "detail_level": "summary"
+}
+```
+
+```json Search for functions
+{
+  "object_type": "function",
+  "pattern": "calc%",
   "detail_level": "summary"
 }
 ```

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -172,9 +172,11 @@ export interface Connector {
   /**
    * Get stored procedures/functions in the database or in a specific schema
    * @param schema Optional schema name. If not provided, implementation should use the default schema
+   * @param routineType Optional filter: "procedure" for procedures only, "function" for functions only.
+   *   If not provided, returns both procedures and functions.
    * @returns Promise with array of stored procedure/function names
    */
-  getStoredProcedures(schema?: string): Promise<string[]>;
+  getStoredProcedures(schema?: string, routineType?: "procedure" | "function"): Promise<string[]>;
 
   /**
    * Get details for a specific stored procedure/function

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -377,7 +377,7 @@ export class MySQLConnector implements Connector {
     }
   }
 
-  async getStoredProcedures(schema?: string): Promise<string[]> {
+  async getStoredProcedures(schema?: string, routineType?: "procedure" | "function"): Promise<string[]> {
     if (!this.pool) {
       throw new Error("Not connected to database");
     }
@@ -388,14 +388,22 @@ export class MySQLConnector implements Connector {
         ? "WHERE ROUTINE_SCHEMA = ?"
         : "WHERE ROUTINE_SCHEMA = DATABASE()";
 
-      const queryParams = schema ? [schema] : [];
+      const queryParams: string[] = schema ? [schema] : [];
 
-      // Get all stored procedures and functions
+      // Build optional routine type filter
+      let typeFilter = "";
+      if (routineType === "function") {
+        typeFilter = " AND ROUTINE_TYPE = 'FUNCTION'";
+      } else if (routineType === "procedure") {
+        typeFilter = " AND ROUTINE_TYPE = 'PROCEDURE'";
+      }
+
+      // Get stored procedures and/or functions
       const [rows] = (await this.pool.query(
         `
         SELECT ROUTINE_NAME
         FROM INFORMATION_SCHEMA.ROUTINES
-        ${schemaClause}
+        ${schemaClause}${typeFilter}
         ORDER BY ROUTINE_NAME
       `,
         queryParams

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -345,7 +345,7 @@ export class SQLiteConnector implements Connector {
     }
   }
 
-  async getStoredProcedures(schema?: string): Promise<string[]> {
+  async getStoredProcedures(schema?: string, routineType?: "procedure" | "function"): Promise<string[]> {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");
     }
@@ -360,7 +360,7 @@ export class SQLiteConnector implements Connector {
     // 2. User-defined functions cannot be listed via SQL queries
     // 3. We don't want to misrepresent triggers as stored procedures
 
-    return [];
+    return []; // routineType parameter accepted but ignored for SQLite
   }
 
   async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -150,8 +150,8 @@ export function getSearchObjectsMetadata(sourceId: string): { name: string; desc
     ? `Search Database Objects (${dbType})`
     : `Search Database Objects on ${sourceId} (${dbType})`;
   const description = isSingleSource
-    ? `Search and list database objects (schemas, tables, columns, procedures, indexes) on the ${dbType} database`
-    : `Search and list database objects (schemas, tables, columns, procedures, indexes) on the '${sourceId}' ${dbType} database`;
+    ? `Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the ${dbType} database`
+    : `Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the '${sourceId}' ${dbType} database`;
 
   return {
     name: toolName,


### PR DESCRIPTION
## Summary
- Adds `"function"` as a first-class object type in the `search_objects` tool, so LLMs and users can discover database functions separately from stored procedures
- Updates all database connectors (PostgreSQL, MySQL, MariaDB, SQL Server, SQLite) with an optional `routineType` filter on `getStoredProcedures()` to efficiently filter at the SQL level
- Updates tool description to include "functions" in the list of searchable types

## Context
Closes #245. Previously, database functions were only discoverable under `object_type="procedure"`. This made it harder for LLMs to find functions specifically. Now:
- `search_objects(object_type="function")` returns only functions
- `search_objects(object_type="procedure")` returns only procedures
- Function execution via `SELECT my_function()` already worked through `execute_sql`

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] All 32 search-objects unit tests pass (5 new tests for function search)
- [x] New tests verify: function name search, summary/full detail levels, table filter rejection, routineType filter passed to connectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)