### PR TITLE
Fix: include views in PostgreSQL getTableComment() relkind filter

### DIFF
--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -167,6 +167,12 @@ class PostgreSQLIntegrationTest extends IntegrationTestBase<PostgreSQLTestContai
       ON CONFLICT DO NOTHING
     `, {});
 
+    // Create a view with a comment (for view comment test)
+    await connector.executeSQL(`
+      CREATE OR REPLACE VIEW active_users AS SELECT id, name, email FROM users WHERE age >= 25
+    `, {});
+    await connector.executeSQL(`COMMENT ON VIEW active_users IS 'Users aged 25 or older'`, {});
+
     // Create test stored procedures using SQL language to avoid dollar quoting
     await connector.executeSQL(`
       CREATE OR REPLACE FUNCTION get_user_count()
@@ -243,6 +249,11 @@ describe('PostgreSQL Connector Integration Tests', () => {
       expect(result.rows[0].json_data).toBeDefined();
       expect(result.rows[0].uuid_val).toBeDefined();
       expect(result.rows[0].array_val).toBeDefined();
+    });
+
+    it('should return comment for views via getTableComment', async () => {
+      const comment = await postgresTest.connector.getTableComment!('active_users');
+      expect(comment).toBe('Users aged 25 or older');
     });
 
     it('should handle PostgreSQL returning clause', async () => {

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -382,7 +382,7 @@ export class PostgresConnector implements Connector {
         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
         WHERE c.relname = $1
         AND n.nspname = $2
-        AND c.relkind IN ('r','p','m','f')
+        AND c.relkind IN ('r','p','m','f','v')
       `,
         [tableName, schemaToUse]
       );


### PR DESCRIPTION
## Summary
- `getTableComment()` in the PostgreSQL connector filtered `pg_class.relkind IN ('r','p','m','f')`, excluding `'v'` (ordinary views)
- Views returned by `search_objects` always had null comments despite `COMMENT ON VIEW` being set
- Added `'v'` to the relkind filter so `obj_description()` can return view comments

Closes #296

## Test plan
- [ ] Existing unit tests pass
- [ ] Verify with PostgreSQL: create a view with `COMMENT ON VIEW`, call `search_objects` with `detail_level: "full"`, confirm comment is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)