### PR TITLE
feat: support optional database driver packages

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -32,6 +32,29 @@ title: "Installation"
   </Tab>
 </Tabs>
 
+### Minimal Installation
+
+By default, DBHub installs drivers for all supported databases (PostgreSQL, MySQL, MariaDB, SQL Server, SQLite). If you only need specific databases, you can skip the unnecessary drivers to reduce installation size:
+
+```bash
+# Install with only the PostgreSQL driver
+npm install -g @bytebase/dbhub@latest --omit=optional && npm install -g pg
+
+# Install with only PostgreSQL and MySQL drivers
+npm install -g @bytebase/dbhub@latest --omit=optional && npm install -g pg mysql2
+```
+
+Available driver packages:
+- `pg` — PostgreSQL
+- `mysql2` — MySQL
+- `mariadb` — MariaDB
+- `mssql` — SQL Server
+- `better-sqlite3` — SQLite
+
+<Note>
+When a driver is not installed, DBHub will skip that connector at startup and log a message. All other connectors will work normally.
+</Note>
+
 ## Docker
 
 <Tabs>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -34,7 +34,9 @@ title: "Installation"
 
 ### Minimal Installation
 
-By default, DBHub installs drivers for all supported databases (PostgreSQL, MySQL, MariaDB, SQL Server, SQLite). If you only need specific databases, you can skip the unnecessary drivers to reduce installation size:
+By default, DBHub installs drivers for all supported databases (PostgreSQL, MySQL, MariaDB, SQL Server, SQLite). If you only need specific databases, you can skip the unnecessary drivers to reduce installation size.
+
+This applies to `npm install` (global or local). When using `npx`, all optional dependencies are installed automatically.
 
 ```bash
 # Install with only the PostgreSQL driver
@@ -52,7 +54,7 @@ Available driver packages:
 - `better-sqlite3` — SQLite
 
 <Note>
-When a driver is not installed, DBHub will skip that connector at startup and log a message. All other connectors will work normally.
+When a driver is not installed, DBHub will skip that connector at startup and log a message. All other connectors will work normally. Note that `--demo` mode requires the `better-sqlite3` driver.
 </Note>
 
 ## Docker

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -34,9 +34,9 @@ title: "Installation"
 
 ### Minimal Installation
 
-By default, DBHub installs drivers for all supported databases (PostgreSQL, MySQL, MariaDB, SQL Server, SQLite). If you only need specific databases, you can skip the unnecessary drivers to reduce installation size.
+By default, DBHub attempts to install drivers for all supported databases (PostgreSQL, MySQL, MariaDB, SQL Server, SQLite). If you only need specific databases, you can skip the unnecessary drivers to reduce installation size.
 
-This applies to `npm install` (global or local). When using `npx`, all optional dependencies are installed automatically.
+This applies to `npm install` (global or local). When using `npx`, npm will attempt to install all optional dependencies, but some drivers may be skipped if installation fails or is not supported on your platform.
 
 ```bash
 # Install with only the PostgreSQL driver

--- a/package.json
+++ b/package.json
@@ -43,16 +43,18 @@
     "@azure/identity": "^4.8.0",
     "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "better-sqlite3": "^11.9.0",
     "dotenv": "^16.4.7",
     "express": "^4.18.2",
-    "mariadb": "^3.4.0",
-    "mssql": "^11.0.1",
-    "mysql2": "^3.13.0",
-    "pg": "^8.13.3",
     "ssh-config": "^5.0.3",
     "ssh2": "^1.16.0",
     "zod": "^3.24.2"
+  },
+  "optionalDependencies": {
+    "better-sqlite3": "^11.9.0",
+    "mariadb": "^3.4.0",
+    "mssql": "^11.0.1",
+    "mysql2": "^3.13.0",
+    "pg": "^8.13.3"
   },
   "devDependencies": {
     "@testcontainers/mariadb": "^11.0.3",

--- a/src/__tests__/load-connectors.test.ts
+++ b/src/__tests__/load-connectors.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { isDriverNotInstalled } from "../utils/module-loader.js";
+
+describe("isDriverNotInstalled", () => {
+  it("should return true when the driver package is missing", () => {
+    const err = new Error(
+      "Cannot find package 'pg' imported from /fake/path"
+    );
+    (err as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
+
+    expect(isDriverNotInstalled(err, "pg")).toBe(true);
+  });
+
+  it("should return false when a different driver is missing", () => {
+    const err = new Error(
+      "Cannot find package 'pg' imported from /fake/path"
+    );
+    (err as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
+
+    expect(isDriverNotInstalled(err, "mysql2")).toBe(false);
+  });
+
+  it("should return false for unrelated ERR_MODULE_NOT_FOUND errors", () => {
+    const err = new Error(
+      "Cannot find package 'some-internal-dep' imported from /fake/path"
+    );
+    (err as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
+
+    expect(isDriverNotInstalled(err, "pg")).toBe(false);
+    expect(isDriverNotInstalled(err, "mysql2")).toBe(false);
+  });
+
+  it("should return false for non-module errors", () => {
+    const err = new Error("Some other error");
+    expect(isDriverNotInstalled(err, "pg")).toBe(false);
+  });
+
+  it("should return false for non-Error values", () => {
+    expect(isDriverNotInstalled("string error", "pg")).toBe(false);
+    expect(isDriverNotInstalled(null, "pg")).toBe(false);
+    expect(isDriverNotInstalled(undefined, "pg")).toBe(false);
+  });
+});

--- a/src/__tests__/load-connectors.test.ts
+++ b/src/__tests__/load-connectors.test.ts
@@ -20,6 +20,24 @@ describe("isDriverNotInstalled", () => {
     expect(isDriverNotInstalled(err, "mysql2")).toBe(false);
   });
 
+  it("should return true for driver subpath imports", () => {
+    const err = new Error(
+      "Cannot find package 'mysql2/promise' imported from /fake/path"
+    );
+    (err as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
+
+    expect(isDriverNotInstalled(err, "mysql2")).toBe(true);
+  });
+
+  it("should return false when missing module name only contains driver as a substring", () => {
+    const err = new Error(
+      "Cannot find package 'pg-connection-string' imported from /fake/path"
+    );
+    (err as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
+
+    expect(isDriverNotInstalled(err, "pg")).toBe(false);
+  });
+
   it("should return false for unrelated ERR_MODULE_NOT_FOUND errors", () => {
     const err = new Error(
       "Cannot find package 'some-internal-dep' imported from /fake/path"

--- a/src/__tests__/load-connectors.test.ts
+++ b/src/__tests__/load-connectors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { isDriverNotInstalled } from "../utils/module-loader.js";
 
 describe("isDriverNotInstalled", () => {
@@ -20,13 +20,13 @@ describe("isDriverNotInstalled", () => {
     expect(isDriverNotInstalled(err, "mysql2")).toBe(false);
   });
 
-  it("should return true for driver subpath imports", () => {
+  it("should return false for driver subpath imports", () => {
     const err = new Error(
       "Cannot find package 'mysql2/promise' imported from /fake/path"
     );
     (err as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
 
-    expect(isDriverNotInstalled(err, "mysql2")).toBe(true);
+    expect(isDriverNotInstalled(err, "mysql2")).toBe(false);
   });
 
   it("should return false when missing module name only contains driver as a substring", () => {
@@ -57,5 +57,68 @@ describe("isDriverNotInstalled", () => {
     expect(isDriverNotInstalled("string error", "pg")).toBe(false);
     expect(isDriverNotInstalled(null, "pg")).toBe(false);
     expect(isDriverNotInstalled(undefined, "pg")).toBe(false);
+  });
+});
+
+describe("loadConnectors", () => {
+  it("should log and continue when a driver is missing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Mock a connector module that throws ERR_MODULE_NOT_FOUND for its driver
+    const driverErr = new Error("Cannot find package 'pg' imported from /fake/path");
+    (driverErr as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
+
+    const connectorModules = [
+      { load: () => Promise.reject(driverErr), name: "PostgreSQL", driver: "pg" },
+    ];
+
+    // Inline the loadConnectors logic to test without importing index.ts
+    // (which triggers side effects)
+    await Promise.all(
+      connectorModules.map(async ({ load, name, driver }) => {
+        try {
+          await load();
+        } catch (err) {
+          if (isDriverNotInstalled(err, driver)) {
+            console.error(
+              `Skipping ${name} connector: driver package "${driver}" not installed.`
+            );
+          } else {
+            throw err;
+          }
+        }
+      })
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Skipping PostgreSQL connector: driver package "pg" not installed.'
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("should rethrow non-driver errors", async () => {
+    const runtimeErr = new Error("Unexpected syntax error");
+
+    const connectorModules = [
+      { load: () => Promise.reject(runtimeErr), name: "PostgreSQL", driver: "pg" },
+    ];
+
+    await expect(
+      Promise.all(
+        connectorModules.map(async ({ load, name, driver }) => {
+          try {
+            await load();
+          } catch (err) {
+            if (isDriverNotInstalled(err, driver)) {
+              console.error(
+                `Skipping ${name} connector: driver package "${driver}" not installed.`
+              );
+            } else {
+              throw err;
+            }
+          }
+        })
+      )
+    ).rejects.toThrow("Unexpected syntax error");
   });
 });

--- a/src/__tests__/load-connectors.test.ts
+++ b/src/__tests__/load-connectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { isDriverNotInstalled } from "../utils/module-loader.js";
+import { isDriverNotInstalled, loadConnectors } from "../utils/module-loader.js";
 
 describe("isDriverNotInstalled", () => {
   it("should return true when the driver package is missing", () => {
@@ -20,13 +20,13 @@ describe("isDriverNotInstalled", () => {
     expect(isDriverNotInstalled(err, "mysql2")).toBe(false);
   });
 
-  it("should return false for driver subpath imports", () => {
+  it("should return true for driver subpath imports", () => {
     const err = new Error(
       "Cannot find package 'mysql2/promise' imported from /fake/path"
     );
     (err as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
 
-    expect(isDriverNotInstalled(err, "mysql2")).toBe(false);
+    expect(isDriverNotInstalled(err, "mysql2")).toBe(true);
   });
 
   it("should return false when missing module name only contains driver as a substring", () => {
@@ -64,31 +64,12 @@ describe("loadConnectors", () => {
   it("should log and continue when a driver is missing", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    // Mock a connector module that throws ERR_MODULE_NOT_FOUND for its driver
     const driverErr = new Error("Cannot find package 'pg' imported from /fake/path");
     (driverErr as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
 
-    const connectorModules = [
+    await loadConnectors([
       { load: () => Promise.reject(driverErr), name: "PostgreSQL", driver: "pg" },
-    ];
-
-    // Inline the loadConnectors logic to test without importing index.ts
-    // (which triggers side effects)
-    await Promise.all(
-      connectorModules.map(async ({ load, name, driver }) => {
-        try {
-          await load();
-        } catch (err) {
-          if (isDriverNotInstalled(err, driver)) {
-            console.error(
-              `Skipping ${name} connector: driver package "${driver}" not installed.`
-            );
-          } else {
-            throw err;
-          }
-        }
-      })
-    );
+    ]);
 
     expect(errorSpy).toHaveBeenCalledWith(
       'Skipping PostgreSQL connector: driver package "pg" not installed.'
@@ -99,26 +80,18 @@ describe("loadConnectors", () => {
   it("should rethrow non-driver errors", async () => {
     const runtimeErr = new Error("Unexpected syntax error");
 
-    const connectorModules = [
-      { load: () => Promise.reject(runtimeErr), name: "PostgreSQL", driver: "pg" },
-    ];
-
     await expect(
-      Promise.all(
-        connectorModules.map(async ({ load, name, driver }) => {
-          try {
-            await load();
-          } catch (err) {
-            if (isDriverNotInstalled(err, driver)) {
-              console.error(
-                `Skipping ${name} connector: driver package "${driver}" not installed.`
-              );
-            } else {
-              throw err;
-            }
-          }
-        })
-      )
+      loadConnectors([
+        { load: () => Promise.reject(runtimeErr), name: "PostgreSQL", driver: "pg" },
+      ])
     ).rejects.toThrow("Unexpected syntax error");
+  });
+
+  it("should load all connectors when drivers are available", async () => {
+    let loaded = 0;
+    await loadConnectors([
+      { load: async () => { loaded++; }, name: "TestDB", driver: "test-driver" },
+    ]);
+    expect(loaded).toBe(1);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,30 +5,24 @@ import { main } from "./server.js";
 // Dynamically import connector modules so missing driver packages
 // (e.g. when only one database type is needed) don't crash the server.
 const connectorModules = [
-  { modulePath: "./connectors/postgres/index.js", name: "PostgreSQL" },
-  { modulePath: "./connectors/sqlserver/index.js", name: "SQL Server" },
-  { modulePath: "./connectors/sqlite/index.js", name: "SQLite" },
-  { modulePath: "./connectors/mysql/index.js", name: "MySQL" },
-  { modulePath: "./connectors/mariadb/index.js", name: "MariaDB" },
+  { modulePath: "./connectors/postgres/index.js", name: "PostgreSQL", driver: "pg" },
+  { modulePath: "./connectors/sqlserver/index.js", name: "SQL Server", driver: "mssql" },
+  { modulePath: "./connectors/sqlite/index.js", name: "SQLite", driver: "better-sqlite3" },
+  { modulePath: "./connectors/mysql/index.js", name: "MySQL", driver: "mysql2" },
+  { modulePath: "./connectors/mariadb/index.js", name: "MariaDB", driver: "mariadb" },
 ];
 
-function isModuleNotFound(err: unknown): boolean {
-  return (
-    err instanceof Error &&
-    "code" in err &&
-    (err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND"
-  );
-}
+import { isDriverNotInstalled } from "./utils/module-loader.js";
 
-async function loadConnectors(): Promise<void> {
+export async function loadConnectors(): Promise<void> {
   await Promise.all(
-    connectorModules.map(async ({ modulePath, name }) => {
+    connectorModules.map(async ({ modulePath, name, driver }) => {
       try {
         await import(modulePath);
       } catch (err) {
-        if (isModuleNotFound(err)) {
+        if (isDriverNotInstalled(err, driver)) {
           console.error(
-            `Skipping ${name} connector: driver package not installed.`
+            `Skipping ${name} connector: driver package "${driver}" not installed.`
           );
         } else {
           throw err;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,24 @@
 #!/usr/bin/env node
 
 import { main } from "./server.js";
+import { isDriverNotInstalled } from "./utils/module-loader.js";
 
 // Dynamically import connector modules so missing driver packages
 // (e.g. when only one database type is needed) don't crash the server.
+// Each load function uses a string literal so the bundler can resolve it.
 const connectorModules = [
-  { modulePath: "./connectors/postgres/index.js", name: "PostgreSQL", driver: "pg" },
-  { modulePath: "./connectors/sqlserver/index.js", name: "SQL Server", driver: "mssql" },
-  { modulePath: "./connectors/sqlite/index.js", name: "SQLite", driver: "better-sqlite3" },
-  { modulePath: "./connectors/mysql/index.js", name: "MySQL", driver: "mysql2" },
-  { modulePath: "./connectors/mariadb/index.js", name: "MariaDB", driver: "mariadb" },
+  { load: () => import("./connectors/postgres/index.js"), name: "PostgreSQL", driver: "pg" },
+  { load: () => import("./connectors/sqlserver/index.js"), name: "SQL Server", driver: "mssql" },
+  { load: () => import("./connectors/sqlite/index.js"), name: "SQLite", driver: "better-sqlite3" },
+  { load: () => import("./connectors/mysql/index.js"), name: "MySQL", driver: "mysql2" },
+  { load: () => import("./connectors/mariadb/index.js"), name: "MariaDB", driver: "mariadb" },
 ];
-
-import { isDriverNotInstalled } from "./utils/module-loader.js";
 
 export async function loadConnectors(): Promise<void> {
   await Promise.all(
-    connectorModules.map(async ({ modulePath, name, driver }) => {
+    connectorModules.map(async ({ load, name, driver }) => {
       try {
-        await import(modulePath);
+        await load();
       } catch (err) {
         if (isDriverNotInstalled(err, driver)) {
           console.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,46 @@
 #!/usr/bin/env node
 
-// Import connector modules to register them
-import "./connectors/postgres/index.js"; // Register PostgreSQL connector
-import "./connectors/sqlserver/index.js"; // Register SQL Server connector
-import "./connectors/sqlite/index.js"; // SQLite connector
-import "./connectors/mysql/index.js"; // MySQL connector
-import "./connectors/mariadb/index.js"; // MariaDB connector
-
-// Import main function from server.ts
 import { main } from "./server.js";
 
-/**
- * Entry point for the DBHub MCP Server
- * Handles top-level exceptions and starts the server
- */
-main().catch((error) => {
-  console.error("Fatal error:", error);
-  process.exit(1);
-});
+// Dynamically import connector modules so missing driver packages
+// (e.g. when only one database type is needed) don't crash the server.
+const connectorModules = [
+  { modulePath: "./connectors/postgres/index.js", name: "PostgreSQL" },
+  { modulePath: "./connectors/sqlserver/index.js", name: "SQL Server" },
+  { modulePath: "./connectors/sqlite/index.js", name: "SQLite" },
+  { modulePath: "./connectors/mysql/index.js", name: "MySQL" },
+  { modulePath: "./connectors/mariadb/index.js", name: "MariaDB" },
+];
+
+function isModuleNotFound(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND"
+  );
+}
+
+async function loadConnectors(): Promise<void> {
+  await Promise.all(
+    connectorModules.map(async ({ modulePath, name }) => {
+      try {
+        await import(modulePath);
+      } catch (err) {
+        if (isModuleNotFound(err)) {
+          console.error(
+            `Skipping ${name} connector: driver package not installed.`
+          );
+        } else {
+          throw err;
+        }
+      }
+    })
+  );
+}
+
+loadConnectors()
+  .then(() => main())
+  .catch((error) => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
 import { main } from "./server.js";
-import { isDriverNotInstalled } from "./utils/module-loader.js";
+import { loadConnectors } from "./utils/module-loader.js";
 
-// Dynamically import connector modules so missing driver packages
-// (e.g. when only one database type is needed) don't crash the server.
 // Each load function uses a string literal so the bundler can resolve it.
 const connectorModules = [
   { load: () => import("./connectors/postgres/index.js"), name: "PostgreSQL", driver: "pg" },
@@ -14,25 +12,7 @@ const connectorModules = [
   { load: () => import("./connectors/mariadb/index.js"), name: "MariaDB", driver: "mariadb" },
 ];
 
-export async function loadConnectors(): Promise<void> {
-  await Promise.all(
-    connectorModules.map(async ({ load, name, driver }) => {
-      try {
-        await load();
-      } catch (err) {
-        if (isDriverNotInstalled(err, driver)) {
-          console.error(
-            `Skipping ${name} connector: driver package "${driver}" not installed.`
-          );
-        } else {
-          throw err;
-        }
-      }
-    })
-  );
-}
-
-loadConnectors()
+loadConnectors(connectorModules)
   .then(() => main())
   .catch((error) => {
     console.error("Fatal error:", error);

--- a/src/utils/module-loader.ts
+++ b/src/utils/module-loader.ts
@@ -1,0 +1,13 @@
+/**
+ * Check if an error is an ERR_MODULE_NOT_FOUND for a specific driver package.
+ * This distinguishes a missing optional driver (e.g. "pg" not installed) from
+ * other module errors (e.g. a typo in an internal import).
+ */
+export function isDriverNotInstalled(err: unknown, driver: string): boolean {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND" &&
+    err.message.includes(driver)
+  );
+}

--- a/src/utils/module-loader.ts
+++ b/src/utils/module-loader.ts
@@ -23,9 +23,5 @@ export function isDriverNotInstalled(err: unknown, driver: string): boolean {
   }
 
   const missingSpecifier = match[1];
-  // Match the exact driver package or a subpath import (e.g. "mysql2/promise")
-  return (
-    missingSpecifier === driver ||
-    missingSpecifier.startsWith(`${driver}/`)
-  );
+  return missingSpecifier === driver;
 }

--- a/src/utils/module-loader.ts
+++ b/src/utils/module-loader.ts
@@ -1,12 +1,13 @@
 // Matches the package name from Node.js ERR_MODULE_NOT_FOUND messages:
 //   Cannot find package 'pg' imported from ...
-//   Cannot find module 'pg' ...
+//   Cannot find module 'mysql2/promise' ...
 const MISSING_MODULE_RE = /Cannot find (?:package|module) '([^']+)'/;
 
 /**
  * Check if an error is an ERR_MODULE_NOT_FOUND for a specific driver package.
- * This distinguishes a missing optional driver (e.g. "pg" not installed) from
- * other module errors (e.g. a missing internal dependency like "pg-connection-string").
+ * Matches the exact package name or a subpath import (e.g. "mysql2/promise"
+ * matches driver "mysql2"), but not unrelated packages that happen to contain
+ * the driver name as a substring (e.g. "pg-connection-string" does not match "pg").
  */
 export function isDriverNotInstalled(err: unknown, driver: string): boolean {
   if (
@@ -23,5 +24,38 @@ export function isDriverNotInstalled(err: unknown, driver: string): boolean {
   }
 
   const missingSpecifier = match[1];
-  return missingSpecifier === driver;
+  return (
+    missingSpecifier === driver ||
+    missingSpecifier.startsWith(`${driver}/`)
+  );
+}
+
+export interface ConnectorModule {
+  load: () => Promise<unknown>;
+  name: string;
+  driver: string;
+}
+
+/**
+ * Load connector modules, gracefully skipping any whose driver package
+ * is not installed.
+ */
+export async function loadConnectors(
+  connectorModules: ConnectorModule[]
+): Promise<void> {
+  await Promise.all(
+    connectorModules.map(async ({ load, name, driver }) => {
+      try {
+        await load();
+      } catch (err) {
+        if (isDriverNotInstalled(err, driver)) {
+          console.error(
+            `Skipping ${name} connector: driver package "${driver}" not installed.`
+          );
+        } else {
+          throw err;
+        }
+      }
+    })
+  );
 }

--- a/src/utils/module-loader.ts
+++ b/src/utils/module-loader.ts
@@ -1,13 +1,31 @@
+// Matches the package name from Node.js ERR_MODULE_NOT_FOUND messages:
+//   Cannot find package 'pg' imported from ...
+//   Cannot find module 'pg' ...
+const MISSING_MODULE_RE = /Cannot find (?:package|module) '([^']+)'/;
+
 /**
  * Check if an error is an ERR_MODULE_NOT_FOUND for a specific driver package.
  * This distinguishes a missing optional driver (e.g. "pg" not installed) from
- * other module errors (e.g. a typo in an internal import).
+ * other module errors (e.g. a missing internal dependency like "pg-connection-string").
  */
 export function isDriverNotInstalled(err: unknown, driver: string): boolean {
+  if (
+    !(err instanceof Error) ||
+    !("code" in err) ||
+    (err as NodeJS.ErrnoException).code !== "ERR_MODULE_NOT_FOUND"
+  ) {
+    return false;
+  }
+
+  const match = err.message.match(MISSING_MODULE_RE);
+  if (!match) {
+    return false;
+  }
+
+  const missingSpecifier = match[1];
+  // Match the exact driver package or a subpath import (e.g. "mysql2/promise")
   return (
-    err instanceof Error &&
-    "code" in err &&
-    (err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND" &&
-    err.message.includes(driver)
+    missingSpecifier === driver ||
+    missingSpecifier.startsWith(`${driver}/`)
   );
 }


### PR DESCRIPTION
## Summary
- Move database driver packages (`pg`, `mysql2`, `mariadb`, `mssql`, `better-sqlite3`) from `dependencies` to `optionalDependencies`
- Load connectors dynamically at startup with `import()` instead of static imports, gracefully skipping missing drivers
- Only catch `ERR_MODULE_NOT_FOUND` errors — real bugs in connector code still surface immediately
- Add "Minimal Installation" section to installation docs

Closes #281

## Test plan
- [ ] `pnpm run build:backend` compiles successfully
- [ ] `pnpm test:unit` passes (no regressions)
- [ ] `npx @bytebase/dbhub@latest --demo` works with all drivers installed
- [ ] Install with `--omit=optional` + only `pg`, verify server starts and skips other connectors
- [ ] Introduce a syntax error in a connector file, verify it throws instead of being silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)