### PR TITLE
fix: resolve SSH config from ~/.ssh/config for TOML sources

### DIFF
--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -247,12 +247,15 @@ npx @bytebase/dbhub@latest --dsn "..." \
 # ProxyJump (multi-hop: bastion1 → bastion2 → target)
 npx @bytebase/dbhub@latest --dsn "..." \
   --ssh-host target.internal --ssh-proxy-jump "bastion1.com,admin@bastion2:2222"
+
+# SSH config alias (resolves host, user, key, and ProxyJump from ~/.ssh/config)
+npx @bytebase/dbhub@latest --dsn "..." --ssh-host mybastion
 ```
 
 <Note>
-- ProxyJump is automatically read from `~/.ssh/config` when using SSH host aliases
-- ProxyCommand is not supported (requires shell execution). Use ProxyJump instead
-- Path expansion for `~/` is supported in file paths
+- When `--ssh-host` is a plain alias (no dots, not an IP address), DBHub automatically resolves it from `~/.ssh/config`, reading the `Hostname`, `User`, `IdentityFile`, and `ProxyJump` directives. Explicit flags always override values from the config file.
+- ProxyCommand is not supported (requires shell execution). Use ProxyJump instead.
+- Path expansion for `~/` is supported in file paths.
 </Note>
 
 ## Quick Reference

--- a/src/config/__tests__/ssh-config-integration.test.ts
+++ b/src/config/__tests__/ssh-config-integration.test.ts
@@ -7,7 +7,8 @@ import * as sshConfigParser from '../../utils/ssh-config-parser.js';
 // Mock the ssh-config-parser module
 vi.mock('../../utils/ssh-config-parser.js', () => ({
   parseSSHConfig: vi.fn(),
-  looksLikeSSHAlias: vi.fn()
+  looksLikeSSHAlias: vi.fn(),
+  getDefaultSSHConfigPath: vi.fn(() => join(homedir(), '.ssh', 'config'))
 }));
 
 describe('SSH Config Integration', () => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,9 +2,9 @@ import dotenv from "dotenv";
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
-import { homedir } from "os";
+
 import type { SSHTunnelConfig } from "../types/ssh.js";
-import { parseSSHConfig, looksLikeSSHAlias } from "../utils/ssh-config-parser.js";
+import { parseSSHConfig, looksLikeSSHAlias, getDefaultSSHConfigPath } from "../utils/ssh-config-parser.js";
 import type { SourceConfig } from "../types/config.js";
 import { loadTomlConfig } from "./toml-loader.js";
 import { parseConnectionInfoFromDSN } from "../utils/dsn-obfuscate.js";
@@ -411,7 +411,7 @@ export function resolveSSHConfig(): { config: SSHTunnelConfig; source: string } 
   // Check if the host looks like an SSH config alias
   if (sshConfigHost && looksLikeSSHAlias(sshConfigHost)) {
     // Try to parse SSH config for this host, default to ~/.ssh/config
-    const sshConfigPath = path.join(homedir(), '.ssh', 'config');
+    const sshConfigPath = getDefaultSSHConfigPath();
     console.error(`Attempting to parse SSH config for host '${sshConfigHost}' from: ${sshConfigPath}`);
     const sshConfigData = parseSSHConfig(sshConfigHost, sshConfigPath);
     if (sshConfigData) {

--- a/src/connectors/__tests__/manager.test.ts
+++ b/src/connectors/__tests__/manager.test.ts
@@ -1,14 +1,141 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectorManager } from "../manager.js";
 import type { SourceConfig } from "../../types/config.js";
+import { homedir } from "os";
+import { join } from "path";
 
 const mocks = vi.hoisted(() => ({
   generateRdsAuthToken: vi.fn(),
+  parseSSHConfig: vi.fn(),
+  looksLikeSSHAlias: vi.fn(),
+  getDefaultSSHConfigPath: vi.fn(() => join(homedir(), '.ssh', 'config')),
 }));
 
 vi.mock("../../utils/aws-rds-signer.js", () => ({
   generateRdsAuthToken: mocks.generateRdsAuthToken,
 }));
+
+vi.mock("../../utils/ssh-config-parser.js", () => ({
+  parseSSHConfig: mocks.parseSSHConfig,
+  looksLikeSSHAlias: mocks.looksLikeSSHAlias,
+  getDefaultSSHConfigPath: mocks.getDefaultSSHConfigPath,
+}));
+
+describe("ConnectorManager SSH config resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should resolve SSH config from ~/.ssh/config for alias hosts", async () => {
+    mocks.looksLikeSSHAlias.mockReturnValue(true);
+    mocks.parseSSHConfig.mockReturnValue({
+      host: "bastion.example.com",
+      port: 2222,
+      username: "ubuntu",
+      privateKey: "/home/user/.ssh/id_rsa",
+    });
+
+    const manager = new ConnectorManager();
+    const source: SourceConfig = {
+      id: "test",
+      type: "postgres",
+      dsn: "postgres://user:pass@db.internal:5432/mydb",
+      ssh_host: "mybastion",
+    };
+
+    // connectSource is private; connectWithSources calls it.
+    // It will fail when trying to establish the actual SSH tunnel,
+    // but only after the config resolution succeeds.
+    await expect(manager.connectWithSources([source])).rejects.toThrow();
+
+    expect(mocks.looksLikeSSHAlias).toHaveBeenCalledWith("mybastion");
+    expect(mocks.parseSSHConfig).toHaveBeenCalledWith("mybastion", expect.stringContaining(".ssh/config"));
+  });
+
+  it("should let explicit TOML fields override SSH config values", async () => {
+    mocks.looksLikeSSHAlias.mockReturnValue(true);
+    mocks.parseSSHConfig.mockReturnValue({
+      host: "bastion.example.com",
+      port: 2222,
+      username: "ubuntu",
+      privateKey: "/home/user/.ssh/id_rsa",
+    });
+
+    const manager = new ConnectorManager();
+    const source: SourceConfig = {
+      id: "test",
+      type: "postgres",
+      dsn: "postgres://user:pass@db.internal:5432/mydb",
+      ssh_host: "mybastion",
+      ssh_user: "override-user",
+      ssh_port: 3333,
+      ssh_key: "/custom/key",
+    };
+
+    await expect(manager.connectWithSources([source])).rejects.toThrow();
+
+    // Verify parseSSHConfig was still called (alias was resolved)
+    expect(mocks.parseSSHConfig).toHaveBeenCalled();
+  });
+
+  it("should throw when SSH alias not found and no ssh_user provided", async () => {
+    mocks.looksLikeSSHAlias.mockReturnValue(true);
+    mocks.parseSSHConfig.mockReturnValue(null);
+
+    const manager = new ConnectorManager();
+    const source: SourceConfig = {
+      id: "test",
+      type: "postgres",
+      dsn: "postgres://user:pass@db.internal:5432/mydb",
+      ssh_host: "unknown-alias",
+    };
+
+    await expect(manager.connectWithSources([source])).rejects.toThrow(
+      "SSH tunnel requires ssh_user (or a matching Host entry in ~/.ssh/config with User)"
+    );
+  });
+
+  it("should throw when no auth method available after SSH config resolution", async () => {
+    mocks.looksLikeSSHAlias.mockReturnValue(true);
+    mocks.parseSSHConfig.mockReturnValue({
+      host: "bastion.example.com",
+      username: "ubuntu",
+      // No privateKey, no password
+    });
+
+    const manager = new ConnectorManager();
+    const source: SourceConfig = {
+      id: "test",
+      type: "postgres",
+      dsn: "postgres://user:pass@db.internal:5432/mydb",
+      ssh_host: "mybastion",
+    };
+
+    await expect(manager.connectWithSources([source])).rejects.toThrow(
+      "SSH tunnel requires either ssh_password or ssh_key (or a matching Host entry in ~/.ssh/config with IdentityFile)"
+    );
+  });
+
+  it("should skip SSH config resolution for direct hostnames", async () => {
+    mocks.looksLikeSSHAlias.mockReturnValue(false);
+
+    const manager = new ConnectorManager();
+    const source: SourceConfig = {
+      id: "test",
+      type: "postgres",
+      dsn: "postgres://user:pass@db.internal:5432/mydb",
+      ssh_host: "bastion.example.com",
+      ssh_user: "myuser",
+      ssh_key: "/home/user/.ssh/id_rsa",
+    };
+
+    // Will fail at tunnel establishment, not at config resolution
+    await expect(manager.connectWithSources([source])).rejects.toThrow();
+
+    expect(mocks.looksLikeSSHAlias).toHaveBeenCalledWith("bastion.example.com");
+    expect(mocks.parseSSHConfig).not.toHaveBeenCalled();
+  });
+});
 
 describe("ConnectorManager IAM DSN rewrite", () => {
   beforeEach(() => {

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -7,9 +7,7 @@ import { getDatabaseTypeFromDSN, getDefaultPortForType } from "../utils/dsn-obfu
 import { redactDSN } from "../config/env.js";
 import { SafeURL } from "../utils/safe-url.js";
 import { generateRdsAuthToken } from "../utils/aws-rds-signer.js";
-import { parseSSHConfig, looksLikeSSHAlias } from "../utils/ssh-config-parser.js";
-import { homedir } from "os";
-import { join } from "path";
+import { parseSSHConfig, looksLikeSSHAlias, getDefaultSSHConfigPath } from "../utils/ssh-config-parser.js";
 
 // Singleton instance for global access
 let managerInstance: ConnectorManager | null = null;
@@ -153,16 +151,17 @@ export class ConnectorManager {
       // If ssh_host looks like an SSH config alias, resolve from ~/.ssh/config
       let resolvedSSHConfig: SSHTunnelConfig | null = null;
       if (looksLikeSSHAlias(source.ssh_host)) {
-        const sshConfigPath = join(homedir(), '.ssh', 'config');
+        const sshConfigPath = getDefaultSSHConfigPath();
         console.error(`  Resolving SSH config for host '${source.ssh_host}' from: ${sshConfigPath}`);
         resolvedSSHConfig = parseSSHConfig(source.ssh_host, sshConfigPath);
       }
 
       // Build SSH config: explicit TOML fields override SSH config values
+      const username = source.ssh_user || resolvedSSHConfig?.username;
       const sshConfig: SSHTunnelConfig = {
-        host: source.ssh_host,
+        host: resolvedSSHConfig?.host || source.ssh_host,
         port: source.ssh_port || resolvedSSHConfig?.port || 22,
-        username: source.ssh_user || resolvedSSHConfig?.username || '',
+        username: username || '',
         password: source.ssh_password,
         privateKey: source.ssh_key || resolvedSSHConfig?.privateKey,
         passphrase: source.ssh_passphrase,
@@ -171,13 +170,8 @@ export class ConnectorManager {
         keepaliveCountMax: source.ssh_keepalive_count_max,
       };
 
-      // Use resolved hostname if SSH config provided one
-      if (resolvedSSHConfig?.host) {
-        sshConfig.host = resolvedSSHConfig.host;
-      }
-
       // Validate required SSH fields
-      if (!sshConfig.username) {
+      if (!username) {
         throw new Error(
           `Source '${sourceId}': SSH tunnel requires ssh_user (or a matching Host entry in ~/.ssh/config with User)`
         );

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -7,6 +7,9 @@ import { getDatabaseTypeFromDSN, getDefaultPortForType } from "../utils/dsn-obfu
 import { redactDSN } from "../config/env.js";
 import { SafeURL } from "../utils/safe-url.js";
 import { generateRdsAuthToken } from "../utils/aws-rds-signer.js";
+import { parseSSHConfig, looksLikeSSHAlias } from "../utils/ssh-config-parser.js";
+import { homedir } from "os";
+import { join } from "path";
 
 // Singleton instance for global access
 let managerInstance: ConnectorManager | null = null;
@@ -147,29 +150,43 @@ export class ConnectorManager {
     // Setup SSH tunnel if needed
     let actualDSN = dsn;
     if (source.ssh_host) {
-      // Validate required SSH fields
-      if (!source.ssh_user) {
-        throw new Error(
-          `Source '${sourceId}': SSH tunnel requires ssh_user`
-        );
+      // If ssh_host looks like an SSH config alias, resolve from ~/.ssh/config
+      let resolvedSSHConfig: SSHTunnelConfig | null = null;
+      if (looksLikeSSHAlias(source.ssh_host)) {
+        const sshConfigPath = join(homedir(), '.ssh', 'config');
+        console.error(`  Resolving SSH config for host '${source.ssh_host}' from: ${sshConfigPath}`);
+        resolvedSSHConfig = parseSSHConfig(source.ssh_host, sshConfigPath);
       }
 
+      // Build SSH config: explicit TOML fields override SSH config values
       const sshConfig: SSHTunnelConfig = {
         host: source.ssh_host,
-        port: source.ssh_port || 22,
-        username: source.ssh_user,
+        port: source.ssh_port || resolvedSSHConfig?.port || 22,
+        username: source.ssh_user || resolvedSSHConfig?.username || '',
         password: source.ssh_password,
-        privateKey: source.ssh_key,
+        privateKey: source.ssh_key || resolvedSSHConfig?.privateKey,
         passphrase: source.ssh_passphrase,
-        proxyJump: source.ssh_proxy_jump,
+        proxyJump: source.ssh_proxy_jump || resolvedSSHConfig?.proxyJump,
         keepaliveInterval: source.ssh_keepalive_interval,
         keepaliveCountMax: source.ssh_keepalive_count_max,
       };
 
+      // Use resolved hostname if SSH config provided one
+      if (resolvedSSHConfig?.host) {
+        sshConfig.host = resolvedSSHConfig.host;
+      }
+
+      // Validate required SSH fields
+      if (!sshConfig.username) {
+        throw new Error(
+          `Source '${sourceId}': SSH tunnel requires ssh_user (or a matching Host entry in ~/.ssh/config with User)`
+        );
+      }
+
       // Validate SSH auth
       if (!sshConfig.password && !sshConfig.privateKey) {
         throw new Error(
-          `Source '${sourceId}': SSH tunnel requires either ssh_password or ssh_key`
+          `Source '${sourceId}': SSH tunnel requires either ssh_password or ssh_key (or a matching Host entry in ~/.ssh/config with IdentityFile)`
         );
       }
 

--- a/src/utils/ssh-config-parser.ts
+++ b/src/utils/ssh-config-parser.ts
@@ -5,6 +5,13 @@ import SSHConfig from 'ssh-config';
 import type { SSHTunnelConfig, JumpHost } from '../types/ssh.js';
 
 /**
+ * Default path to the user's SSH config file
+ */
+export function getDefaultSSHConfigPath(): string {
+  return join(homedir(), '.ssh', 'config');
+}
+
+/**
  * Default SSH key paths to check if no IdentityFile is specified
  */
 const DEFAULT_SSH_KEYS = [


### PR DESCRIPTION
## Summary
When `ssh_host` in TOML config is an SSH alias (e.g., `my-bastion` instead of `bastion.example.com`), DBHub now reads `~/.ssh/config` to resolve `User`, `IdentityFile`, `Port`, `HostName`, and `ProxyJump` — matching the existing behavior in the CLI/env-var path.

Explicit TOML fields (`ssh_user`, `ssh_key`, etc.) take priority over `~/.ssh/config` values.

## Changes
- Add SSH config resolution via `parseSSHConfig`/`looksLikeSSHAlias` in `ConnectorManager.connectSource()` (`src/connectors/manager.ts`)
- Extract `getDefaultSSHConfigPath()` helper in `src/utils/ssh-config-parser.ts` to eliminate duplicate path construction
- Update `src/config/env.ts` to use the shared helper (removes duplicate `homedir` import)
- Improve error messages to mention `~/.ssh/config` as an alternative to explicit fields

Closes #262

## Test plan
- [x] Existing unit tests pass (no regressions)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)