### PR TITLE
Fix: prevent readonly bypass via MySQL conditional comments

### DIFF
--- a/src/tools/__tests__/execute-sql.test.ts
+++ b/src/tools/__tests__/execute-sql.test.ts
@@ -196,7 +196,6 @@ describe('execute-sql tool', () => {
       ['single-line comment', '-- Fetch users\nSELECT * FROM users'],
       ['multi-line comment', '/* Fetch all */\nSELECT * FROM products'],
       ['inline comments', 'SELECT id, -- user id\n       name FROM users'],
-      ['only comments', '-- Just a comment\n/* Another */'],
     ])('should allow SELECT with %s', async (_, sql) => {
       const mockResult: SQLResult = { rows: [], rowCount: 0 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
@@ -205,6 +204,14 @@ describe('execute-sql tool', () => {
       const result = await handler({ sql }, null);
 
       expect(parseToolResponse(result).success).toBe(true);
+    });
+
+    it('should reject comment-only SQL in readonly mode', async () => {
+      const sql = '-- Just a comment\n/* Another */';
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
+
+      expect(parseToolResponse(result).code).toBe('READONLY_VIOLATION');
     });
 
     it('should reject write statement hidden after comment', async () => {

--- a/src/tools/__tests__/execute-sql.test.ts
+++ b/src/tools/__tests__/execute-sql.test.ts
@@ -214,6 +214,28 @@ describe('execute-sql tool', () => {
       expect(parseToolResponse(result).code).toBe('READONLY_VIOLATION');
     });
 
+    it('should reject MySQL conditional comment bypass with mysql connector', async () => {
+      const mysqlConnector = createMockConnector('mysql', 'mysql_source');
+      mockGetCurrentConnector.mockReturnValue(mysqlConnector);
+
+      const sql = 'SELECT 1; /*!50000 DROP TABLE users */';
+      const handler = createExecuteSqlToolHandler('mysql_source');
+      const result = await handler({ sql }, null);
+
+      expect(parseToolResponse(result).code).toBe('READONLY_VIOLATION');
+    });
+
+    it('should reject MariaDB M-bang comment bypass with mariadb connector', async () => {
+      const mariadbConnector = createMockConnector('mariadb', 'mariadb_source');
+      mockGetCurrentConnector.mockReturnValue(mariadbConnector);
+
+      const sql = 'SELECT 1; /*M! DELETE FROM users */';
+      const handler = createExecuteSqlToolHandler('mariadb_source');
+      const result = await handler({ sql }, null);
+
+      expect(parseToolResponse(result).code).toBe('READONLY_VIOLATION');
+    });
+
     it('should reject write statement hidden after comment', async () => {
       const sql = '-- Insert new user\nINSERT INTO users (name) VALUES (\'test\')';
       const handler = createExecuteSqlToolHandler('test_source');

--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -69,13 +69,41 @@ describe("isReadOnlySQL", () => {
   });
 
   describe("edge cases", () => {
-    it("should treat empty SQL after comment stripping as read-only", () => {
-      expect(isReadOnlySQL("-- just a comment", "postgres")).toBe(true);
+    it("should treat empty SQL after comment stripping as not read-only", () => {
+      expect(isReadOnlySQL("-- just a comment", "postgres")).toBe(false);
     });
 
     it("should be case-insensitive", () => {
       expect(isReadOnlySQL("select * from users", "postgres")).toBe(true);
       expect(isReadOnlySQL("SELECT * FROM users", "postgres")).toBe(true);
+    });
+  });
+
+  describe("MySQL conditional comment bypass prevention", () => {
+    it("should reject MySQL conditional comment containing DELETE", () => {
+      expect(isReadOnlySQL("/*!50000 DELETE FROM users WHERE 1=1 */", "mysql")).toBe(false);
+    });
+
+    it("should reject MySQL conditional comment containing DROP", () => {
+      expect(isReadOnlySQL("/*!50000 DROP TABLE users */", "mysql")).toBe(false);
+    });
+
+    it("should reject MariaDB conditional comment containing DELETE", () => {
+      expect(isReadOnlySQL("/*!50000 DELETE FROM users */", "mariadb")).toBe(false);
+    });
+
+    it("should reject even SELECT inside MySQL conditional comment (safe default)", () => {
+      // Conditional comment syntax is preserved as plain text, so the first
+      // word includes the /*! prefix — safer to deny than to parse the body.
+      expect(isReadOnlySQL("/*!50000 SELECT 1 */", "mysql")).toBe(false);
+    });
+
+    it("should still strip regular comments for MySQL", () => {
+      expect(isReadOnlySQL("/* comment */ SELECT 1", "mysql")).toBe(true);
+    });
+
+    it("should reject conditional comment without version number", () => {
+      expect(isReadOnlySQL("/*! DELETE FROM users */", "mysql")).toBe(false);
     });
   });
 });

--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -105,5 +105,13 @@ describe("isReadOnlySQL", () => {
     it("should reject conditional comment without version number", () => {
       expect(isReadOnlySQL("/*! DELETE FROM users */", "mysql")).toBe(false);
     });
+
+    it("should reject MariaDB M-bang executable comment", () => {
+      expect(isReadOnlySQL("/*M! DELETE FROM users */", "mariadb")).toBe(false);
+    });
+
+    it("should reject MariaDB M-bang executable comment on MySQL dialect", () => {
+      expect(isReadOnlySQL("/*M! DROP TABLE users */", "mysql")).toBe(false);
+    });
   });
 });

--- a/src/utils/__tests__/sql-parser.test.ts
+++ b/src/utils/__tests__/sql-parser.test.ts
@@ -46,6 +46,35 @@ describe("stripCommentsAndStrings", () => {
       expect(stripCommentsAndStrings(sql, "mysql")).toBe("SELECT   still comment */ 1");
     });
 
+    it("should preserve MySQL conditional comments for MySQL dialect", () => {
+      const sql = "SELECT 1; /*!50000 DELETE FROM users */";
+      // Conditional comments are executable in MySQL — must not be stripped
+      expect(stripCommentsAndStrings(sql, "mysql")).toContain("DELETE FROM users");
+    });
+
+    it("should preserve MySQL conditional comments without version number", () => {
+      const sql = "/*! DROP TABLE users */";
+      expect(stripCommentsAndStrings(sql, "mysql")).toContain("DROP TABLE users");
+    });
+
+    it("should preserve MySQL conditional comments for MariaDB dialect", () => {
+      const sql = "/*!50000 DELETE FROM users */";
+      expect(stripCommentsAndStrings(sql, "mariadb")).toContain("DELETE FROM users");
+    });
+
+    it("should still strip regular comments for MySQL dialect", () => {
+      const sql = "SELECT /* comment */ 1";
+      expect(stripCommentsAndStrings(sql, "mysql")).toBe("SELECT   1");
+    });
+
+    it("should strip conditional comments for non-MySQL dialects", () => {
+      // PostgreSQL/SQLite/SQL Server don't execute conditional comments
+      const sql = "/*!50000 DELETE FROM users */";
+      expect(stripCommentsAndStrings(sql, "postgres")).toBe(" ");
+      expect(stripCommentsAndStrings(sql, "sqlite")).toBe(" ");
+      expect(stripCommentsAndStrings(sql, "sqlserver")).toBe(" ");
+    });
+
     it("should handle deeply nested block comments in PostgreSQL", () => {
       const sql = "SELECT /* a /* b /* c */ b */ a */ 1";
       expect(stripCommentsAndStrings(sql, "postgres")).toBe("SELECT   1");

--- a/src/utils/__tests__/sql-parser.test.ts
+++ b/src/utils/__tests__/sql-parser.test.ts
@@ -62,6 +62,16 @@ describe("stripCommentsAndStrings", () => {
       expect(stripCommentsAndStrings(sql, "mariadb")).toContain("DELETE FROM users");
     });
 
+    it("should preserve MariaDB M-bang executable comments for MariaDB dialect", () => {
+      const sql = "SELECT 1; /*M! DROP TABLE users; DELETE FROM audit_log */";
+      expect(stripCommentsAndStrings(sql, "mariadb")).toContain("DROP TABLE users");
+    });
+
+    it("should preserve MariaDB M-bang executable comments for MySQL dialect", () => {
+      const sql = "/*M! DELETE FROM users */";
+      expect(stripCommentsAndStrings(sql, "mysql")).toContain("DELETE FROM users");
+    });
+
     it("should still strip regular comments for MySQL dialect", () => {
       const sql = "SELECT /* comment */ 1";
       expect(stripCommentsAndStrings(sql, "mysql")).toBe("SELECT   1");

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -25,9 +25,11 @@ export function isReadOnlySQL(sql: string, connectorType: ConnectorType | string
   // Strip comments and strings before analyzing
   const cleanedSQL = stripCommentsAndStrings(sql, connectorType as ConnectorType).trim().toLowerCase();
 
-  // If the statement is empty after removing comments, consider it read-only
+  // If the statement is empty after removing comments, deny it.
+  // An empty result may indicate that executable content was stripped
+  // (e.g. MySQL conditional comments), so the safe default is to reject.
   if (!cleanedSQL) {
-    return true;
+    return false;
   }
 
   const firstWord = cleanedSQL.split(/\s+/)[0];

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -25,9 +25,8 @@ export function isReadOnlySQL(sql: string, connectorType: ConnectorType | string
   // Strip comments and strings before analyzing
   const cleanedSQL = stripCommentsAndStrings(sql, connectorType as ConnectorType).trim().toLowerCase();
 
-  // If the statement is empty after removing comments, deny it.
-  // An empty result may indicate that executable content was stripped
-  // (e.g. MySQL conditional comments), so the safe default is to reject.
+  // Empty after stripping → deny. Attacker-crafted inputs may reduce to
+  // empty strings after comment/string removal to evade keyword checks.
   if (!cleanedSQL) {
     return false;
   }

--- a/src/utils/sql-parser.ts
+++ b/src/utils/sql-parser.ts
@@ -29,8 +29,8 @@ function scanMultiLineComment(sql: string, i: number): SQLToken | null {
 
 /**
  * MySQL/MariaDB-specific multi-line comment scanner that preserves conditional comments.
- * MySQL conditional comments (/*!nnnnn ... * /) and MariaDB-specific comments
- * (/*M! ... * /) are executable. Stripping them would let malicious SQL bypass
+ * MySQL conditional comments (`/*!nnnnn ... *\/`) and MariaDB-specific comments
+ * (`/*M! ... *\/`) are executable. Stripping them would let malicious SQL bypass
  * read-only checks, so we return null to let them pass through as plain text.
  */
 function scanMultiLineCommentMySQL(sql: string, i: number): SQLToken | null {

--- a/src/utils/sql-parser.ts
+++ b/src/utils/sql-parser.ts
@@ -27,6 +27,19 @@ function scanMultiLineComment(sql: string, i: number): SQLToken | null {
   return { type: TokenType.Comment, end: j };
 }
 
+/**
+ * MySQL-specific multi-line comment scanner that preserves conditional comments.
+ * MySQL conditional comments (/*!nnnnn ... * /) are executable — MySQL runs
+ * the body if its version >= nnnnn. Stripping them would let malicious SQL
+ * bypass read-only checks, so we return null to let them pass through as plain text.
+ */
+function scanMultiLineCommentMySQL(sql: string, i: number): SQLToken | null {
+  if (sql[i] !== "/" || sql[i + 1] !== "*") { return null; }
+  // Conditional comment: /*! or /*!nnnnn — MySQL executes the body
+  if (sql[i + 2] === "!") { return null; }
+  return scanMultiLineComment(sql, i);
+}
+
 function scanNestedMultiLineComment(sql: string, i: number): SQLToken | null {
   if (sql[i] !== "/" || sql[i + 1] !== "*") { return null; }
   let j = i + 2;
@@ -120,7 +133,7 @@ function scanTokenPostgres(sql: string, i: number): SQLToken {
 
 function scanTokenMySQL(sql: string, i: number): SQLToken {
   return scanSingleLineComment(sql, i)
-    ?? scanMultiLineComment(sql, i)
+    ?? scanMultiLineCommentMySQL(sql, i)
     ?? scanSingleQuotedString(sql, i)
     ?? scanDoubleQuotedString(sql, i)
     ?? scanBacktickQuotedIdentifier(sql, i)

--- a/src/utils/sql-parser.ts
+++ b/src/utils/sql-parser.ts
@@ -28,14 +28,16 @@ function scanMultiLineComment(sql: string, i: number): SQLToken | null {
 }
 
 /**
- * MySQL-specific multi-line comment scanner that preserves conditional comments.
- * MySQL conditional comments (/*!nnnnn ... * /) are executable — MySQL runs
- * the body if its version >= nnnnn. Stripping them would let malicious SQL
- * bypass read-only checks, so we return null to let them pass through as plain text.
+ * MySQL/MariaDB-specific multi-line comment scanner that preserves conditional comments.
+ * MySQL conditional comments (/*!nnnnn ... * /) and MariaDB-specific comments
+ * (/*M! ... * /) are executable. Stripping them would let malicious SQL bypass
+ * read-only checks, so we return null to let them pass through as plain text.
  */
 function scanMultiLineCommentMySQL(sql: string, i: number): SQLToken | null {
   if (sql[i] !== "/" || sql[i + 1] !== "*") { return null; }
-  if (sql[i + 2] === "!") { return null; }
+  const next = sql[i + 2];
+  const nextNext = sql[i + 3];
+  if (next === "!" || (next === "M" && nextNext === "!")) { return null; }
   return scanMultiLineComment(sql, i);
 }
 

--- a/src/utils/sql-parser.ts
+++ b/src/utils/sql-parser.ts
@@ -35,7 +35,6 @@ function scanMultiLineComment(sql: string, i: number): SQLToken | null {
  */
 function scanMultiLineCommentMySQL(sql: string, i: number): SQLToken | null {
   if (sql[i] !== "/" || sql[i + 1] !== "*") { return null; }
-  // Conditional comment: /*! or /*!nnnnn — MySQL executes the body
   if (sql[i + 2] === "!") { return null; }
   return scanMultiLineComment(sql, i);
 }


### PR DESCRIPTION
## Summary
MySQL conditional comments (`/*!50000 ... */`) were stripped by the SQL parser as regular comments, but MySQL/MariaDB actually execute their contents. This allowed attackers to hide destructive SQL (DELETE, DROP) inside conditional comments to bypass readonly mode.

**Two fixes applied (defense in depth):**
- The MySQL/MariaDB scanner now preserves conditional comments as plain text so the readonly keyword check can see the executable content.
- Empty statements after comment stripping now return `false` (deny) instead of `true` (allow).

## Changes
- `src/utils/sql-parser.ts`: Added `scanMultiLineCommentMySQL()` that skips conditional comments (`/*!...*/`), letting them pass through as plain text. Used in the MySQL token scanner.
- `src/utils/allowed-keywords.ts`: Changed empty-after-stripping from `return true` to `return false`.
- Updated tests in `sql-parser.test.ts`, `allowed-keywords.test.ts`, and `execute-sql.test.ts`.

Closes #283

## Credit
Reported by **Sebastián Alba Vives** ([@Sebasteuo](https://github.com/Sebasteuo)) — including root cause analysis, PoC, and suggested fixes.

## Test plan
- [x] New tests for MySQL conditional comment bypass (DELETE, DROP, version-less `/*!`)
- [x] New tests confirming regular comments still stripped for MySQL
- [x] New tests confirming conditional comments still stripped for non-MySQL dialects
- [x] Existing tests updated for empty-statement denial behavior
- [x] All 143 affected tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)