### PR TITLE
Fix: externalize database drivers to prevent dynamic require error

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
   dts: true,
   clean: true,
   outDir: 'dist',
+  // Database drivers are optionalDependencies loaded at runtime via dynamic
+  // import(). They must be external so tsup does not bundle their CJS code
+  // into ESM chunks (which causes "Dynamic require of X is not supported").
+  external: ['pg', 'mysql2', 'mariadb', 'mssql', 'better-sqlite3'],
   // Copy the employee-sqlite demo data to dist
   async onSuccess() {
     // Create target directory


### PR DESCRIPTION
## Summary
- Commit 1eefec4 moved database drivers to `optionalDependencies` with dynamic `import()`, but tsup bundled their CJS code into ESM chunks
- At runtime, the bundled CJS `require("events")` calls fail with "Dynamic require of 'events' is not supported"
- Adding the driver packages to tsup's `external` list ensures they're loaded from `node_modules` at runtime via standard ES imports

## Changes
- Add `external: ['pg', 'mysql2', 'mariadb', 'mssql', 'better-sqlite3']` to `tsup.config.ts`

Closes #288

## Test plan
- [x] `pnpm run build:backend` succeeds
- [x] Built output uses `import pg from "pg"` (external) instead of inlining pg internals
- [x] No `Dynamic require` / `__require` / `createRequire` shims in output
- [x] Runtime smoke test: no "Dynamic require" error loading dist/index.js
- [x] `load-connectors.test.ts` passes (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)