### PR TITLE
fix: correct SSH keepalive validation issues

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -486,8 +486,8 @@ export function resolveSSHConfig(): { config: SSHTunnelConfig; source: string } 
   }
 
   const parseNonNegativeInteger = (value: string, name: string): number => {
-    const parsed = Number.parseInt(value, 10);
-    if (Number.isNaN(parsed) || parsed < 0) {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 0) {
       throw new Error(`Invalid value for ${name}: "${value}". Expected a non-negative integer.`);
     }
     return parsed;

--- a/src/utils/ssh-tunnel.ts
+++ b/src/utils/ssh-tunnel.ts
@@ -172,13 +172,13 @@ export class SSHTunnel {
         sshConfig.sock = sock;
       }
       if (keepaliveInterval !== undefined) {
-        if (Number.isNaN(keepaliveInterval) || keepaliveInterval <= 0) {
+        if (Number.isNaN(keepaliveInterval) || keepaliveInterval < 0) {
           const desc = label || `${hostInfo.host}:${hostInfo.port}`;
           console.warn(
             `Invalid SSH keepaliveInterval (${keepaliveInterval}) for ${desc}; ` +
             'keepalive configuration will be ignored.'
           );
-        } else {
+        } else if (keepaliveInterval > 0) {
           sshConfig.keepaliveInterval = keepaliveInterval * 1000; // Convert seconds to milliseconds
           sshConfig.keepaliveCountMax = keepaliveCountMax ?? 3;
         }


### PR DESCRIPTION
- Allow keepaliveInterval=0 to silently disable keepalive instead of emitting a spurious warning (0 is valid in ssh2 meaning "disabled")
- Fix parseNonNegativeInteger to reject partial numeric strings like "1.5" or "10abc" which Number.parseInt silently accepted

Addresses review comments from #254.