### PR TITLE
feat: make cloud provider packages optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/rds-signer": "^3.1001.0",
-    "@azure/identity": "^4.8.0",
     "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "dotenv": "^16.4.7",
@@ -51,6 +49,8 @@
     "zod": "^3.24.2"
   },
   "optionalDependencies": {
+    "@aws-sdk/rds-signer": "^3.1001.0",
+    "@azure/identity": "^4.8.0",
     "better-sqlite3": "^11.9.0",
     "mariadb": "^3.4.0",
     "mssql": "^11.0.1",

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -94,18 +94,18 @@ export class SQLServerDSNParser implements DSNParser {
       // Handle authentication types
       switch (options.authentication) {
         case "azure-active-directory-access-token": {
+          let DefaultAzureCredential: typeof import("@azure/identity")["DefaultAzureCredential"];
           try {
-            let DefaultAzureCredential: typeof import("@azure/identity")["DefaultAzureCredential"];
-            try {
-              ({ DefaultAzureCredential } = await import("@azure/identity"));
-            } catch (importError) {
-              if (isDriverNotInstalled(importError, "@azure/identity")) {
-                throw new Error(
-                  'Azure AD authentication requires the "@azure/identity" package. Install it with: pnpm add @azure/identity'
-                );
-              }
-              throw importError;
+            ({ DefaultAzureCredential } = await import("@azure/identity"));
+          } catch (importError) {
+            if (isDriverNotInstalled(importError, "@azure/identity")) {
+              throw new Error(
+                'Azure AD authentication requires the "@azure/identity" package. Install it with: pnpm add @azure/identity'
+              );
             }
+            throw importError;
+          }
+          try {
             const credential = new DefaultAzureCredential();
             const token = await credential.getToken("https://database.windows.net/");
             config.authentication = {

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -11,6 +11,7 @@ import {
   ExecuteOptions,
   ConnectorConfig,
 } from "../interface.js";
+import { isDriverNotInstalled } from "../../utils/module-loader.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
@@ -97,10 +98,13 @@ export class SQLServerDSNParser implements DSNParser {
             let DefaultAzureCredential: typeof import("@azure/identity")["DefaultAzureCredential"];
             try {
               ({ DefaultAzureCredential } = await import("@azure/identity"));
-            } catch {
-              throw new Error(
-                'Azure AD authentication requires the "@azure/identity" package. Install it with: npm install @azure/identity'
-              );
+            } catch (importError) {
+              if (isDriverNotInstalled(importError, "@azure/identity")) {
+                throw new Error(
+                  'Azure AD authentication requires the "@azure/identity" package. Install it with: pnpm add @azure/identity'
+                );
+              }
+              throw importError;
             }
             const credential = new DefaultAzureCredential();
             const token = await credential.getToken("https://database.windows.net/");

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -94,7 +94,14 @@ export class SQLServerDSNParser implements DSNParser {
       switch (options.authentication) {
         case "azure-active-directory-access-token": {
           try {
-            const { DefaultAzureCredential } = await import("@azure/identity");
+            let DefaultAzureCredential: typeof import("@azure/identity")["DefaultAzureCredential"];
+            try {
+              ({ DefaultAzureCredential } = await import("@azure/identity"));
+            } catch {
+              throw new Error(
+                'Azure AD authentication requires the "@azure/identity" package. Install it with: npm install @azure/identity'
+              );
+            }
             const credential = new DefaultAzureCredential();
             const token = await credential.getToken("https://database.windows.net/");
             config.authentication = {

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -11,7 +11,6 @@ import {
   ExecuteOptions,
   ConnectorConfig,
 } from "../interface.js";
-import { DefaultAzureCredential } from "@azure/identity";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
@@ -95,6 +94,7 @@ export class SQLServerDSNParser implements DSNParser {
       switch (options.authentication) {
         case "azure-active-directory-access-token": {
           try {
+            const { DefaultAzureCredential } = await import("@azure/identity");
             const credential = new DefaultAzureCredential();
             const token = await credential.getToken("https://database.windows.net/");
             config.authentication = {

--- a/src/utils/__tests__/aws-rds-signer-missing.test.ts
+++ b/src/utils/__tests__/aws-rds-signer-missing.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isDriverNotInstalled } from '../module-loader.js';
+
+describe('generateRdsAuthToken missing package', () => {
+  it('should throw actionable error when @aws-sdk/rds-signer is not installed', async () => {
+    // Simulate ERR_MODULE_NOT_FOUND for @aws-sdk/rds-signer
+    const err = new Error(
+      "Cannot find package '@aws-sdk/rds-signer' imported from /fake/path"
+    );
+    (err as NodeJS.ErrnoException).code = 'ERR_MODULE_NOT_FOUND';
+
+    expect(isDriverNotInstalled(err, '@aws-sdk/rds-signer')).toBe(true);
+  });
+
+  it('should not match unrelated ERR_MODULE_NOT_FOUND errors', () => {
+    const err = new Error(
+      "Cannot find package 'some-other-pkg' imported from /fake/path"
+    );
+    (err as NodeJS.ErrnoException).code = 'ERR_MODULE_NOT_FOUND';
+
+    expect(isDriverNotInstalled(err, '@aws-sdk/rds-signer')).toBe(false);
+  });
+});

--- a/src/utils/__tests__/aws-rds-signer-missing.test.ts
+++ b/src/utils/__tests__/aws-rds-signer-missing.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { isDriverNotInstalled } from '../module-loader.js';
 
-describe('generateRdsAuthToken missing package', () => {
-  it('should throw actionable error when @aws-sdk/rds-signer is not installed', async () => {
-    // Simulate ERR_MODULE_NOT_FOUND for @aws-sdk/rds-signer
+describe('isDriverNotInstalled with scoped packages', () => {
+  it('should match ERR_MODULE_NOT_FOUND for @aws-sdk/rds-signer', () => {
     const err = new Error(
       "Cannot find package '@aws-sdk/rds-signer' imported from /fake/path"
     );

--- a/src/utils/aws-rds-signer.ts
+++ b/src/utils/aws-rds-signer.ts
@@ -1,3 +1,5 @@
+import { isDriverNotInstalled } from "./module-loader.js";
+
 export interface RdsAuthTokenParams {
   hostname: string;
   port: number;
@@ -14,10 +16,13 @@ export async function generateRdsAuthToken(params: RdsAuthTokenParams): Promise<
   let Signer: typeof import("@aws-sdk/rds-signer")["Signer"];
   try {
     ({ Signer } = await import("@aws-sdk/rds-signer"));
-  } catch {
-    throw new Error(
-      'AWS IAM authentication requires the "@aws-sdk/rds-signer" package. Install it with: npm install @aws-sdk/rds-signer'
-    );
+  } catch (error) {
+    if (isDriverNotInstalled(error, "@aws-sdk/rds-signer")) {
+      throw new Error(
+        'AWS IAM authentication requires the "@aws-sdk/rds-signer" package. Install it with: pnpm add @aws-sdk/rds-signer'
+      );
+    }
+    throw error;
   }
 
   const signer = new Signer({

--- a/src/utils/aws-rds-signer.ts
+++ b/src/utils/aws-rds-signer.ts
@@ -11,7 +11,14 @@ export interface RdsAuthTokenParams {
  * (AWS CLI profile, env vars, instance role, etc.).
  */
 export async function generateRdsAuthToken(params: RdsAuthTokenParams): Promise<string> {
-  const { Signer } = await import("@aws-sdk/rds-signer");
+  let Signer: typeof import("@aws-sdk/rds-signer")["Signer"];
+  try {
+    ({ Signer } = await import("@aws-sdk/rds-signer"));
+  } catch {
+    throw new Error(
+      'AWS IAM authentication requires the "@aws-sdk/rds-signer" package. Install it with: npm install @aws-sdk/rds-signer'
+    );
+  }
 
   const signer = new Signer({
     hostname: params.hostname,

--- a/src/utils/aws-rds-signer.ts
+++ b/src/utils/aws-rds-signer.ts
@@ -1,5 +1,3 @@
-import { Signer } from "@aws-sdk/rds-signer";
-
 export interface RdsAuthTokenParams {
   hostname: string;
   port: number;
@@ -13,6 +11,8 @@ export interface RdsAuthTokenParams {
  * (AWS CLI profile, env vars, instance role, etc.).
  */
 export async function generateRdsAuthToken(params: RdsAuthTokenParams): Promise<string> {
+  const { Signer } = await import("@aws-sdk/rds-signer");
+
   const signer = new Signer({
     hostname: params.hostname,
     port: params.port,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,9 +9,11 @@ export default defineConfig({
   clean: true,
   outDir: 'dist',
   // Optional runtime-loaded dependencies (database drivers and cloud auth
-  // packages) are optionalDependencies loaded via dynamic import(). They must
-  // be external so tsup does not bundle their CJS code into ESM chunks (which
-  // causes "Dynamic require of X is not supported").
+  // packages) are declared as optionalDependencies and loaded via dynamic
+  // import(). Database drivers must be external so tsup does not bundle their
+  // CJS code into ESM chunks (which causes "Dynamic require of X is not
+  // supported"). Cloud auth packages are externalized to keep their large
+  // dependency trees out of the bundle.
   external: ['pg', 'mysql2', 'mariadb', 'mssql', 'better-sqlite3', '@aws-sdk/rds-signer', '@azure/identity'],
   // Copy the employee-sqlite demo data to dist
   async onSuccess() {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   // Database drivers are optionalDependencies loaded at runtime via dynamic
   // import(). They must be external so tsup does not bundle their CJS code
   // into ESM chunks (which causes "Dynamic require of X is not supported").
-  external: ['pg', 'mysql2', 'mariadb', 'mssql', 'better-sqlite3'],
+  external: ['pg', 'mysql2', 'mariadb', 'mssql', 'better-sqlite3', '@aws-sdk/rds-signer', '@azure/identity'],
   // Copy the employee-sqlite demo data to dist
   async onSuccess() {
     // Create target directory

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,9 +8,10 @@ export default defineConfig({
   dts: true,
   clean: true,
   outDir: 'dist',
-  // Database drivers are optionalDependencies loaded at runtime via dynamic
-  // import(). They must be external so tsup does not bundle their CJS code
-  // into ESM chunks (which causes "Dynamic require of X is not supported").
+  // Optional runtime-loaded dependencies (database drivers and cloud auth
+  // packages) are optionalDependencies loaded via dynamic import(). They must
+  // be external so tsup does not bundle their CJS code into ESM chunks (which
+  // causes "Dynamic require of X is not supported").
   external: ['pg', 'mysql2', 'mariadb', 'mssql', 'better-sqlite3', '@aws-sdk/rds-signer', '@azure/identity'],
   // Copy the employee-sqlite demo data to dist
   async onSuccess() {


### PR DESCRIPTION
## Summary
- Move `@aws-sdk/rds-signer` and `@azure/identity` from `dependencies` to `optionalDependencies`
- Switch static imports to dynamic `import()` so packages are only loaded when AWS IAM or Azure AD auth is used
- Add both to tsup `external` list to prevent bundling CJS into ESM (same pattern as database drivers in #291)

Closes #295

## Test plan
- [x] `pnpm run build:backend` succeeds
- [x] `pnpm test:build` smoke test passes
- [x] `pnpm test:unit` passes (including aws-rds-signer tests)
- [x] Verified smoke test catches missing externals for database drivers (cloud packages are ESM-native so don't trigger CJS errors, but externalization still prevents bundling ~1MB of SDK code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)