### PR TITLE
Quote identifiers in SHOW CREATE PROCEDURE/FUNCTION for MySQL and MariaDB

### DIFF
--- a/src/connectors/__tests__/procedure-identifier-quoting.test.ts
+++ b/src/connectors/__tests__/procedure-identifier-quoting.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { quoteIdentifier } from "../../utils/identifier-quoter.js";
+
+/**
+ * Verify that MySQL/MariaDB SHOW CREATE PROCEDURE/FUNCTION statements
+ * use properly quoted identifiers. Procedure and schema names containing
+ * spaces, reserved words, or special characters cause syntax errors
+ * without backtick quoting.
+ *
+ * The connectors build SQL like:
+ *   SHOW CREATE PROCEDURE ${quotedSchema}.${quotedProcName}
+ *
+ * This test validates the quoting produces valid SQL fragments.
+ */
+describe("SHOW CREATE PROCEDURE identifier quoting", () => {
+  describe("MySQL/MariaDB backtick quoting for procedure names", () => {
+    it("should quote names with spaces", () => {
+      const schema = quoteIdentifier("my schema", "mysql");
+      const proc = quoteIdentifier("my procedure", "mysql");
+      const sql = `SHOW CREATE PROCEDURE ${schema}.${proc}`;
+      expect(sql).toBe("SHOW CREATE PROCEDURE `my schema`.`my procedure`");
+    });
+
+    it("should quote reserved words", () => {
+      const schema = quoteIdentifier("order", "mysql");
+      const proc = quoteIdentifier("select", "mysql");
+      const sql = `SHOW CREATE PROCEDURE ${schema}.${proc}`;
+      expect(sql).toBe("SHOW CREATE PROCEDURE `order`.`select`");
+    });
+
+    it("should escape backticks in names", () => {
+      const schema = quoteIdentifier("db`name", "mysql");
+      const proc = quoteIdentifier("proc`name", "mysql");
+      const sql = `SHOW CREATE PROCEDURE ${schema}.${proc}`;
+      expect(sql).toBe("SHOW CREATE PROCEDURE `db``name`.`proc``name`");
+    });
+
+    it("should quote names with dots", () => {
+      const schema = quoteIdentifier("my.db", "mysql");
+      const proc = quoteIdentifier("calc.totals", "mysql");
+      const sql = `SHOW CREATE FUNCTION ${schema}.${proc}`;
+      expect(sql).toBe("SHOW CREATE FUNCTION `my.db`.`calc.totals`");
+    });
+
+    it("should also work for MariaDB (same syntax)", () => {
+      const schema = quoteIdentifier("test schema", "mariadb");
+      const proc = quoteIdentifier("get-data", "mariadb");
+      const sql = `SHOW CREATE PROCEDURE ${schema}.${proc}`;
+      expect(sql).toBe("SHOW CREATE PROCEDURE `test schema`.`get-data`");
+    });
+  });
+
+  describe("unquoted identifiers break with special characters", () => {
+    it("demonstrates the problem: spaces in names produce invalid SQL", () => {
+      const schema = "my schema";
+      const proc = "my procedure";
+      const unquotedSQL = `SHOW CREATE PROCEDURE ${schema}.${proc}`;
+      // This SQL is invalid and will cause MySQL syntax errors
+      expect(unquotedSQL).toBe("SHOW CREATE PROCEDURE my schema.my procedure");
+      // The database would parse "my" as the schema and "schema.my" as noise
+    });
+
+    it("demonstrates the problem: reserved words produce invalid SQL", () => {
+      const schema = "order";
+      const proc = "select";
+      const unquotedSQL = `SHOW CREATE PROCEDURE ${schema}.${proc}`;
+      // "order" and "select" are reserved words; MySQL will misparse this
+      expect(unquotedSQL).toBe("SHOW CREATE PROCEDURE order.select");
+    });
+  });
+});

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -16,6 +16,7 @@ import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
+import { quoteIdentifier } from "../../utils/identifier-quoter.js";
 
 /**
  * MariaDB DSN Parser
@@ -467,11 +468,13 @@ export class MariaDBConnector implements Connector {
         const schemaValue = schema || (await this.getCurrentSchema());
 
         // For full definition - different approaches based on type
+        const quotedSchema = quoteIdentifier(schemaValue, "mariadb");
+        const quotedProcName = quoteIdentifier(procedureName, "mariadb");
         if (procedure.procedure_type === "procedure") {
           // Try to get the definition from SHOW CREATE PROCEDURE
           try {
             const defRows = await this.pool.query(`
-              SHOW CREATE PROCEDURE ${schemaValue}.${procedureName}
+              SHOW CREATE PROCEDURE ${quotedSchema}.${quotedProcName}
             `) as any[];
 
             if (defRows && defRows.length > 0) {
@@ -484,7 +487,7 @@ export class MariaDBConnector implements Connector {
           // Try to get the definition for functions
           try {
             const defRows = await this.pool.query(`
-              SHOW CREATE FUNCTION ${schemaValue}.${procedureName}
+              SHOW CREATE FUNCTION ${quotedSchema}.${quotedProcName}
             `) as any[];
 
             if (defRows && defRows.length > 0) {

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -16,6 +16,7 @@ import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
+import { quoteIdentifier } from "../../utils/identifier-quoter.js";
 
 /**
  * MySQL DSN Parser
@@ -475,11 +476,13 @@ export class MySQLConnector implements Connector {
         const schemaValue = schema || (await this.getCurrentSchema());
 
         // For full definition - different approaches based on type
+        const quotedSchema = quoteIdentifier(schemaValue, "mysql");
+        const quotedProcName = quoteIdentifier(procedureName, "mysql");
         if (procedure.procedure_type === "procedure") {
           // Try to get the definition from SHOW CREATE PROCEDURE
           try {
             const [defRows] = (await this.pool.query(`
-              SHOW CREATE PROCEDURE ${schemaValue}.${procedureName}
+              SHOW CREATE PROCEDURE ${quotedSchema}.${quotedProcName}
             `)) as [any[], any];
 
             if (defRows && defRows.length > 0) {
@@ -492,7 +495,7 @@ export class MySQLConnector implements Connector {
           // Try to get the definition for functions
           try {
             const [defRows] = (await this.pool.query(`
-              SHOW CREATE FUNCTION ${schemaValue}.${procedureName}
+              SHOW CREATE FUNCTION ${quotedSchema}.${quotedProcName}
             `)) as [any[], any];
 
             if (defRows && defRows.length > 0) {


### PR DESCRIPTION
Ran into this while using `search_objects` with `detail_level=full` against a MySQL database that has a schema named with a reserved word. The `SHOW CREATE PROCEDURE` query failed with a syntax error because the schema and procedure names weren't being quoted.

Looking at the code, the MySQL and MariaDB connectors both interpolate `schemaValue` and `procedureName` directly into `SHOW CREATE PROCEDURE` and `SHOW CREATE FUNCTION` statements:

```sql
SHOW CREATE PROCEDURE ${schemaValue}.${procedureName}
```

Names containing spaces, reserved words (like `order`, `select`), dots, or backticks produce invalid SQL here. The rest of the codebase already handles this — the SQLite connector uses `quoteIdentifier()` for PRAGMA statements, and the `search-objects` tool uses `quoteQualifiedIdentifier()` for COUNT queries. These four call sites were the only ones missing it.

**Before:** `SHOW CREATE PROCEDURE order.get_totals` → MySQL syntax error
**After:** `SHOW CREATE PROCEDURE \`order\`.\`get_totals\`` → works correctly

The fix adds `quoteIdentifier()` calls (from the existing `identifier-quoter.ts` utility) to the four affected `SHOW CREATE` statements in both `mysql/index.ts` and `mariadb/index.ts`.

**Tests added:** `procedure-identifier-quoting.test.ts` — 7 cases covering spaces, reserved words, backtick escaping, dots, and MariaDB parity.