### PR TITLE
fix: prevent IAM refresh timer race during shutdown

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,7 +7,7 @@ This guide will walk you through setting up DBHub and connecting it to an AI too
 ## Prerequisites
 
 Before starting, ensure you have:
-- Node.js 18+ installed (for NPM method) **OR** Docker installed
+- Node.js 20+ installed (for NPM method) **OR** Docker installed
 - Access to an AI tool (Claude Desktop, Claude Code, Cursor, or VS Code)
 - Optionally: A PostgreSQL, MySQL, or other supported database
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "test:watch": "vitest",
     "test:integration": "vitest run --project integration"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "keywords": [],
   "author": "",
   "license": "MIT",

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -23,6 +23,7 @@ export class ConnectorManager {
   private sourceConfigs: Map<string, SourceConfig> = new Map(); // Store original source configs
   private sourceIds: string[] = []; // Ordered list of source IDs (first is default)
   private iamRefreshTimers: Map<string, NodeJS.Timeout> = new Map();
+  private isDisconnecting = false;
 
   // Lazy connection support
   private lazySources: Map<string, SourceConfig> = new Map(); // Sources pending lazy connection
@@ -252,6 +253,15 @@ export class ConnectorManager {
    * Close all database connections
    */
   async disconnect(): Promise<void> {
+    // Set shutdown flag first to prevent IAM refresh timers from firing during teardown
+    this.isDisconnecting = true;
+
+    // Stop all IAM refresh timers before disconnecting connectors
+    for (const timer of this.iamRefreshTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.iamRefreshTimers.clear();
+
     // Disconnect multi-source connections
     for (const [sourceId, connector] of this.connectors.entries()) {
       try {
@@ -271,19 +281,14 @@ export class ConnectorManager {
       }
     }
 
-    // Stop all IAM refresh timers
-    for (const timer of this.iamRefreshTimers.values()) {
-      clearTimeout(timer);
-    }
-
     // Clear multi-source state
     this.connectors.clear();
     this.sshTunnels.clear();
     this.sourceConfigs.clear();
-    this.iamRefreshTimers.clear();
     this.lazySources.clear();
     this.pendingConnections.clear();
     this.sourceIds = [];
+    this.isDisconnecting = false;
   }
 
   /**
@@ -400,6 +405,10 @@ export class ConnectorManager {
   }
 
   private scheduleIamRefresh(source: SourceConfig): void {
+    if (this.isDisconnecting) {
+      return;
+    }
+
     const sourceId = source.id;
     const existingTimer = this.iamRefreshTimers.get(sourceId);
     if (existingTimer) {
@@ -411,6 +420,9 @@ export class ConnectorManager {
     }
 
     const timer = setTimeout(async () => {
+      if (this.isDisconnecting) {
+        return;
+      }
       try {
         await this.refreshIamSourceConnection(source);
       } catch (error) {
@@ -419,8 +431,8 @@ export class ConnectorManager {
           error
         );
       } finally {
-        // Continue rotating as long as source remains configured.
-        if (this.sourceConfigs.has(sourceId)) {
+        // Continue rotating as long as source remains configured and not shutting down.
+        if (!this.isDisconnecting && this.sourceConfigs.has(sourceId)) {
           this.scheduleIamRefresh(source);
         }
       }

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -443,7 +443,7 @@ export class ConnectorManager {
 
   private async refreshIamSourceConnection(source: SourceConfig): Promise<void> {
     const sourceId = source.id;
-    if (!source.aws_iam_auth || !this.connectors.has(sourceId)) {
+    if (this.isDisconnecting || !source.aws_iam_auth || !this.connectors.has(sourceId)) {
       return;
     }
 
@@ -459,6 +459,10 @@ export class ConnectorManager {
     if (existingTunnel) {
       await existingTunnel.close();
       this.sshTunnels.delete(sourceId);
+    }
+
+    if (this.isDisconnecting) {
+      return;
     }
 
     await this.connectSource(source);


### PR DESCRIPTION
## Summary
- Fix race condition where IAM refresh timers could fire during `disconnect()`, reopening connections mid-teardown
- Add `isDisconnecting` flag checked in `scheduleIamRefresh` and timer callbacks to prevent orphaned timers
- Clear IAM timers before disconnecting connectors/tunnels (not after)
- Add `engines.node >= 20` to package.json since `@aws-sdk/rds-signer` requires it

Follows up on review comments from #258.

## Test plan
- [x] `pnpm test:unit` — all relevant tests pass (aws-rds-signer, toml-loader, manager)
- [x] `pnpm run build:backend` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)