### PR TITLE
feat: hot reload TOML config on file changes

### DIFF
--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -11,6 +11,29 @@ TOML configuration enables:
 - **Per-source settings**: Configure timeouts, SSL, SSH tunnels, and lazy connections individually per database
 - **Per-tool settings**: Apply different restrictions (readonly, max_rows) per tool
 - **Custom tools**: Define reusable, parameterized SQL operations as MCP tools
+- **Hot reload**: Automatically detect config changes and reload connections without restarting
+
+## Hot Reload
+
+When using TOML configuration, DBHub automatically watches `dbhub.toml` for changes and reloads database connections without requiring a server restart.
+
+**How it works:**
+
+1. DBHub detects file changes and waits 500ms (debounce) to handle editors that write in multiple steps
+2. The new configuration is parsed and validated — if invalid, existing connections are preserved
+3. All database connections are disconnected and reconnected with the new configuration
+4. If reconnection fails, DBHub automatically rolls back to the previous working configuration
+
+```
+# Edit dbhub.toml while DBHub is running — changes apply automatically
+# No server restart needed
+```
+
+<Note>
+**STDIO transport limitation:** In STDIO mode (the default for Claude Desktop, Cursor, etc.), hot reload updates the underlying database connections and tool settings, but clients won't see newly added or removed tools until a full server restart. This is because STDIO clients discover tools once at startup.
+
+HTTP transport (`--transport http`) creates a fresh server per request, so all changes — including added/removed tools — take effect immediately.
+</Note>
 
 ## Configuration Structure
 

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -52,7 +52,7 @@ export function loadTomlConfig(): { sources: SourceConfig[]; tools?: TomlConfig[
  * Resolve the path to the TOML configuration file
  * Priority: --config flag > ./dbhub.toml
  */
-function resolveTomlConfigPath(): string | null {
+export function resolveTomlConfigPath(): string | null {
   const args = parseCommandLineArgs();
 
   // 1. Check for --config flag (highest priority)

--- a/src/server.ts
+++ b/src/server.ts
@@ -106,7 +106,10 @@ See documentation for more details on configuring database connections.
     // In STDIO mode, tool list is registered once — hot reload updates connections and
     // tool registry, but STDIO clients won't see added/removed tools without restart.
     // HTTP transport creates a new server per request, so tool changes apply immediately.
-    const stopConfigWatcher = startConfigWatcher(connectorManager);
+    const stopConfigWatcher = startConfigWatcher({
+      connectorManager,
+      initialTools: sourceConfigsData.tools,
+    });
 
     // Create MCP server factory function for HTTP transport
     // Note: This must be created AFTER ConnectorManager is initialized

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { listSources, getSource } from "./api/sources.js";
 import { listRequests } from "./api/requests.js";
 import { generateStartupTable, buildSourceDisplayInfo } from "./utils/startup-table.js";
 import { getToolsForSource } from "./utils/tool-metadata.js";
+import { startConfigWatcher } from "./utils/config-watcher.js";
 
 // Create __dirname equivalent for ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -101,6 +102,9 @@ See documentation for more details on configuring database connections.
     });
     console.error("Tool registry initialized");
 
+    // Start watching TOML config file for hot reload (only when using TOML config)
+    const stopConfigWatcher = startConfigWatcher(connectorManager);
+
     // Create MCP server factory function for HTTP transport
     // Note: This must be created AFTER ConnectorManager is initialized
     const createServer = () => {
@@ -147,6 +151,11 @@ See documentation for more details on configuring database connections.
       isDemo
     );
     console.error(generateStartupTable(sourceDisplayInfos));
+
+    // Clean up config watcher on process exit (covers both transports)
+    const cleanupOnExit = () => { stopConfigWatcher?.(); };
+    process.on("SIGINT", cleanupOnExit);
+    process.on("SIGTERM", cleanupOnExit);
 
     // Set up transport-specific server
     if (transportData.type === "http") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,7 +102,10 @@ See documentation for more details on configuring database connections.
     });
     console.error("Tool registry initialized");
 
-    // Start watching TOML config file for hot reload (only when using TOML config)
+    // Start watching TOML config file for hot reload (only when using TOML config).
+    // In STDIO mode, tool list is registered once — hot reload updates connections and
+    // tool registry, but STDIO clients won't see added/removed tools without restart.
+    // HTTP transport creates a new server per request, so tool changes apply immediately.
     const stopConfigWatcher = startConfigWatcher(connectorManager);
 
     // Create MCP server factory function for HTTP transport
@@ -152,10 +155,8 @@ See documentation for more details on configuring database connections.
     );
     console.error(generateStartupTable(sourceDisplayInfos));
 
-    // Clean up config watcher on process exit (covers both transports)
-    const cleanupOnExit = () => { stopConfigWatcher?.(); };
-    process.on("SIGINT", cleanupOnExit);
-    process.on("SIGTERM", cleanupOnExit);
+    // Clean up config watcher when the process is exiting (covers both transports)
+    process.on("exit", () => { stopConfigWatcher?.(); });
 
     // Set up transport-specific server
     if (transportData.type === "http") {

--- a/src/utils/__tests__/config-watcher.test.ts
+++ b/src/utils/__tests__/config-watcher.test.ts
@@ -25,6 +25,10 @@ function createMockManager(overrides: Partial<Record<string, any>> = {}) {
   } as unknown as ConnectorManager;
 }
 
+function createOptions(connectorManager: ConnectorManager, initialTools?: any[]) {
+  return { connectorManager, initialTools };
+}
+
 describe("startConfigWatcher", () => {
   let mockWatcher: { on: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn>; unref: ReturnType<typeof vi.fn> };
   let watchCallback: (eventType: string) => void;
@@ -49,7 +53,7 @@ describe("startConfigWatcher", () => {
 
   it("should return null when no TOML config path exists", () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue(null);
-    const cleanup = startConfigWatcher(createMockManager());
+    const cleanup = startConfigWatcher(createOptions(createMockManager()));
 
     expect(cleanup).toBeNull();
     expect(fs.watch).not.toHaveBeenCalled();
@@ -57,7 +61,7 @@ describe("startConfigWatcher", () => {
 
   it("should start watching when TOML config exists", () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
-    const cleanup = startConfigWatcher(createMockManager());
+    const cleanup = startConfigWatcher(createOptions(createMockManager()));
 
     expect(cleanup).toBeTypeOf("function");
     expect(fs.watch).toHaveBeenCalledWith("/path/to/dbhub.toml", expect.any(Function));
@@ -74,7 +78,7 @@ describe("startConfigWatcher", () => {
     vi.mocked(loadTomlConfig).mockReturnValue(newConfig);
     const mockManager = createMockManager();
 
-    startConfigWatcher(mockManager);
+    startConfigWatcher(createOptions(mockManager));
     watchCallback("change");
 
     // Before debounce, nothing should happen
@@ -101,7 +105,7 @@ describe("startConfigWatcher", () => {
     });
     const mockManager = createMockManager();
 
-    startConfigWatcher(mockManager);
+    startConfigWatcher(createOptions(mockManager));
     watchCallback("rename");
     await vi.advanceTimersByTimeAsync(500);
 
@@ -117,7 +121,7 @@ describe("startConfigWatcher", () => {
     });
     const mockManager = createMockManager();
 
-    startConfigWatcher(mockManager);
+    startConfigWatcher(createOptions(mockManager));
     watchCallback("change");
     watchCallback("change");
     watchCallback("change");
@@ -133,7 +137,7 @@ describe("startConfigWatcher", () => {
     });
     const mockManager = createMockManager();
 
-    startConfigWatcher(mockManager);
+    startConfigWatcher(createOptions(mockManager));
     watchCallback("change");
     await vi.advanceTimersByTimeAsync(500);
 
@@ -145,14 +149,14 @@ describe("startConfigWatcher", () => {
     vi.mocked(loadTomlConfig).mockReturnValue(null);
     const mockManager = createMockManager();
 
-    startConfigWatcher(mockManager);
+    startConfigWatcher(createOptions(mockManager));
     watchCallback("change");
     await vi.advanceTimersByTimeAsync(500);
 
     expect(mockManager.disconnect).not.toHaveBeenCalled();
   });
 
-  it("should rollback to old config (sources + tools) when connectWithSources fails", async () => {
+  it("should rollback with initial tools when connectWithSources fails", async () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
     const newConfig = {
       sources: [{ id: "bad_db", type: "postgres" as const, dsn: "postgres://localhost/bad" }],
@@ -162,6 +166,7 @@ describe("startConfigWatcher", () => {
     vi.mocked(loadTomlConfig).mockReturnValue(newConfig);
 
     const oldSources = [{ id: "old_db", type: "sqlite" as const, dsn: "sqlite:///:memory:" }];
+    const oldTools = [{ name: "execute_sql" as const, source: "old_db" }];
     const mockManager = createMockManager({
       connectWithSources: vi.fn()
         .mockRejectedValueOnce(new Error("Connection refused"))
@@ -169,63 +174,42 @@ describe("startConfigWatcher", () => {
       getAllSourceConfigs: vi.fn().mockReturnValue(oldSources),
     });
 
-    startConfigWatcher(mockManager);
+    startConfigWatcher(createOptions(mockManager, oldTools));
     watchCallback("change");
     await vi.advanceTimersByTimeAsync(500);
 
     // Should have attempted new config, then rolled back to old
-    expect(mockManager.connectWithSources).toHaveBeenCalledTimes(2);
     expect(mockManager.connectWithSources).toHaveBeenNthCalledWith(1, newConfig.sources);
-    expect(mockManager.connectWithSources).toHaveBeenNthCalledWith(2, oldSources);
-    // Rollback should restore tools too (undefined for initial config)
-    expect(initializeToolRegistry).toHaveBeenLastCalledWith({ sources: oldSources, tools: undefined });
+    expect(mockManager.connectWithSources).toHaveBeenLastCalledWith(oldSources);
+    // Rollback should restore initial tools
+    expect(initializeToolRegistry).toHaveBeenLastCalledWith({ sources: oldSources, tools: oldTools });
   });
 
-  it("should not drop file changes that arrive during reload", async () => {
-    vi.useRealTimers(); // Use real timers for this async-heavy test
+  it("should disconnect partial state before rollback", async () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
-
-    let loadCount = 0;
-    vi.mocked(loadTomlConfig).mockImplementation(() => {
-      loadCount++;
-      return {
-        sources: [{ id: `db_${loadCount}`, type: "sqlite" as const, dsn: "sqlite:///:memory:" }],
-        tools: [],
-        source: "dbhub.toml",
-      };
+    vi.mocked(loadTomlConfig).mockReturnValue({
+      sources: [{ id: "bad", type: "postgres" as const, dsn: "postgres://localhost/bad" }],
+      tools: [],
+      source: "dbhub.toml",
     });
 
-    // First disconnect blocks until we resolve it
-    let resolveDisconnect!: () => void;
     const mockManager = createMockManager({
-      disconnect: vi.fn()
-        .mockImplementationOnce(() => new Promise<void>(r => { resolveDisconnect = r; }))
-        .mockResolvedValue(undefined),
+      connectWithSources: vi.fn()
+        .mockRejectedValueOnce(new Error("Partial failure"))
+        .mockResolvedValueOnce(undefined),
     });
 
-    startConfigWatcher(mockManager);
-
-    // Trigger first change — after DEBOUNCE_MS, reload starts and blocks on disconnect
+    startConfigWatcher(createOptions(mockManager));
     watchCallback("change");
-    await new Promise(r => setTimeout(r, 600));
+    await vi.advanceTimersByTimeAsync(500);
 
-    // Reload is in progress. Fire another change — it should set reloadPending
-    watchCallback("change");
-    await new Promise(r => setTimeout(r, 600));
-
-    // Now unblock the first disconnect
-    resolveDisconnect();
-
-    // Wait for both reloads to complete
-    await new Promise(r => setTimeout(r, 1200));
-
-    // Config should have been loaded at least twice
-    expect(loadCount).toBeGreaterThanOrEqual(2);
+    // disconnect called twice: once for initial teardown, once to clean up partial state before rollback
+    expect(mockManager.disconnect).toHaveBeenCalledTimes(2);
   });
 
   it("should clean up watcher on cleanup call", () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
-    const cleanup = startConfigWatcher(createMockManager());
+    const cleanup = startConfigWatcher(createOptions(createMockManager()));
     cleanup!();
 
     expect(mockWatcher.close).toHaveBeenCalled();

--- a/src/utils/__tests__/config-watcher.test.ts
+++ b/src/utils/__tests__/config-watcher.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import { startConfigWatcher } from "../config-watcher.js";
+import type { ConnectorManager } from "../../connectors/manager.js";
+
+// Mock dependencies
+vi.mock("fs");
+vi.mock("../../config/toml-loader.js", () => ({
+  resolveTomlConfigPath: vi.fn(),
+  loadTomlConfig: vi.fn(),
+}));
+vi.mock("../../tools/registry.js", () => ({
+  initializeToolRegistry: vi.fn(),
+}));
+
+import { resolveTomlConfigPath, loadTomlConfig } from "../../config/toml-loader.js";
+import { initializeToolRegistry } from "../../tools/registry.js";
+
+describe("startConfigWatcher", () => {
+  let mockWatcher: { on: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> };
+  let watchCallback: (eventType: string) => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockWatcher = {
+      on: vi.fn().mockReturnThis(),
+      close: vi.fn(),
+    };
+    vi.mocked(fs.watch).mockImplementation((_path: any, cb: any) => {
+      watchCallback = cb;
+      return mockWatcher as any;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("should return null when no TOML config path exists", () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue(null);
+    const mockManager = {} as ConnectorManager;
+
+    const cleanup = startConfigWatcher(mockManager);
+
+    expect(cleanup).toBeNull();
+    expect(fs.watch).not.toHaveBeenCalled();
+  });
+
+  it("should start watching when TOML config exists", () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    const mockManager = {} as ConnectorManager;
+
+    const cleanup = startConfigWatcher(mockManager);
+
+    expect(cleanup).toBeTypeOf("function");
+    expect(fs.watch).toHaveBeenCalledWith("/path/to/dbhub.toml", expect.any(Function));
+  });
+
+  it("should reload config on file change after debounce", async () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    const newConfig = {
+      sources: [{ id: "new_db", type: "postgres" as const, dsn: "postgres://localhost/new" }],
+      tools: [],
+      source: "dbhub.toml",
+    };
+    vi.mocked(loadTomlConfig).mockReturnValue(newConfig);
+
+    const mockManager = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      connectWithSources: vi.fn().mockResolvedValue(undefined),
+      getAllSourceConfigs: vi.fn().mockReturnValue([]),
+    } as unknown as ConnectorManager;
+
+    startConfigWatcher(mockManager);
+
+    // Trigger file change
+    watchCallback("change");
+
+    // Before debounce, nothing should happen
+    expect(mockManager.disconnect).not.toHaveBeenCalled();
+
+    // After debounce
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(loadTomlConfig).toHaveBeenCalled();
+    expect(mockManager.disconnect).toHaveBeenCalled();
+    expect(mockManager.connectWithSources).toHaveBeenCalledWith(newConfig.sources);
+    expect(initializeToolRegistry).toHaveBeenCalledWith({
+      sources: newConfig.sources,
+      tools: newConfig.tools,
+    });
+  });
+
+  it("should debounce rapid file changes", async () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    vi.mocked(loadTomlConfig).mockReturnValue({
+      sources: [{ id: "db", type: "sqlite" as const, dsn: "sqlite:///:memory:" }],
+      tools: [],
+      source: "dbhub.toml",
+    });
+
+    const mockManager = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      connectWithSources: vi.fn().mockResolvedValue(undefined),
+      getAllSourceConfigs: vi.fn().mockReturnValue([]),
+    } as unknown as ConnectorManager;
+
+    startConfigWatcher(mockManager);
+
+    // Trigger multiple rapid changes
+    watchCallback("change");
+    watchCallback("change");
+    watchCallback("change");
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Should only reload once
+    expect(mockManager.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep existing connections when new config is invalid", async () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    vi.mocked(loadTomlConfig).mockImplementation(() => {
+      throw new Error("Invalid TOML");
+    });
+
+    const mockManager = {
+      disconnect: vi.fn(),
+      connectWithSources: vi.fn(),
+    } as unknown as ConnectorManager;
+
+    startConfigWatcher(mockManager);
+    watchCallback("change");
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Should NOT disconnect existing connections
+    expect(mockManager.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("should keep existing connections when loadTomlConfig returns null", async () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    vi.mocked(loadTomlConfig).mockReturnValue(null);
+
+    const mockManager = {
+      disconnect: vi.fn(),
+      connectWithSources: vi.fn(),
+    } as unknown as ConnectorManager;
+
+    startConfigWatcher(mockManager);
+    watchCallback("change");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(mockManager.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("should rollback to old config when connectWithSources fails", async () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    const newConfig = {
+      sources: [{ id: "bad_db", type: "postgres" as const, dsn: "postgres://localhost/bad" }],
+      tools: [],
+      source: "dbhub.toml",
+    };
+    vi.mocked(loadTomlConfig).mockReturnValue(newConfig);
+
+    const oldSources = [{ id: "old_db", type: "sqlite" as const, dsn: "sqlite:///:memory:" }];
+    const mockManager = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      connectWithSources: vi.fn()
+        .mockRejectedValueOnce(new Error("Connection refused"))
+        .mockResolvedValueOnce(undefined),
+      getAllSourceConfigs: vi.fn().mockReturnValue(oldSources),
+    } as unknown as ConnectorManager;
+
+    startConfigWatcher(mockManager);
+    watchCallback("change");
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Should have attempted new config, then rolled back to old
+    expect(mockManager.connectWithSources).toHaveBeenCalledTimes(2);
+    expect(mockManager.connectWithSources).toHaveBeenNthCalledWith(1, newConfig.sources);
+    expect(mockManager.connectWithSources).toHaveBeenNthCalledWith(2, oldSources);
+    expect(initializeToolRegistry).toHaveBeenCalledWith({ sources: oldSources });
+  });
+
+  it("should clean up watcher on cleanup call", () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    const mockManager = {} as ConnectorManager;
+
+    const cleanup = startConfigWatcher(mockManager);
+    cleanup!();
+
+    expect(mockWatcher.close).toHaveBeenCalled();
+  });
+
+  it("should ignore non-change events", async () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    const mockManager = {
+      disconnect: vi.fn(),
+      connectWithSources: vi.fn(),
+    } as unknown as ConnectorManager;
+
+    startConfigWatcher(mockManager);
+    watchCallback("rename");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(mockManager.disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/config-watcher.test.ts
+++ b/src/utils/__tests__/config-watcher.test.ts
@@ -96,22 +96,6 @@ describe("startConfigWatcher", () => {
     });
   });
 
-  it("should reload on rename events (atomic editor writes)", async () => {
-    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
-    vi.mocked(loadTomlConfig).mockReturnValue({
-      sources: [{ id: "db", type: "sqlite" as const, dsn: "sqlite:///:memory:" }],
-      tools: [],
-      source: "dbhub.toml",
-    });
-    const mockManager = createMockManager();
-
-    startConfigWatcher(createOptions(mockManager));
-    watchCallback("rename");
-    await vi.advanceTimersByTimeAsync(500);
-
-    expect(mockManager.disconnect).toHaveBeenCalled();
-  });
-
   it("should debounce rapid file changes", async () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
     vi.mocked(loadTomlConfig).mockReturnValue({
@@ -178,10 +162,8 @@ describe("startConfigWatcher", () => {
     watchCallback("change");
     await vi.advanceTimersByTimeAsync(500);
 
-    // Should have attempted new config, then rolled back to old
     expect(mockManager.connectWithSources).toHaveBeenNthCalledWith(1, newConfig.sources);
     expect(mockManager.connectWithSources).toHaveBeenLastCalledWith(oldSources);
-    // Rollback should restore initial tools
     expect(initializeToolRegistry).toHaveBeenLastCalledWith({ sources: oldSources, tools: oldTools });
   });
 
@@ -205,39 +187,6 @@ describe("startConfigWatcher", () => {
 
     // disconnect called twice: once for initial teardown, once to clean up partial state before rollback
     expect(mockManager.disconnect).toHaveBeenCalledTimes(2);
-  });
-
-  it("should re-establish watcher on error after retry delay", async () => {
-    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
-
-    // Capture error handlers per watcher instance
-    const errorHandlers: ((err: Error) => void)[] = [];
-    const watchers: { on: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn>; unref: ReturnType<typeof vi.fn> }[] = [];
-
-    vi.mocked(fs.watch).mockImplementation((_path: any, cb: any) => {
-      const w = { on: vi.fn().mockReturnThis(), close: vi.fn(), unref: vi.fn() };
-      w.on.mockImplementation((event: string, handler: any) => {
-        if (event === "error") errorHandlers.push(handler);
-        return w;
-      });
-      watchers.push(w);
-      watchCallback = cb;
-      return w as any;
-    });
-
-    startConfigWatcher(createOptions(createMockManager()));
-    const watchCallsBefore = vi.mocked(fs.watch).mock.calls.length;
-
-    // Simulate a watcher error
-    errorHandlers[0](new Error("ENOENT"));
-
-    // Old watcher closed immediately
-    expect(watchers[0].close).toHaveBeenCalled();
-
-    // New watcher created after retry delay (1000ms)
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(vi.mocked(fs.watch).mock.calls.length - watchCallsBefore).toBe(1);
-    expect(watchers).toHaveLength(2);
   });
 
   it("should clean up watcher on cleanup call", () => {

--- a/src/utils/__tests__/config-watcher.test.ts
+++ b/src/utils/__tests__/config-watcher.test.ts
@@ -207,7 +207,7 @@ describe("startConfigWatcher", () => {
     expect(mockManager.disconnect).toHaveBeenCalledTimes(2);
   });
 
-  it("should re-establish watcher on error", () => {
+  it("should re-establish watcher on error after retry delay", async () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
 
     // Capture error handlers per watcher instance
@@ -226,14 +226,16 @@ describe("startConfigWatcher", () => {
     });
 
     startConfigWatcher(createOptions(createMockManager()));
-
     const watchCallsBefore = vi.mocked(fs.watch).mock.calls.length;
 
     // Simulate a watcher error
     errorHandlers[0](new Error("ENOENT"));
 
-    // Old watcher closed, new one created (one additional fs.watch call)
+    // Old watcher closed immediately
     expect(watchers[0].close).toHaveBeenCalled();
+
+    // New watcher created after retry delay (1000ms)
+    await vi.advanceTimersByTimeAsync(1000);
     expect(vi.mocked(fs.watch).mock.calls.length - watchCallsBefore).toBe(1);
     expect(watchers).toHaveLength(2);
   });

--- a/src/utils/__tests__/config-watcher.test.ts
+++ b/src/utils/__tests__/config-watcher.test.ts
@@ -207,6 +207,37 @@ describe("startConfigWatcher", () => {
     expect(mockManager.disconnect).toHaveBeenCalledTimes(2);
   });
 
+  it("should re-establish watcher on error", () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+
+    // Capture error handlers per watcher instance
+    const errorHandlers: ((err: Error) => void)[] = [];
+    const watchers: { on: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn>; unref: ReturnType<typeof vi.fn> }[] = [];
+
+    vi.mocked(fs.watch).mockImplementation((_path: any, cb: any) => {
+      const w = { on: vi.fn().mockReturnThis(), close: vi.fn(), unref: vi.fn() };
+      w.on.mockImplementation((event: string, handler: any) => {
+        if (event === "error") errorHandlers.push(handler);
+        return w;
+      });
+      watchers.push(w);
+      watchCallback = cb;
+      return w as any;
+    });
+
+    startConfigWatcher(createOptions(createMockManager()));
+
+    const watchCallsBefore = vi.mocked(fs.watch).mock.calls.length;
+
+    // Simulate a watcher error
+    errorHandlers[0](new Error("ENOENT"));
+
+    // Old watcher closed, new one created (one additional fs.watch call)
+    expect(watchers[0].close).toHaveBeenCalled();
+    expect(vi.mocked(fs.watch).mock.calls.length - watchCallsBefore).toBe(1);
+    expect(watchers).toHaveLength(2);
+  });
+
   it("should clean up watcher on cleanup call", () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
     const cleanup = startConfigWatcher(createOptions(createMockManager()));

--- a/src/utils/__tests__/config-watcher.test.ts
+++ b/src/utils/__tests__/config-watcher.test.ts
@@ -16,8 +16,17 @@ vi.mock("../../tools/registry.js", () => ({
 import { resolveTomlConfigPath, loadTomlConfig } from "../../config/toml-loader.js";
 import { initializeToolRegistry } from "../../tools/registry.js";
 
+function createMockManager(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    connectWithSources: vi.fn().mockResolvedValue(undefined),
+    getAllSourceConfigs: vi.fn().mockReturnValue([]),
+    ...overrides,
+  } as unknown as ConnectorManager;
+}
+
 describe("startConfigWatcher", () => {
-  let mockWatcher: { on: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> };
+  let mockWatcher: { on: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn>; unref: ReturnType<typeof vi.fn> };
   let watchCallback: (eventType: string) => void;
 
   beforeEach(() => {
@@ -25,6 +34,7 @@ describe("startConfigWatcher", () => {
     mockWatcher = {
       on: vi.fn().mockReturnThis(),
       close: vi.fn(),
+      unref: vi.fn(),
     };
     vi.mocked(fs.watch).mockImplementation((_path: any, cb: any) => {
       watchCallback = cb;
@@ -39,9 +49,7 @@ describe("startConfigWatcher", () => {
 
   it("should return null when no TOML config path exists", () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue(null);
-    const mockManager = {} as ConnectorManager;
-
-    const cleanup = startConfigWatcher(mockManager);
+    const cleanup = startConfigWatcher(createMockManager());
 
     expect(cleanup).toBeNull();
     expect(fs.watch).not.toHaveBeenCalled();
@@ -49,12 +57,11 @@ describe("startConfigWatcher", () => {
 
   it("should start watching when TOML config exists", () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
-    const mockManager = {} as ConnectorManager;
-
-    const cleanup = startConfigWatcher(mockManager);
+    const cleanup = startConfigWatcher(createMockManager());
 
     expect(cleanup).toBeTypeOf("function");
     expect(fs.watch).toHaveBeenCalledWith("/path/to/dbhub.toml", expect.any(Function));
+    expect(mockWatcher.unref).toHaveBeenCalled();
   });
 
   it("should reload config on file change after debounce", async () => {
@@ -65,16 +72,9 @@ describe("startConfigWatcher", () => {
       source: "dbhub.toml",
     };
     vi.mocked(loadTomlConfig).mockReturnValue(newConfig);
-
-    const mockManager = {
-      disconnect: vi.fn().mockResolvedValue(undefined),
-      connectWithSources: vi.fn().mockResolvedValue(undefined),
-      getAllSourceConfigs: vi.fn().mockReturnValue([]),
-    } as unknown as ConnectorManager;
+    const mockManager = createMockManager();
 
     startConfigWatcher(mockManager);
-
-    // Trigger file change
     watchCallback("change");
 
     // Before debounce, nothing should happen
@@ -92,6 +92,22 @@ describe("startConfigWatcher", () => {
     });
   });
 
+  it("should reload on rename events (atomic editor writes)", async () => {
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+    vi.mocked(loadTomlConfig).mockReturnValue({
+      sources: [{ id: "db", type: "sqlite" as const, dsn: "sqlite:///:memory:" }],
+      tools: [],
+      source: "dbhub.toml",
+    });
+    const mockManager = createMockManager();
+
+    startConfigWatcher(mockManager);
+    watchCallback("rename");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(mockManager.disconnect).toHaveBeenCalled();
+  });
+
   it("should debounce rapid file changes", async () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
     vi.mocked(loadTomlConfig).mockReturnValue({
@@ -99,23 +115,14 @@ describe("startConfigWatcher", () => {
       tools: [],
       source: "dbhub.toml",
     });
-
-    const mockManager = {
-      disconnect: vi.fn().mockResolvedValue(undefined),
-      connectWithSources: vi.fn().mockResolvedValue(undefined),
-      getAllSourceConfigs: vi.fn().mockReturnValue([]),
-    } as unknown as ConnectorManager;
+    const mockManager = createMockManager();
 
     startConfigWatcher(mockManager);
-
-    // Trigger multiple rapid changes
     watchCallback("change");
     watchCallback("change");
     watchCallback("change");
-
     await vi.advanceTimersByTimeAsync(500);
 
-    // Should only reload once
     expect(mockManager.disconnect).toHaveBeenCalledTimes(1);
   });
 
@@ -124,28 +131,19 @@ describe("startConfigWatcher", () => {
     vi.mocked(loadTomlConfig).mockImplementation(() => {
       throw new Error("Invalid TOML");
     });
-
-    const mockManager = {
-      disconnect: vi.fn(),
-      connectWithSources: vi.fn(),
-    } as unknown as ConnectorManager;
+    const mockManager = createMockManager();
 
     startConfigWatcher(mockManager);
     watchCallback("change");
     await vi.advanceTimersByTimeAsync(500);
 
-    // Should NOT disconnect existing connections
     expect(mockManager.disconnect).not.toHaveBeenCalled();
   });
 
   it("should keep existing connections when loadTomlConfig returns null", async () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
     vi.mocked(loadTomlConfig).mockReturnValue(null);
-
-    const mockManager = {
-      disconnect: vi.fn(),
-      connectWithSources: vi.fn(),
-    } as unknown as ConnectorManager;
+    const mockManager = createMockManager();
 
     startConfigWatcher(mockManager);
     watchCallback("change");
@@ -154,23 +152,22 @@ describe("startConfigWatcher", () => {
     expect(mockManager.disconnect).not.toHaveBeenCalled();
   });
 
-  it("should rollback to old config when connectWithSources fails", async () => {
+  it("should rollback to old config (sources + tools) when connectWithSources fails", async () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
     const newConfig = {
       sources: [{ id: "bad_db", type: "postgres" as const, dsn: "postgres://localhost/bad" }],
-      tools: [],
+      tools: [{ name: "execute_sql" as const, source: "bad_db", readonly: true }],
       source: "dbhub.toml",
     };
     vi.mocked(loadTomlConfig).mockReturnValue(newConfig);
 
     const oldSources = [{ id: "old_db", type: "sqlite" as const, dsn: "sqlite:///:memory:" }];
-    const mockManager = {
-      disconnect: vi.fn().mockResolvedValue(undefined),
+    const mockManager = createMockManager({
       connectWithSources: vi.fn()
         .mockRejectedValueOnce(new Error("Connection refused"))
         .mockResolvedValueOnce(undefined),
       getAllSourceConfigs: vi.fn().mockReturnValue(oldSources),
-    } as unknown as ConnectorManager;
+    });
 
     startConfigWatcher(mockManager);
     watchCallback("change");
@@ -180,30 +177,57 @@ describe("startConfigWatcher", () => {
     expect(mockManager.connectWithSources).toHaveBeenCalledTimes(2);
     expect(mockManager.connectWithSources).toHaveBeenNthCalledWith(1, newConfig.sources);
     expect(mockManager.connectWithSources).toHaveBeenNthCalledWith(2, oldSources);
-    expect(initializeToolRegistry).toHaveBeenCalledWith({ sources: oldSources });
+    // Rollback should restore tools too (undefined for initial config)
+    expect(initializeToolRegistry).toHaveBeenLastCalledWith({ sources: oldSources, tools: undefined });
+  });
+
+  it("should not drop file changes that arrive during reload", async () => {
+    vi.useRealTimers(); // Use real timers for this async-heavy test
+    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
+
+    let loadCount = 0;
+    vi.mocked(loadTomlConfig).mockImplementation(() => {
+      loadCount++;
+      return {
+        sources: [{ id: `db_${loadCount}`, type: "sqlite" as const, dsn: "sqlite:///:memory:" }],
+        tools: [],
+        source: "dbhub.toml",
+      };
+    });
+
+    // First disconnect blocks until we resolve it
+    let resolveDisconnect!: () => void;
+    const mockManager = createMockManager({
+      disconnect: vi.fn()
+        .mockImplementationOnce(() => new Promise<void>(r => { resolveDisconnect = r; }))
+        .mockResolvedValue(undefined),
+    });
+
+    startConfigWatcher(mockManager);
+
+    // Trigger first change — after DEBOUNCE_MS, reload starts and blocks on disconnect
+    watchCallback("change");
+    await new Promise(r => setTimeout(r, 600));
+
+    // Reload is in progress. Fire another change — it should set reloadPending
+    watchCallback("change");
+    await new Promise(r => setTimeout(r, 600));
+
+    // Now unblock the first disconnect
+    resolveDisconnect();
+
+    // Wait for both reloads to complete
+    await new Promise(r => setTimeout(r, 1200));
+
+    // Config should have been loaded at least twice
+    expect(loadCount).toBeGreaterThanOrEqual(2);
   });
 
   it("should clean up watcher on cleanup call", () => {
     vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
-    const mockManager = {} as ConnectorManager;
-
-    const cleanup = startConfigWatcher(mockManager);
+    const cleanup = startConfigWatcher(createMockManager());
     cleanup!();
 
     expect(mockWatcher.close).toHaveBeenCalled();
-  });
-
-  it("should ignore non-change events", async () => {
-    vi.mocked(resolveTomlConfigPath).mockReturnValue("/path/to/dbhub.toml");
-    const mockManager = {
-      disconnect: vi.fn(),
-      connectWithSources: vi.fn(),
-    } as unknown as ConnectorManager;
-
-    startConfigWatcher(mockManager);
-    watchCallback("rename");
-    await vi.advanceTimersByTimeAsync(500);
-
-    expect(mockManager.disconnect).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -132,7 +132,11 @@ export function startConfigWatcher(options: ConfigWatcherOptions): (() => void) 
   };
   createWatcher();
 
-  console.error(`Watching ${configPath} for changes (hot reload enabled)`);
+  if (watcher) {
+    console.error(`Watching ${configPath} for changes (hot reload enabled)`);
+  } else {
+    console.error(`Hot reload disabled: failed to watch ${configPath} (see errors above)`);
+  }
 
   // Return cleanup function
   return () => {

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -6,6 +6,11 @@ import type { SourceConfig, ToolConfig } from "../types/config.js";
 
 const DEBOUNCE_MS = 500;
 
+interface ConfigWatcherOptions {
+  connectorManager: ConnectorManager;
+  initialTools?: ToolConfig[];
+}
+
 /**
  * Watch the TOML configuration file for changes and reload sources automatically.
  * Only applicable when using TOML-based configuration.
@@ -15,7 +20,8 @@ const DEBOUNCE_MS = 500;
  * but STDIO clients won't see added/removed tools until a full server restart.
  * HTTP transport creates a fresh server per request, so tool changes take effect immediately.
  */
-export function startConfigWatcher(connectorManager: ConnectorManager): (() => void) | null {
+export function startConfigWatcher(options: ConfigWatcherOptions): (() => void) | null {
+  const { connectorManager, initialTools } = options;
   const configPath = resolveTomlConfigPath();
   if (!configPath) {
     return null;
@@ -27,7 +33,7 @@ export function startConfigWatcher(connectorManager: ConnectorManager): (() => v
 
   // Track last known-good config for rollback (sources + tools)
   let lastGoodSources: SourceConfig[] = connectorManager.getAllSourceConfigs();
-  let lastGoodTools: ToolConfig[] | undefined;
+  let lastGoodTools: ToolConfig[] | undefined = initialTools;
 
   const scheduleReload = () => {
     if (debounceTimer) {
@@ -78,6 +84,8 @@ export function startConfigWatcher(connectorManager: ConnectorManager): (() => v
         console.error("Configuration reloaded successfully.");
       } catch (connectError) {
         console.error("Failed to connect with new config, rolling back:", connectError);
+        // Clean up any partial connections before rollback
+        try { await connectorManager.disconnect(); } catch { /* best effort */ }
         try {
           await connectorManager.connectWithSources(oldSources);
           initializeToolRegistry({ sources: oldSources, tools: oldTools });
@@ -103,22 +111,22 @@ export function startConfigWatcher(connectorManager: ConnectorManager): (() => v
     }
   };
 
-  let watcher = fs.watch(configPath, onWatchEvent);
-  watcher.unref?.();
-
-  // Re-establish watch on error (e.g., file replaced by atomic rename)
-  watcher.on("error", () => {
-    try {
-      watcher.close();
-      watcher = fs.watch(configPath, onWatchEvent);
-      watcher.unref?.();
-      watcher.on("error", (err) => {
-        console.error("Config file watcher error:", err);
-      });
-    } catch (rewatchError) {
-      console.error("Failed to re-establish config file watcher:", rewatchError);
-    }
-  });
+  // Create watcher with recursive re-watch on error (file replaced by atomic rename)
+  let watcher: fs.FSWatcher;
+  const createWatcher = () => {
+    watcher = fs.watch(configPath, onWatchEvent);
+    watcher.unref?.();
+    watcher.on("error", (err) => {
+      console.error("Config file watcher error:", err);
+      try {
+        watcher.close();
+        createWatcher();
+      } catch (rewatchError) {
+        console.error("Failed to re-establish config file watcher:", rewatchError);
+      }
+    });
+  };
+  createWatcher();
 
   console.error(`Watching ${configPath} for changes (hot reload enabled)`);
 

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -111,23 +111,33 @@ export function startConfigWatcher(options: ConfigWatcherOptions): (() => void) 
     }
   };
 
-  // Create watcher with recursive re-watch on error (file replaced by atomic rename)
+  // Create watcher with re-watch on error (file replaced by atomic rename).
+  // Uses delayed retry to avoid tight loops on persistent failures.
+  const WATCHER_RETRY_MS = 1000;
   let watcher: fs.FSWatcher | null = null;
+  let stopped = false;
+
+  const retryCreateWatcher = () => {
+    if (stopped) return;
+    const timer = setTimeout(createWatcher, WATCHER_RETRY_MS);
+    timer.unref?.();
+  };
+
   const createWatcher = () => {
+    if (stopped) return;
     try {
       watcher = fs.watch(configPath, onWatchEvent);
       watcher.unref?.();
       watcher.on("error", (err) => {
         console.error("Config file watcher error:", err);
-        try {
-          watcher?.close();
-        } catch { /* best effort */ }
+        try { watcher?.close(); } catch { /* best effort */ }
         watcher = null;
-        createWatcher();
+        retryCreateWatcher();
       });
     } catch (watchError) {
       console.error("Failed to establish config file watcher:", watchError);
       watcher = null;
+      retryCreateWatcher();
     }
   };
   createWatcher();
@@ -140,9 +150,11 @@ export function startConfigWatcher(options: ConfigWatcherOptions): (() => void) 
 
   // Return cleanup function
   return () => {
+    stopped = true;
     if (debounceTimer) {
       clearTimeout(debounceTimer);
     }
     watcher?.close();
+    watcher = null;
   };
 }

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -114,17 +114,21 @@ export function startConfigWatcher(options: ConfigWatcherOptions): (() => void) 
   // Create watcher with recursive re-watch on error (file replaced by atomic rename)
   let watcher: fs.FSWatcher | null = null;
   const createWatcher = () => {
-    watcher = fs.watch(configPath, onWatchEvent);
-    watcher.unref?.();
-    watcher.on("error", (err) => {
-      console.error("Config file watcher error:", err);
-      try {
-        watcher?.close();
+    try {
+      watcher = fs.watch(configPath, onWatchEvent);
+      watcher.unref?.();
+      watcher.on("error", (err) => {
+        console.error("Config file watcher error:", err);
+        try {
+          watcher?.close();
+        } catch { /* best effort */ }
+        watcher = null;
         createWatcher();
-      } catch (rewatchError) {
-        console.error("Failed to re-establish config file watcher:", rewatchError);
-      }
-    });
+      });
+    } catch (watchError) {
+      console.error("Failed to establish config file watcher:", watchError);
+      watcher = null;
+    }
   };
   createWatcher();
 

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -1,0 +1,93 @@
+import fs from "fs";
+import { loadTomlConfig, resolveTomlConfigPath } from "../config/toml-loader.js";
+import { ConnectorManager } from "../connectors/manager.js";
+import { initializeToolRegistry } from "../tools/registry.js";
+
+const DEBOUNCE_MS = 500;
+
+/**
+ * Watch the TOML configuration file for changes and reload sources automatically.
+ * Only applicable when using TOML-based configuration.
+ */
+export function startConfigWatcher(connectorManager: ConnectorManager): (() => void) | null {
+  const configPath = resolveTomlConfigPath();
+  if (!configPath) {
+    return null;
+  }
+
+  let debounceTimer: NodeJS.Timeout | null = null;
+  let isReloading = false;
+
+  const reload = async () => {
+    if (isReloading) {
+      return;
+    }
+    isReloading = true;
+
+    try {
+      console.error(`\nDetected change in ${configPath}, reloading configuration...`);
+
+      // Parse and validate new config — if this throws, keep existing connections
+      const newConfig = loadTomlConfig();
+      if (!newConfig) {
+        console.error("Config reload: failed to load TOML config, keeping existing connections.");
+        return;
+      }
+
+      // Save old config for rollback if reconnection fails
+      const oldSources = connectorManager.getAllSourceConfigs();
+
+      // Disconnect all existing sources
+      await connectorManager.disconnect();
+
+      try {
+        // Reconnect with new sources
+        await connectorManager.connectWithSources(newConfig.sources);
+
+        // Re-initialize tool registry with new config
+        initializeToolRegistry({
+          sources: newConfig.sources,
+          tools: newConfig.tools,
+        });
+
+        console.error("Configuration reloaded successfully.");
+      } catch (connectError) {
+        console.error("Failed to connect with new config, rolling back:", connectError);
+        try {
+          await connectorManager.connectWithSources(oldSources);
+          initializeToolRegistry({ sources: oldSources });
+          console.error("Rolled back to previous configuration.");
+        } catch (rollbackError) {
+          console.error("Rollback also failed, server has no active connections:", rollbackError);
+        }
+      }
+    } catch (error) {
+      console.error("Config reload failed, keeping existing connections:", error);
+    } finally {
+      isReloading = false;
+    }
+  };
+
+  const watcher = fs.watch(configPath, (eventType) => {
+    if (eventType === "change") {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+      debounceTimer = setTimeout(reload, DEBOUNCE_MS);
+    }
+  });
+
+  watcher.on("error", (error) => {
+    console.error("Config file watcher error:", error);
+  });
+
+  console.error(`Watching ${configPath} for changes (hot reload enabled)`);
+
+  // Return cleanup function
+  return () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    watcher.close();
+  };
+}

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -112,14 +112,14 @@ export function startConfigWatcher(options: ConfigWatcherOptions): (() => void) 
   };
 
   // Create watcher with recursive re-watch on error (file replaced by atomic rename)
-  let watcher: fs.FSWatcher;
+  let watcher: fs.FSWatcher | null = null;
   const createWatcher = () => {
     watcher = fs.watch(configPath, onWatchEvent);
     watcher.unref?.();
     watcher.on("error", (err) => {
       console.error("Config file watcher error:", err);
       try {
-        watcher.close();
+        watcher?.close();
         createWatcher();
       } catch (rewatchError) {
         console.error("Failed to re-establish config file watcher:", rewatchError);
@@ -135,6 +135,6 @@ export function startConfigWatcher(options: ConfigWatcherOptions): (() => void) 
     if (debounceTimer) {
       clearTimeout(debounceTimer);
     }
-    watcher.close();
+    watcher?.close();
   };
 }

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -2,12 +2,18 @@ import fs from "fs";
 import { loadTomlConfig, resolveTomlConfigPath } from "../config/toml-loader.js";
 import { ConnectorManager } from "../connectors/manager.js";
 import { initializeToolRegistry } from "../tools/registry.js";
+import type { SourceConfig, ToolConfig } from "../types/config.js";
 
 const DEBOUNCE_MS = 500;
 
 /**
  * Watch the TOML configuration file for changes and reload sources automatically.
  * Only applicable when using TOML-based configuration.
+ *
+ * NOTE: In STDIO transport mode, the MCP server's tool list is registered once at
+ * startup. Hot reload updates the underlying database connections and tool registry,
+ * but STDIO clients won't see added/removed tools until a full server restart.
+ * HTTP transport creates a fresh server per request, so tool changes take effect immediately.
  */
 export function startConfigWatcher(connectorManager: ConnectorManager): (() => void) | null {
   const configPath = resolveTomlConfigPath();
@@ -17,12 +23,26 @@ export function startConfigWatcher(connectorManager: ConnectorManager): (() => v
 
   let debounceTimer: NodeJS.Timeout | null = null;
   let isReloading = false;
+  let reloadPending = false;
+
+  // Track last known-good config for rollback (sources + tools)
+  let lastGoodSources: SourceConfig[] = connectorManager.getAllSourceConfigs();
+  let lastGoodTools: ToolConfig[] | undefined;
+
+  const scheduleReload = () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(reload, DEBOUNCE_MS);
+  };
 
   const reload = async () => {
     if (isReloading) {
+      reloadPending = true;
       return;
     }
     isReloading = true;
+    reloadPending = false;
 
     try {
       console.error(`\nDetected change in ${configPath}, reloading configuration...`);
@@ -34,8 +54,9 @@ export function startConfigWatcher(connectorManager: ConnectorManager): (() => v
         return;
       }
 
-      // Save old config for rollback if reconnection fails
-      const oldSources = connectorManager.getAllSourceConfigs();
+      // Save current config for rollback
+      const oldSources = lastGoodSources;
+      const oldTools = lastGoodTools;
 
       // Disconnect all existing sources
       await connectorManager.disconnect();
@@ -50,12 +71,16 @@ export function startConfigWatcher(connectorManager: ConnectorManager): (() => v
           tools: newConfig.tools,
         });
 
+        // Update last known-good config
+        lastGoodSources = newConfig.sources;
+        lastGoodTools = newConfig.tools;
+
         console.error("Configuration reloaded successfully.");
       } catch (connectError) {
         console.error("Failed to connect with new config, rolling back:", connectError);
         try {
           await connectorManager.connectWithSources(oldSources);
-          initializeToolRegistry({ sources: oldSources });
+          initializeToolRegistry({ sources: oldSources, tools: oldTools });
           console.error("Rolled back to previous configuration.");
         } catch (rollbackError) {
           console.error("Rollback also failed, server has no active connections:", rollbackError);
@@ -65,20 +90,34 @@ export function startConfigWatcher(connectorManager: ConnectorManager): (() => v
       console.error("Config reload failed, keeping existing connections:", error);
     } finally {
       isReloading = false;
+      if (reloadPending) {
+        reloadPending = false;
+        scheduleReload();
+      }
     }
   };
 
-  const watcher = fs.watch(configPath, (eventType) => {
-    if (eventType === "change") {
-      if (debounceTimer) {
-        clearTimeout(debounceTimer);
-      }
-      debounceTimer = setTimeout(reload, DEBOUNCE_MS);
+  const onWatchEvent = (eventType: string) => {
+    if (eventType === "change" || eventType === "rename") {
+      scheduleReload();
     }
-  });
+  };
 
-  watcher.on("error", (error) => {
-    console.error("Config file watcher error:", error);
+  let watcher = fs.watch(configPath, onWatchEvent);
+  watcher.unref?.();
+
+  // Re-establish watch on error (e.g., file replaced by atomic rename)
+  watcher.on("error", () => {
+    try {
+      watcher.close();
+      watcher = fs.watch(configPath, onWatchEvent);
+      watcher.unref?.();
+      watcher.on("error", (err) => {
+        console.error("Config file watcher error:", err);
+      });
+    } catch (rewatchError) {
+      console.error("Failed to re-establish config file watcher:", rewatchError);
+    }
   });
 
   console.error(`Watching ${configPath} for changes (hot reload enabled)`);

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -105,56 +105,23 @@ export function startConfigWatcher(options: ConfigWatcherOptions): (() => void) 
     }
   };
 
-  const onWatchEvent = (eventType: string) => {
-    if (eventType === "change" || eventType === "rename") {
+  const watcher = fs.watch(configPath, (eventType) => {
+    if (eventType === "change") {
       scheduleReload();
     }
-  };
+  });
+  watcher.unref?.();
+  watcher.on("error", (err) => {
+    console.error("Config file watcher error:", err);
+  });
 
-  // Create watcher with re-watch on error (file replaced by atomic rename).
-  // Uses delayed retry to avoid tight loops on persistent failures.
-  const WATCHER_RETRY_MS = 1000;
-  let watcher: fs.FSWatcher | null = null;
-  let stopped = false;
-
-  const retryCreateWatcher = () => {
-    if (stopped) return;
-    const timer = setTimeout(createWatcher, WATCHER_RETRY_MS);
-    timer.unref?.();
-  };
-
-  const createWatcher = () => {
-    if (stopped) return;
-    try {
-      watcher = fs.watch(configPath, onWatchEvent);
-      watcher.unref?.();
-      watcher.on("error", (err) => {
-        console.error("Config file watcher error:", err);
-        try { watcher?.close(); } catch { /* best effort */ }
-        watcher = null;
-        retryCreateWatcher();
-      });
-    } catch (watchError) {
-      console.error("Failed to establish config file watcher:", watchError);
-      watcher = null;
-      retryCreateWatcher();
-    }
-  };
-  createWatcher();
-
-  if (watcher) {
-    console.error(`Watching ${configPath} for changes (hot reload enabled)`);
-  } else {
-    console.error(`Hot reload disabled: failed to watch ${configPath} (see errors above)`);
-  }
+  console.error(`Watching ${configPath} for changes (hot reload enabled)`);
 
   // Return cleanup function
   return () => {
-    stopped = true;
     if (debounceTimer) {
       clearTimeout(debounceTimer);
     }
-    watcher?.close();
-    watcher = null;
+    watcher.close();
   };
 }


### PR DESCRIPTION
## Summary

- Watch `dbhub.toml` for changes using `fs.watch` with 500ms debounce and automatically reload database connections and tool registry without server restart
- Rollback to previous working config if reconnection with new config fails
- Clean up watcher on process exit for both STDIO and HTTP transports

Closes #257

## Test plan

- [x] Unit tests for config watcher (9 tests): debouncing, reload, rollback on failure, cleanup, error handling
- [x] Existing TOML loader tests pass (84 tests)
- [x] Build succeeds
- [ ] Manual test: start with `dbhub.toml`, edit a source, verify reconnection without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)