### PR TITLE
fix: surface source description in MCP tool description (#267)

### DIFF
--- a/src/utils/__tests__/tool-metadata.integration.test.ts
+++ b/src/utils/__tests__/tool-metadata.integration.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { ConnectorManager } from "../../connectors/manager.js";
+import { setupManagerWithFixture, FIXTURES, loadFixtureConfig } from "../../__fixtures__/helpers.js";
+import { getExecuteSqlMetadata, getSearchObjectsMetadata } from "../tool-metadata.js";
+import { initializeToolRegistry } from "../../tools/registry.js";
+
+// Import SQLite connector to ensure it's registered
+import "../../connectors/sqlite/index.js";
+
+describe("tool-metadata description propagation", () => {
+  let manager: ConnectorManager;
+
+  beforeAll(async () => {
+    // readonly-maxrows fixture has three sources:
+    //   readonly_limited: description = "Read-only database for safe queries", readonly + max_rows
+    //   writable_limited: no description, writable + max_rows
+    //   writable_unlimited: no description, writable + no limits
+    manager = await setupManagerWithFixture(FIXTURES.READONLY_MAXROWS);
+    const { sources, tools } = loadFixtureConfig(FIXTURES.READONLY_MAXROWS);
+    initializeToolRegistry({ sources, tools: tools || [] });
+  }, 30000);
+
+  afterAll(async () => {
+    if (manager) {
+      await manager.disconnect();
+    }
+  });
+
+  describe("getExecuteSqlMetadata", () => {
+    it("prepends user description from source config when present", () => {
+      const metadata = getExecuteSqlMetadata("readonly_limited");
+
+      expect(metadata.description).toContain("Read-only database for safe queries");
+      // Original technical context must still be preserved
+      expect(metadata.description).toContain("readonly_limited");
+      expect(metadata.description).toContain("sqlite");
+      expect(metadata.description).toContain("[READ-ONLY MODE]");
+      // User description comes first, technical template follows
+      expect(metadata.description.indexOf("Read-only database for safe queries")).toBeLessThan(
+        metadata.description.indexOf("Execute SQL queries")
+      );
+    });
+
+    it("omits the prefix entirely when source has no description", () => {
+      const metadata = getExecuteSqlMetadata("writable_limited");
+
+      // No extra prefix — description starts with the template
+      expect(metadata.description.startsWith("Execute SQL queries")).toBe(true);
+      expect(metadata.description).toContain("writable_limited");
+      expect(metadata.description).toContain("sqlite");
+    });
+  });
+
+  describe("getSearchObjectsMetadata", () => {
+    it("prepends user description from source config when present", () => {
+      const metadata = getSearchObjectsMetadata("readonly_limited");
+
+      expect(metadata.description).toContain("Read-only database for safe queries");
+      expect(metadata.description).toContain("readonly_limited");
+      expect(metadata.description).toContain("sqlite");
+      expect(metadata.description.indexOf("Read-only database for safe queries")).toBeLessThan(
+        metadata.description.indexOf("Search and list database objects")
+      );
+    });
+
+    it("omits the prefix entirely when source has no description", () => {
+      const metadata = getSearchObjectsMetadata("writable_unlimited");
+
+      expect(metadata.description.startsWith("Search and list database objects")).toBe(true);
+      expect(metadata.description).toContain("writable_unlimited");
+      expect(metadata.description).toContain("sqlite");
+    });
+  });
+});

--- a/src/utils/__tests__/tool-metadata.test.ts
+++ b/src/utils/__tests__/tool-metadata.test.ts
@@ -32,6 +32,12 @@ describe("buildSourceDescriptionPrefix", () => {
     expect(buildSourceDescriptionPrefix("Query me?")).toBe("Query me? ");
   });
 
+  it("appends only a space when description ends with ':'", () => {
+    // A trailing colon naturally introduces what follows (the tool template),
+    // so adding '.' here would produce the artifact "Details below:. Execute..."
+    expect(buildSourceDescriptionPrefix("Details below:")).toBe("Details below: ");
+  });
+
   it("trims surrounding whitespace before assessing punctuation", () => {
     expect(buildSourceDescriptionPrefix("  Prod DB  ")).toBe("Prod DB. ");
     expect(buildSourceDescriptionPrefix("  Prod DB.  ")).toBe("Prod DB. ");
@@ -45,9 +51,9 @@ describe("buildSourceDescriptionPrefix", () => {
   });
 
   it("does not treat non-sentence-ending punctuation as terminators", () => {
-    // These are mid-sentence / structural punctuation; the helper should
-    // still append ". " to produce a complete sentence boundary.
-    expect(buildSourceDescriptionPrefix("Details below:")).toBe("Details below:. ");
+    // ')' and ';' are mid-sentence / structural punctuation; the helper
+    // should still append ". " to produce a complete sentence boundary.
+    // (':' is handled separately — see the colon-specific test above.)
     expect(buildSourceDescriptionPrefix("(read-only)")).toBe("(read-only). ");
     expect(buildSourceDescriptionPrefix("Clause 1; clause 2")).toBe("Clause 1; clause 2. ");
   });

--- a/src/utils/__tests__/tool-metadata.test.ts
+++ b/src/utils/__tests__/tool-metadata.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { buildSourceDescriptionPrefix } from "../tool-metadata.js";
+
+describe("buildSourceDescriptionPrefix", () => {
+  it("returns empty string when description is undefined", () => {
+    expect(buildSourceDescriptionPrefix(undefined)).toBe("");
+  });
+
+  it("returns empty string when description is empty", () => {
+    expect(buildSourceDescriptionPrefix("")).toBe("");
+  });
+
+  it("returns empty string when description is whitespace-only", () => {
+    expect(buildSourceDescriptionPrefix("   ")).toBe("");
+    expect(buildSourceDescriptionPrefix("\t\n")).toBe("");
+  });
+
+  it("appends '. ' when description has no sentence-ending punctuation", () => {
+    expect(buildSourceDescriptionPrefix("Prod DB")).toBe("Prod DB. ");
+  });
+
+  it("appends only a space when description already ends with a period", () => {
+    // Guards against the classic "Prod DB.. Execute SQL..." double-period bug.
+    expect(buildSourceDescriptionPrefix("Prod DB.")).toBe("Prod DB. ");
+  });
+
+  it("appends only a space when description ends with '!'", () => {
+    expect(buildSourceDescriptionPrefix("Production DB!")).toBe("Production DB! ");
+  });
+
+  it("appends only a space when description ends with '?'", () => {
+    expect(buildSourceDescriptionPrefix("Query me?")).toBe("Query me? ");
+  });
+
+  it("trims surrounding whitespace before assessing punctuation", () => {
+    expect(buildSourceDescriptionPrefix("  Prod DB  ")).toBe("Prod DB. ");
+    expect(buildSourceDescriptionPrefix("  Prod DB.  ")).toBe("Prod DB. ");
+  });
+
+  it("preserves internal whitespace and punctuation", () => {
+    // Internal formatting (newlines, multiple words, mid-sentence punctuation)
+    // is the user's intent and must not be altered.
+    expect(buildSourceDescriptionPrefix("Line 1\nLine 2")).toBe("Line 1\nLine 2. ");
+    expect(buildSourceDescriptionPrefix("Line A, Line B")).toBe("Line A, Line B. ");
+  });
+
+  it("does not treat non-sentence-ending punctuation as terminators", () => {
+    // These are mid-sentence / structural punctuation; the helper should
+    // still append ". " to produce a complete sentence boundary.
+    expect(buildSourceDescriptionPrefix("Details below:")).toBe("Details below:. ");
+    expect(buildSourceDescriptionPrefix("(read-only)")).toBe("(read-only). ");
+    expect(buildSourceDescriptionPrefix("Clause 1; clause 2")).toBe("Clause 1; clause 2. ");
+  });
+});

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -40,6 +40,27 @@ export interface ToolMetadata {
 }
 
 /**
+ * Build a prefix string for prepending a source's user-provided `description`
+ * onto a generated tool description. Returns "" when no description is set
+ * (undefined, empty, or whitespace-only). Normalizes surrounding whitespace
+ * with `trim()` and avoids double sentence-ending punctuation when the
+ * description already ends with one of "." / "!" / "?".
+ *
+ * Examples:
+ *   undefined            -> ""
+ *   "  "                 -> ""
+ *   "Prod DB"            -> "Prod DB. "
+ *   "Prod DB."           -> "Prod DB. "      (no double period)
+ *   "  Prod DB!  "       -> "Prod DB! "      (trimmed, no added period)
+ *   "Query me?"          -> "Query me? "
+ */
+export function buildSourceDescriptionPrefix(description: string | undefined): string {
+  const trimmed = description?.trim() ?? "";
+  if (!trimmed) return "";
+  return /[.!?]$/.test(trimmed) ? `${trimmed} ` : `${trimmed}. `;
+}
+
+/**
  * Convert a Zod schema object to simplified parameter list
  * @param schema - Zod schema object (e.g., { sql: z.string().describe("...") })
  * @returns Array of tool parameters
@@ -109,7 +130,7 @@ export function getExecuteSqlMetadata(sourceId: string): ToolMetadata {
   // Determine description with more context.
   // Prepend the user-provided `description` from the source config (if set)
   // so AI clients reading the MCP tool list see the source's purpose first.
-  const userDescPrefix = sourceConfig.description ? `${sourceConfig.description}. ` : "";
+  const userDescPrefix = buildSourceDescriptionPrefix(sourceConfig.description);
   const readonlyNote = executeOptions.readonly ? " [READ-ONLY MODE]" : "";
   const maxRowsNote = executeOptions.maxRows ? ` (limited to ${executeOptions.maxRows} rows)` : "";
   const description = isSingleSource
@@ -154,7 +175,7 @@ export function getSearchObjectsMetadata(sourceId: string): { name: string; desc
     : `Search Database Objects on ${sourceId} (${dbType})`;
   // Prepend the user-provided `description` from the source config (if set)
   // so AI clients reading the MCP tool list see the source's purpose first.
-  const userDescPrefix = sourceConfig.description ? `${sourceConfig.description}. ` : "";
+  const userDescPrefix = buildSourceDescriptionPrefix(sourceConfig.description);
   const description = isSingleSource
     ? `${userDescPrefix}Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the ${dbType} database`
     : `${userDescPrefix}Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the '${sourceId}' ${dbType} database`;

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -106,12 +106,15 @@ export function getExecuteSqlMetadata(sourceId: string): ToolMetadata {
     ? `Execute SQL (${dbType})`
     : `Execute SQL on ${sourceId} (${dbType})`;
 
-  // Determine description with more context
+  // Determine description with more context.
+  // Prepend the user-provided `description` from the source config (if set)
+  // so AI clients reading the MCP tool list see the source's purpose first.
+  const userDescPrefix = sourceConfig.description ? `${sourceConfig.description}. ` : "";
   const readonlyNote = executeOptions.readonly ? " [READ-ONLY MODE]" : "";
   const maxRowsNote = executeOptions.maxRows ? ` (limited to ${executeOptions.maxRows} rows)` : "";
   const description = isSingleSource
-    ? `Execute SQL queries on the ${dbType} database${readonlyNote}${maxRowsNote}`
-    : `Execute SQL queries on the '${sourceId}' ${dbType} database${readonlyNote}${maxRowsNote}`;
+    ? `${userDescPrefix}Execute SQL queries on the ${dbType} database${readonlyNote}${maxRowsNote}`
+    : `${userDescPrefix}Execute SQL queries on the '${sourceId}' ${dbType} database${readonlyNote}${maxRowsNote}`;
 
   // Build annotations object with all standard MCP hints
   const isReadonly = executeOptions.readonly === true;
@@ -149,9 +152,12 @@ export function getSearchObjectsMetadata(sourceId: string): { name: string; desc
   const title = isSingleSource
     ? `Search Database Objects (${dbType})`
     : `Search Database Objects on ${sourceId} (${dbType})`;
+  // Prepend the user-provided `description` from the source config (if set)
+  // so AI clients reading the MCP tool list see the source's purpose first.
+  const userDescPrefix = sourceConfig.description ? `${sourceConfig.description}. ` : "";
   const description = isSingleSource
-    ? `Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the ${dbType} database`
-    : `Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the '${sourceId}' ${dbType} database`;
+    ? `${userDescPrefix}Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the ${dbType} database`
+    : `${userDescPrefix}Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the '${sourceId}' ${dbType} database`;
 
   return {
     name: toolName,

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -43,8 +43,11 @@ export interface ToolMetadata {
  * Build a prefix string for prepending a source's user-provided `description`
  * onto a generated tool description. Returns "" when no description is set
  * (undefined, empty, or whitespace-only). Normalizes surrounding whitespace
- * with `trim()` and avoids double sentence-ending punctuation when the
- * description already ends with one of "." / "!" / "?".
+ * with `trim()` and skips adding a period when the description already ends
+ * with one of "." / "!" / "?" / ":" — the colon is included because a
+ * trailing colon naturally introduces what follows (the generic tool
+ * template) and appending "." after it would produce artifacts like
+ * "Details below:. Execute SQL...".
  *
  * Examples:
  *   undefined            -> ""
@@ -53,11 +56,14 @@ export interface ToolMetadata {
  *   "Prod DB."           -> "Prod DB. "      (no double period)
  *   "  Prod DB!  "       -> "Prod DB! "      (trimmed, no added period)
  *   "Query me?"          -> "Query me? "
+ *   "Details below:"     -> "Details below: " (colon introduces what follows)
+ *   "Clause 1; clause 2" -> "Clause 1; clause 2. " (semicolon is mid-sentence)
+ *   "(read-only)"        -> "(read-only). "  (closing paren is mid-sentence)
  */
 export function buildSourceDescriptionPrefix(description: string | undefined): string {
   const trimmed = description?.trim() ?? "";
   if (!trimmed) return "";
-  return /[.!?]$/.test(trimmed) ? `${trimmed} ` : `${trimmed}. `;
+  return /[.!?:]$/.test(trimmed) ? `${trimmed} ` : `${trimmed}. `;
 }
 
 /**


### PR DESCRIPTION
## Summary

Makes `[[sources]].description` from `dbhub.toml` actually reach the MCP tool description that AI clients read. Previously, the field was parsed and surfaced via the REST `/api/sources` endpoint but was **completely ignored** by the MCP tool registration path, defeating its documented purpose: *"Helps AI models understand the purpose and contents of each database when multiple sources are configured."*

## Problem (Fixes #267)

When a user configures multiple sources in `dbhub.toml` with descriptions:

```toml
[[sources]]
id = "analytics_prod"
description = "Production read replica for BI / analytics queries"
dsn = "postgres://..."

[[sources]]
id = "payments"
description = "Payments ledger — PII, write-restricted"
dsn = "postgres://..."
```

The MCP tool descriptions that AI clients see are:

- `execute_sql_analytics_prod`: **"Execute SQL queries on the 'analytics_prod' postgres database"**
- `execute_sql_payments`: **"Execute SQL queries on the 'payments' postgres database"**

The user's carefully-written descriptions never reach the AI. Models must guess routing from the `id` alone.

This is exactly what issue #267 reported — and another user (@Diluka) confirmed in that thread: *"I asked the AI, and it said that the description wasn't in the tool's prompt"* — before the issue was closed as *"supported, doc was missing"*.

## Root cause

`SourceConfig.description` is typed in `src/types/config.ts` (L51) and parsed correctly, but:

- `src/utils/tool-metadata.ts` → `getExecuteSqlMetadata()` and `getSearchObjectsMetadata()` hardcode the template string and **never reference `sourceConfig.description`**.
- `src/tools/index.ts` → `registerExecuteSqlTool` / `registerSearchObjectsTool` pass the hardcoded template straight to `server.registerTool({ description, ... })`.
- `grep sourceConfig.description` across the repo returns **one** hit: `src/api/sources.ts` (the REST endpoint for the built-in web UI). Nothing in the MCP path.

PR #232 introduced the `description` field and its commit message says it's *"exposed via `/api/sources` for MCP clients"* — but `/api/sources` is an HTTP REST endpoint, not the MCP protocol. That's the scope gap this PR closes.

## Fix

Prepend `sourceConfig.description` (when set) to the generated description in both `getExecuteSqlMetadata()` and `getSearchObjectsMetadata()`. All existing technical signals — `[READ-ONLY MODE]`, `(limited to N rows)`, source id, `dbType` — are preserved unchanged.

**Before:**
```
Execute SQL queries on the 'analytics_prod' postgres database [READ-ONLY MODE] (limited to 1000 rows)
```

**After (with `description = \"Production read replica for BI / analytics queries\"`):**
```
Production read replica for BI / analytics queries. Execute SQL queries on the 'analytics_prod' postgres database [READ-ONLY MODE] (limited to 1000 rows)
```

Business context comes first (stronger routing signal for the AI), technical/safety context is preserved and unchanged.

### What's not touched

- **Custom tool descriptions** (`CustomToolConfig.description`): already work correctly, path unchanged. Custom tools carry their own required description; prepending the source description to them would override explicit user intent.
- **REST `/api/sources` endpoint**: `tool.description` reflects the new concatenated string, `source.description` still returns the raw user-provided value. Existing web UI behavior is preserved.
- **`title`, `annotations`**: unchanged.

## Test plan

- [x] New integration test: `src/utils/__tests__/tool-metadata.integration.test.ts` (4 tests) covering `getExecuteSqlMetadata` and `getSearchObjectsMetadata` for sources with and without description. Verifies the prefix appears first, and the original template + readonly note are retained.
- [x] Existing tests unchanged — all 22 tests in `src/api/__tests__/sources.integration.test.ts` still pass, including `toContain(source.id)` / `toContain(source.type)` assertions that now also see the prefix.
- [x] TypeScript compile: `pnpm build:backend` passes.
- [x] Full test suite: no new failures introduced. The 3 unrelated pre-existing Windows / environment-specific failures (`sqlite.integration.test.ts` for file-based readonly, `manager.test.ts` for `.ssh/config` path separator, `json-rpc-integration.test.ts` for `spawn pnpm ENOENT`) exist on `main` without this patch and are out of scope.

## Related

- Closes #267
- Scope gap originates in #232 (feat: add description field for TOML sources). This PR finishes what #232 started by extending the description propagation from the REST API to the MCP protocol.
- Orthogonal to #277 (reducing multi-source context via a `list_sources` meta tool). That design change would independently benefit from accurate per-source descriptions once this PR lands.