### PR TITLE
feat: support ${VAR} env variable interpolation in TOML config

### DIFF
--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -11,6 +11,7 @@ TOML configuration enables:
 - **Per-source settings**: Configure timeouts, SSL, SSH tunnels, and lazy connections individually per database
 - **Per-tool settings**: Apply different restrictions (readonly, max_rows) per tool
 - **Custom tools**: Define reusable, parameterized SQL operations as MCP tools
+- **Environment variable interpolation**: Use `${VAR}` syntax to avoid hardcoding credentials
 - **Hot reload**: Automatically detect config changes and reload connections without restarting
 
 ## Hot Reload
@@ -33,6 +34,41 @@ When using TOML configuration, DBHub automatically watches `dbhub.toml` for chan
 **STDIO transport limitation:** In STDIO mode (the default for Claude Desktop, Cursor, etc.), hot reload updates the underlying database connections and tool settings, but clients won't see newly added or removed tools until a full server restart. This is because STDIO clients discover tools once at startup.
 
 HTTP transport (`--transport http`) creates a fresh server per request, so all changes — including added/removed tools — take effect immediately.
+</Note>
+
+## Environment Variable Interpolation
+
+Use `${VAR_NAME}` syntax to reference environment variables in any string value. Variables are resolved from the process environment at config load time.
+
+This lets teams share a single `dbhub.toml` without hardcoding credentials:
+
+```toml dbhub.toml
+[[sources]]
+id = "production"
+dsn = "postgres://readonly_user:${DB_PASSWORD}@db.example.com:5432/mydb"
+
+[[sources]]
+id = "staging"
+type = "mysql"
+host = "${STAGING_HOST}"
+database = "myapp"
+user = "root"
+password = "${STAGING_PASSWORD}"
+ssh_host = "bastion.example.com"
+ssh_password = "${SSH_PASSWORD}"
+```
+
+```bash
+# Set env vars, then start DBHub
+export DB_PASSWORD="s3cret"
+export STAGING_HOST="staging.example.com"
+export STAGING_PASSWORD="staging_pass"
+export SSH_PASSWORD="ssh_pass"
+npx @bytebase/dbhub@latest --config dbhub.toml
+```
+
+<Note>
+Unresolved variables (where the environment variable is not set) are left as the literal `${VAR_NAME}` string. No error is thrown for missing variables.
 </Note>
 
 ## Configuration Structure

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1505,14 +1505,14 @@ max_rows = 0
   });
 
   describe('environment variable interpolation', () => {
-    const originalEnv = process.env;
+    const originalEnv = { ...process.env };
 
     beforeEach(() => {
       process.env = { ...originalEnv };
     });
 
     afterEach(() => {
-      process.env = originalEnv;
+      process.env = { ...originalEnv };
     });
 
     it('should interpolate ${VAR} in DSN strings', () => {
@@ -1598,6 +1598,13 @@ dsn = "postgres://user:\${NONEXISTENT_VAR}@localhost:5432/testdb"
     it('should not affect non-string values', () => {
       const result = interpolateEnvVars({ port: 5432, enabled: true, items: [1, 2] });
       expect(result).toEqual({ port: 5432, enabled: true, items: [1, 2] });
+    });
+
+    it('should preserve Date objects from TOML datetime fields', () => {
+      const date = new Date('2024-01-01T00:00:00Z');
+      const result = interpolateEnvVars({ name: 'test', created: date });
+      expect((result as any).created).toBeInstanceOf(Date);
+      expect((result as any).created.toISOString()).toBe('2024-01-01T00:00:00.000Z');
     });
 
     it('should interpolate variables in custom tool statements', () => {

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -480,9 +480,10 @@ function processSourceConfigs(
  * Supports ${VAR_NAME} syntax, resolved from process.env at load time.
  * Unresolved variables are left as-is (no error thrown).
  */
+const ENV_VAR_PATTERN = /\$\{([^}]+)\}/g;
 export function interpolateEnvVars(value: unknown): unknown {
   if (typeof value === "string") {
-    return value.replace(/\$\{([^}]+)\}/g, (match, varName) => {
+    return value.replace(ENV_VAR_PATTERN, (match, varName) => {
       const envValue = process.env[varName];
       return envValue !== undefined ? envValue : match;
     });
@@ -490,7 +491,7 @@ export function interpolateEnvVars(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => interpolateEnvVars(item));
   }
-  if (value !== null && typeof value === "object") {
+  if (value !== null && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
       result[key] = interpolateEnvVars(val);


### PR DESCRIPTION
## Summary
- Adds `${VAR_NAME}` environment variable interpolation in all string values of `dbhub.toml`, resolved from `process.env` at config load time
- Enables teams to share a single `dbhub.toml` without hardcoding credentials (e.g., `dsn = "postgres://user:${DB_PASSWORD}@host/db"`)
- Unresolved variables are left as-is (no error thrown)

## Changes
- `src/config/toml-loader.ts`: Added `interpolateEnvVars()` function that recursively processes all string values, applied after TOML parsing and before config processing
- `src/config/__tests__/toml-loader.test.ts`: Added 7 tests covering DSN interpolation, multiple variables, connection params, SSH fields, unresolved vars, non-string values, and custom tool statements

Closes #272

## Test plan
- [x] All 91 TOML loader tests pass (84 existing + 7 new)
- [x] Build succeeds
- [ ] Manual test with real env vars in a `dbhub.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)