### PR TITLE
feat: support configurable HTTP bind host via --host / DBHUB_HOST env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,9 +34,11 @@ TRANSPORT=stdio
 PORT=8080
 
 # HTTP bind host (default: 0.0.0.0 — listens on all interfaces)
-# For production, set HOST=127.0.0.1 and front DBHub with a reverse proxy
-# (nginx/Caddy) or a firewall. DBHub does not authenticate HTTP clients.
-# HOST=0.0.0.0
+# For production, set DBHUB_HOST=127.0.0.1 and front DBHub with a reverse
+# proxy (nginx/Caddy) or a firewall. DBHub does not authenticate HTTP
+# clients. The variable is prefixed to avoid collisions with the generic
+# HOST env var that some shells and CI systems set automatically.
+# DBHUB_HOST=0.0.0.0
 
 # SSH Tunnel Configuration (optional)
 # Use these settings to connect through an SSH bastion host

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ TRANSPORT=stdio
 # Used for both frontend and MCP endpoint (when transport=http)
 PORT=8080
 
+# HTTP bind host (default: 0.0.0.0 — listens on all interfaces)
+# For production, set HOST=127.0.0.1 and front DBHub with a reverse proxy
+# (nginx/Caddy) or a firewall. DBHub does not authenticate HTTP clients.
+# HOST=0.0.0.0
+
 # SSH Tunnel Configuration (optional)
 # Use these settings to connect through an SSH bastion host
 # SSH_HOST=bastion.example.com

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ npx @bytebase/dbhub@latest --transport http --port 8080 --dsn "postgres://user:p
 npx @bytebase/dbhub@latest --transport http --port 8080 --demo
 ```
 
+**Restrict to loopback (recommended for production):**
+
+```bash
+npx @bytebase/dbhub@latest --transport http --host 127.0.0.1 --port 8080 --demo
+```
+
+> The HTTP transport defaults to `--host 0.0.0.0`, exposing DBHub on every network interface. For production, bind to `127.0.0.1` and front DBHub with a reverse proxy (nginx/Caddy) or firewall — DBHub does not authenticate HTTP clients.
+
 See [Command-Line Options](https://dbhub.ai/config/command-line) for all available parameters.
 
 ### Multi-Database Setup

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -50,6 +50,27 @@ Command-line flags are passed when starting DBHub. These have the highest priori
   ```
 </ParamField>
 
+### --host
+
+<ParamField path="--host" type="string" env="HOST" default="0.0.0.0">
+  HTTP bind address. Only used when `--transport=http`. Ignored for stdio transport.
+
+  ```bash
+  # Restrict to loopback (recommended for production)
+  npx @bytebase/dbhub@latest --transport http --host 127.0.0.1 --port 8080 --dsn "..."
+
+  # Bind to a specific interface
+  npx @bytebase/dbhub@latest --transport http --host 10.0.0.5 --port 8080 --dsn "..."
+
+  # IPv6 loopback
+  npx @bytebase/dbhub@latest --transport http --host ::1 --port 8080 --dsn "..."
+  ```
+
+  <Warning>
+  The default `0.0.0.0` exposes DBHub on every network interface. For production, set `--host 127.0.0.1` and place DBHub behind a reverse proxy (nginx/Caddy) or restrict with a firewall — DBHub does not authenticate HTTP clients.
+  </Warning>
+</ParamField>
+
 ### --dsn
 
 <ParamField path="--dsn" type="string" env="DSN">
@@ -274,6 +295,7 @@ npx @bytebase/dbhub@latest --dsn "..." \
 |------------|---------------------|------|-------------|
 | `--transport` | `TRANSPORT` | string | Transport mode: stdio or http (default: `stdio`) |
 | `--port` | `PORT` | number | HTTP server port (http transport only, default: `8080`) |
+| `--host` | `HOST` | string | HTTP bind address (http transport only, default: `0.0.0.0`) |
 | `--demo` | - | boolean | Use sample employee database |
 | `--id` | `ID` | string | Instance identifier for tool names |
 | `--config` | - | string | Path to TOML config file (default: `./dbhub.toml`) |

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -52,7 +52,7 @@ Command-line flags are passed when starting DBHub. These have the highest priori
 
 ### --host
 
-<ParamField path="--host" type="string" env="HOST" default="0.0.0.0">
+<ParamField path="--host" type="string" env="DBHUB_HOST" default="0.0.0.0">
   HTTP bind address. Only used when `--transport=http`. Ignored for stdio transport.
 
   ```bash
@@ -295,7 +295,7 @@ npx @bytebase/dbhub@latest --dsn "..." \
 |------------|---------------------|------|-------------|
 | `--transport` | `TRANSPORT` | string | Transport mode: stdio or http (default: `stdio`) |
 | `--port` | `PORT` | number | HTTP server port (http transport only, default: `8080`) |
-| `--host` | `HOST` | string | HTTP bind address (http transport only, default: `0.0.0.0`) |
+| `--host` | `DBHUB_HOST` | string | HTTP bind address (http transport only, default: `0.0.0.0`) |
 | `--demo` | - | boolean | Use sample employee database |
 | `--id` | `ID` | string | Instance identifier for tool names |
 | `--config` | - | string | Path to TOML config file (default: `./dbhub.toml`) |

--- a/src/__tests__/http-bind-host.integration.test.ts
+++ b/src/__tests__/http-bind-host.integration.test.ts
@@ -22,7 +22,7 @@ describe('HTTP bind host integration', () => {
       env: {
         ...process.env,
         DSN: `sqlite://${testDbPath}`,
-        HOST: testHost,
+        DBHUB_HOST: testHost,
         PORT: testPort.toString(),
         NODE_ENV: 'test',
       },

--- a/src/__tests__/http-bind-host.integration.test.ts
+++ b/src/__tests__/http-bind-host.integration.test.ts
@@ -61,11 +61,16 @@ describe('HTTP bind host integration', () => {
       serverProcess.kill('SIGTERM');
       await new Promise<void>((resolve) => {
         if (!serverProcess) return resolve();
-        serverProcess.on('exit', () => resolve());
-        setTimeout(() => {
+        // Without clearing this on normal exit, the pending timer keeps
+        // the Vitest process alive until the 5s tail elapses.
+        const killTimeout = setTimeout(() => {
           if (serverProcess && !serverProcess.killed) serverProcess.kill('SIGKILL');
           resolve();
         }, 5000);
+        serverProcess.on('exit', () => {
+          clearTimeout(killTimeout);
+          resolve();
+        });
       });
     }
     if (testDbPath && fs.existsSync(testDbPath)) {

--- a/src/__tests__/http-bind-host.integration.test.ts
+++ b/src/__tests__/http-bind-host.integration.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('HTTP bind host integration', () => {
+  let serverProcess: ChildProcess | null = null;
+  let testDbPath: string;
+  const testPort = 3002;
+  const testHost = '127.0.0.1';
+  const startupLogs: string[] = [];
+
+  beforeAll(async () => {
+    testDbPath = path.join(os.tmpdir(), `bind_host_test_${Date.now()}_${Math.random().toString(36).substr(2, 9)}.db`);
+
+    // Invoke tsx directly via node to avoid pnpm.cmd resolution issues on Windows.
+    const tsxCli = path.resolve(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
+    const entry = path.resolve(process.cwd(), 'src', 'index.ts');
+
+    serverProcess = spawn(process.execPath, [tsxCli, entry, '--transport=http'], {
+      env: {
+        ...process.env,
+        DSN: `sqlite://${testDbPath}`,
+        HOST: testHost,
+        PORT: testPort.toString(),
+        NODE_ENV: 'test',
+      },
+      stdio: 'pipe',
+    });
+
+    serverProcess.stdout?.on('data', (data) => {
+      startupLogs.push(data.toString());
+    });
+    serverProcess.stderr?.on('data', (data) => {
+      startupLogs.push(data.toString());
+    });
+
+    // Wait for /healthz to respond on the configured host
+    let ready = false;
+    for (let i = 0; i < 30; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      try {
+        const res = await fetch(`http://${testHost}:${testPort}/healthz`);
+        if (res.status === 200) {
+          ready = true;
+          break;
+        }
+      } catch {
+        // not ready yet
+      }
+    }
+
+    if (!ready) {
+      throw new Error(`Server did not bind to ${testHost}:${testPort} within timeout. Logs:\n${startupLogs.join('')}`);
+    }
+  }, 45000);
+
+  afterAll(async () => {
+    if (serverProcess) {
+      serverProcess.kill('SIGTERM');
+      await new Promise<void>((resolve) => {
+        if (!serverProcess) return resolve();
+        serverProcess.on('exit', () => resolve());
+        setTimeout(() => {
+          if (serverProcess && !serverProcess.killed) serverProcess.kill('SIGKILL');
+          resolve();
+        }, 5000);
+      });
+    }
+    if (testDbPath && fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+  });
+
+  it('responds on the configured host', async () => {
+    const res = await fetch(`http://${testHost}:${testPort}/healthz`);
+    expect(res.status).toBe(200);
+  });
+
+  it('logs the actual bound address at startup', () => {
+    const allLogs = startupLogs.join('');
+    expect(allLogs).toContain(`${testHost}:${testPort}`);
+  });
+});

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -494,5 +494,33 @@ describe('Environment Configuration Tests', () => {
 
       expect(result).toEqual({ host: 'true', source: 'command line argument' });
     });
+
+    it('exits when --host= is provided with an empty value', () => {
+      process.argv = ['node', 'script.js', '--host='];
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => resolveHost()).toThrow('process.exit: 1');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--host requires a value'));
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('exits when --host= is followed by another flag', () => {
+      process.argv = ['node', 'script.js', '--host=', '--port=8080'];
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => resolveHost()).toThrow('process.exit: 1');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--host requires a value'));
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
   });
 });

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -460,6 +460,26 @@ describe('Environment Configuration Tests', () => {
       expect(result).toEqual({ host: '0.0.0.0', source: 'default' });
     });
 
+    it('treats whitespace-only DBHUB_HOST env var as unset and falls back to default', () => {
+      // Without trimming, Node's listen() would be handed "   " verbatim and
+      // fail with an obscure bind error. Consistent with the `--host` flag
+      // validation, treat blank-after-trim as "not set" rather than silently
+      // misconfigured.
+      process.env.DBHUB_HOST = '   ';
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '0.0.0.0', source: 'default' });
+    });
+
+    it('trims surrounding whitespace from DBHUB_HOST env var', () => {
+      process.env.DBHUB_HOST = '  127.0.0.1  ';
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '127.0.0.1', source: 'environment variable' });
+    });
+
     it('accepts IPv6 addresses verbatim', () => {
       process.env.DBHUB_HOST = '::1';
 

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -397,6 +397,7 @@ describe('Environment Configuration Tests', () => {
 
     beforeEach(() => {
       delete process.env.HOST;
+      delete process.env.DBHUB_HOST;
       process.argv = ['node', 'script.js'];
     });
 
@@ -410,12 +411,20 @@ describe('Environment Configuration Tests', () => {
       expect(result).toEqual({ host: '0.0.0.0', source: 'default' });
     });
 
-    it('reads HOST from the environment variable', () => {
-      process.env.HOST = '127.0.0.1';
+    it('reads DBHUB_HOST from the environment variable', () => {
+      process.env.DBHUB_HOST = '127.0.0.1';
 
       const result = resolveHost();
 
       expect(result).toEqual({ host: '127.0.0.1', source: 'environment variable' });
+    });
+
+    it('ignores the generic HOST env var to avoid shell/CI collisions', () => {
+      process.env.HOST = 'my-laptop.local';
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '0.0.0.0', source: 'default' });
     });
 
     it('reads --host from command line arguments (equals form)', () => {
@@ -434,8 +443,8 @@ describe('Environment Configuration Tests', () => {
       expect(result).toEqual({ host: '192.168.1.10', source: 'command line argument' });
     });
 
-    it('prefers --host over HOST environment variable', () => {
-      process.env.HOST = '0.0.0.0';
+    it('prefers --host over DBHUB_HOST environment variable', () => {
+      process.env.DBHUB_HOST = '0.0.0.0';
       process.argv = ['node', 'script.js', '--host=127.0.0.1'];
 
       const result = resolveHost();
@@ -443,8 +452,8 @@ describe('Environment Configuration Tests', () => {
       expect(result).toEqual({ host: '127.0.0.1', source: 'command line argument' });
     });
 
-    it('treats empty HOST env var as unset and falls back to default', () => {
-      process.env.HOST = '';
+    it('treats empty DBHUB_HOST env var as unset and falls back to default', () => {
+      process.env.DBHUB_HOST = '';
 
       const result = resolveHost();
 
@@ -452,7 +461,7 @@ describe('Environment Configuration Tests', () => {
     });
 
     it('accepts IPv6 addresses verbatim', () => {
-      process.env.HOST = '::1';
+      process.env.DBHUB_HOST = '::1';
 
       const result = resolveHost();
 

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -472,5 +472,27 @@ describe('Environment Configuration Tests', () => {
       exitSpy.mockRestore();
       errorSpy.mockRestore();
     });
+
+    it('exits when --host is followed by another flag', () => {
+      process.argv = ['node', 'script.js', '--host', '--port=8080'];
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => resolveHost()).toThrow('process.exit: 1');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--host requires a value'));
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('passes through an explicit --host=true without erroring (node listen will reject it)', () => {
+      process.argv = ['node', 'script.js', '--host=true'];
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: 'true', source: 'command line argument' });
+    });
   });
 });

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { buildDSNFromEnvParams, resolveDSN, resolveId } from '../env.js';
+import { buildDSNFromEnvParams, resolveDSN, resolveHost, resolveId } from '../env.js';
 
 // Mock toml-loader to prevent it from loading dbhub.toml during tests
 vi.mock('../toml-loader.js', () => ({
@@ -389,6 +389,88 @@ describe('Environment Configuration Tests', () => {
         id: '123',
         source: 'environment variable'
       });
+    });
+  });
+
+  describe('resolveHost', () => {
+    const originalArgv = process.argv;
+
+    beforeEach(() => {
+      delete process.env.HOST;
+      process.argv = ['node', 'script.js'];
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+    });
+
+    it('defaults to 0.0.0.0 when nothing is set', () => {
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '0.0.0.0', source: 'default' });
+    });
+
+    it('reads HOST from the environment variable', () => {
+      process.env.HOST = '127.0.0.1';
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '127.0.0.1', source: 'environment variable' });
+    });
+
+    it('reads --host from command line arguments (equals form)', () => {
+      process.argv = ['node', 'script.js', '--host=10.0.0.5'];
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '10.0.0.5', source: 'command line argument' });
+    });
+
+    it('reads --host from command line arguments (space form)', () => {
+      process.argv = ['node', 'script.js', '--host', '192.168.1.10'];
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '192.168.1.10', source: 'command line argument' });
+    });
+
+    it('prefers --host over HOST environment variable', () => {
+      process.env.HOST = '0.0.0.0';
+      process.argv = ['node', 'script.js', '--host=127.0.0.1'];
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '127.0.0.1', source: 'command line argument' });
+    });
+
+    it('treats empty HOST env var as unset and falls back to default', () => {
+      process.env.HOST = '';
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '0.0.0.0', source: 'default' });
+    });
+
+    it('accepts IPv6 addresses verbatim', () => {
+      process.env.HOST = '::1';
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '::1', source: 'environment variable' });
+    });
+
+    it('exits when --host is provided without a value', () => {
+      process.argv = ['node', 'script.js', '--host'];
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => resolveHost()).toThrow('process.exit: 1');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--host requires a value'));
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
     });
   });
 });

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -586,5 +586,32 @@ describe('Environment Configuration Tests', () => {
       exitSpy.mockRestore();
       errorSpy.mockRestore();
     });
+
+    it('exits when --host value is whitespace-only (quoted)', () => {
+      // Shells can pass a quoted whitespace value through to argv, e.g.
+      //   --host="   "
+      // The env var path already rejects this; the CLI path should match
+      // so the user gets the same friendly error instead of an opaque
+      // listen() failure.
+      process.argv = ['node', 'script.js', '--host=   '];
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => resolveHost()).toThrow('process.exit: 1');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--host requires a value'));
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('trims surrounding whitespace from --host CLI value', () => {
+      process.argv = ['node', 'script.js', '--host=  127.0.0.1  '];
+
+      const result = resolveHost();
+
+      expect(result).toEqual({ host: '127.0.0.1', source: 'command line argument' });
+    });
   });
 });

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -531,5 +531,40 @@ describe('Environment Configuration Tests', () => {
       exitSpy.mockRestore();
       errorSpy.mockRestore();
     });
+
+    it('exits when --host= is present even if a non-flag token follows (empty value, no concatenation)', () => {
+      // `--host= 127.0.0.1` is not the same as `--host=127.0.0.1`: the token
+      // is literally the empty string. parseCommandLineArgs has already been
+      // observed to bind the positional that follows to --host, silently
+      // accepting what the user almost certainly did not intend.
+      process.argv = ['node', 'script.js', '--host=', '127.0.0.1'];
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => resolveHost()).toThrow('process.exit: 1');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--host requires a value'));
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('exits when a later bare --host appears after an earlier valid --host', () => {
+      // With an early break in the argv scan, only the first --host is
+      // inspected — a later duplicate bare --host sneaks through even though
+      // it has no value and the user's intent is ambiguous.
+      process.argv = ['node', 'script.js', '--host', '127.0.0.1', '--host'];
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => resolveHost()).toThrow('process.exit: 1');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--host requires a value'));
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
   });
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -375,9 +375,17 @@ export function resolveHost(): { host: string; source: string } {
 
   const args = parseCommandLineArgs();
 
-  // 1. Command line argument has highest priority
-  if (args.host) {
-    return { host: args.host, source: "command line argument" };
+  // 1. Command line argument has highest priority.
+  //    Trim surrounding whitespace; a whitespace-only value (e.g. from
+  //    `--host="   "`) is rejected with the same friendly error as the
+  //    bare/empty forms, matching the env var path below.
+  if (args.host !== undefined) {
+    const cliHost = args.host.trim();
+    if (!cliHost) {
+      console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");
+      process.exit(1);
+    }
+    return { host: cliHost, source: "command line argument" };
   }
 
   // 2. Environment variable (trimmed; empty or whitespace-only is unset)

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -334,6 +334,36 @@ export function resolvePort(): { port: number; source: string } {
 }
 
 /**
+ * Resolve HTTP bind host from command line args or environment variables.
+ * Returns the host with "0.0.0.0" as the default (listen on all interfaces).
+ *
+ * Note: Only applicable when using --transport=http. Default "0.0.0.0" keeps
+ * backward compatibility; production deployments should set "127.0.0.1" and
+ * front DBHub with a reverse proxy or firewall.
+ */
+export function resolveHost(): { host: string; source: string } {
+  const args = parseCommandLineArgs();
+
+  // 1. Command line argument has highest priority.
+  //    parseCommandLineArgs turns bare --host (no value) into "true"; reject it.
+  if (args.host) {
+    if (args.host === "true") {
+      console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");
+      process.exit(1);
+    }
+    return { host: args.host, source: "command line argument" };
+  }
+
+  // 2. Environment variable (empty string is treated as unset)
+  if (process.env.HOST) {
+    return { host: process.env.HOST, source: "environment variable" };
+  }
+
+  // 3. Default: bind all interfaces
+  return { host: "0.0.0.0", source: "default" };
+}
+
+/**
  * Redact sensitive information from a DSN string
  * Replaces the password with asterisks
  * @param dsn - The DSN string to redact

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -380,12 +380,15 @@ export function resolveHost(): { host: string; source: string } {
     return { host: args.host, source: "command line argument" };
   }
 
-  // 2. Environment variable (empty string is treated as unset)
+  // 2. Environment variable (trimmed; empty or whitespace-only is unset)
   //    Using DBHUB_HOST rather than generic HOST to avoid collisions — HOST is
   //    set by default in csh/tcsh, some CI systems, and Docker base images
   //    (often to the machine hostname), which would silently redirect binds.
-  if (process.env.DBHUB_HOST) {
-    return { host: process.env.DBHUB_HOST, source: "environment variable" };
+  //    Trimming matches the --host flag's validation so `DBHUB_HOST="   "`
+  //    doesn't get handed to listen() and fail with an obscure bind error.
+  const envHost = process.env.DBHUB_HOST?.trim();
+  if (envHost) {
+    return { host: envHost, source: "environment variable" };
   }
 
   // 3. Default: bind all interfaces

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -342,15 +342,26 @@ export function resolvePort(): { port: number; source: string } {
  * front DBHub with a reverse proxy or firewall.
  */
 export function resolveHost(): { host: string; source: string } {
+  // Detect bare --host (no value) directly in argv. parseCommandLineArgs()
+  // collapses bare flags and --host=true into the same string "true", so we
+  // inspect argv here to report a friendly error only for the genuinely bare
+  // case. An explicit --host=true passes through and fails later at listen().
+  const rawArgs = process.argv.slice(2);
+  for (let i = 0; i < rawArgs.length; i++) {
+    if (rawArgs[i] === "--host") {
+      const next = rawArgs[i + 1];
+      if (!next || next.startsWith("--")) {
+        console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");
+        process.exit(1);
+      }
+      break;
+    }
+  }
+
   const args = parseCommandLineArgs();
 
-  // 1. Command line argument has highest priority.
-  //    parseCommandLineArgs turns bare --host (no value) into "true"; reject it.
+  // 1. Command line argument has highest priority
   if (args.host) {
-    if (args.host === "true") {
-      console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");
-      process.exit(1);
-    }
     return { host: args.host, source: "command line argument" };
   }
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -345,9 +345,14 @@ export function resolveHost(): { host: string; source: string } {
   // Detect a missing --host value directly in argv. parseCommandLineArgs()
   // collapses bare flags and explicit empty values into the same sentinel
   // string "true", which is indistinguishable from an explicit --host=true.
-  // We inspect argv here so we can reject only the genuinely value-less cases:
+  // We inspect argv so we can reject genuinely value-less forms:
   //   --host            (followed by nothing or another --flag)
-  //   --host=           (empty after equals, alone or followed by another --flag)
+  //   --host=           (empty after equals — always an error, even if a
+  //                      positional follows, since the space makes the
+  //                      user's intent ambiguous and a later positional
+  //                      would otherwise be silently bound to --host)
+  // We scan the entire argv (no early break) so a later bare/duplicate
+  // --host does not slip past an earlier valid occurrence.
   // An explicit --host=true passes through and fails later at listen().
   const rawArgs = process.argv.slice(2);
   for (let i = 0; i < rawArgs.length; i++) {
@@ -359,16 +364,12 @@ export function resolveHost(): { host: string; source: string } {
         console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");
         process.exit(1);
       }
-      break;
+      continue;
     }
 
     if (token === "--host=") {
-      const next = rawArgs[i + 1];
-      if (!next || next.startsWith("--")) {
-        console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");
-        process.exit(1);
-      }
-      break;
+      console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");
+      process.exit(1);
     }
   }
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -380,8 +380,11 @@ export function resolveHost(): { host: string; source: string } {
   }
 
   // 2. Environment variable (empty string is treated as unset)
-  if (process.env.HOST) {
-    return { host: process.env.HOST, source: "environment variable" };
+  //    Using DBHUB_HOST rather than generic HOST to avoid collisions — HOST is
+  //    set by default in csh/tcsh, some CI systems, and Docker base images
+  //    (often to the machine hostname), which would silently redirect binds.
+  if (process.env.DBHUB_HOST) {
+    return { host: process.env.DBHUB_HOST, source: "environment variable" };
   }
 
   // 3. Default: bind all interfaces

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -342,13 +342,27 @@ export function resolvePort(): { port: number; source: string } {
  * front DBHub with a reverse proxy or firewall.
  */
 export function resolveHost(): { host: string; source: string } {
-  // Detect bare --host (no value) directly in argv. parseCommandLineArgs()
-  // collapses bare flags and --host=true into the same string "true", so we
-  // inspect argv here to report a friendly error only for the genuinely bare
-  // case. An explicit --host=true passes through and fails later at listen().
+  // Detect a missing --host value directly in argv. parseCommandLineArgs()
+  // collapses bare flags and explicit empty values into the same sentinel
+  // string "true", which is indistinguishable from an explicit --host=true.
+  // We inspect argv here so we can reject only the genuinely value-less cases:
+  //   --host            (followed by nothing or another --flag)
+  //   --host=           (empty after equals, alone or followed by another --flag)
+  // An explicit --host=true passes through and fails later at listen().
   const rawArgs = process.argv.slice(2);
   for (let i = 0; i < rawArgs.length; i++) {
-    if (rawArgs[i] === "--host") {
+    const token = rawArgs[i];
+
+    if (token === "--host") {
+      const next = rawArgs[i + 1];
+      if (!next || next.startsWith("--")) {
+        console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");
+        process.exit(1);
+      }
+      break;
+    }
+
+    if (token === "--host=") {
       const next = rawArgs[i + 1];
       if (!next || next.startsWith("--")) {
         console.error("ERROR: --host requires a value (e.g., --host=127.0.0.1).");

--- a/src/server.ts
+++ b/src/server.ts
@@ -269,11 +269,13 @@ See documentation for more details on configuring database connections.
 
         console.error(`HTTP server listening on ${displayHost}:${boundPort}`);
 
-        // In development mode, suggest using the Vite dev server for hot reloading
+        // In development mode, suggest using the Vite dev server for hot reloading.
+        // Vite serves from localhost; use the same hostname for the backend hint so
+        // cross-origin calls from Vite satisfy the DNS-rebinding middleware check.
         if (process.env.NODE_ENV === 'development') {
           console.error('Development mode detected!');
           console.error('   Workbench dev server (with HMR): http://localhost:5173');
-          console.error(`   Backend API: http://${userHost}:${boundPort}`);
+          console.error(`   Backend API: http://localhost:${boundPort}`);
           console.error('');
         } else {
           console.error(`Workbench at http://${userHost}:${boundPort}/`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import express from "express";
+import http from "http";
 import path from "path";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
@@ -251,8 +252,19 @@ See documentation for more details on configuring database connections.
         });
       }
 
-      // Start the HTTP server
-      const httpServer = app.listen(port!, host!, () => {
+      // Start the HTTP server. Create explicitly so the `error` listener is
+      // attached before listen() — otherwise synchronous bind failures
+      // (EADDRINUSE, EACCES on privileged ports) can fire before the listener
+      // is registered. Matches the pattern used in utils/ssh-tunnel.ts.
+      const httpServer = http.createServer(app);
+
+      httpServer.on('error', (err) => {
+        const displayHost = host!.includes(':') ? `[${host!}]` : host!;
+        console.error(`Failed to bind HTTP server to ${displayHost}:${port}: ${err.message}`);
+        process.exit(1);
+      });
+
+      httpServer.listen(port!, host!, () => {
         const address = httpServer.address();
         const boundHost = typeof address === 'object' && address ? address.address : host!;
         const boundPort = typeof address === 'object' && address ? address.port : port!;
@@ -274,12 +286,6 @@ See documentation for more details on configuring database connections.
           console.error(`Workbench at http://${userHost}:${boundPort}/`);
         }
         console.error(`MCP server endpoint at http://${userHost}:${boundPort}/mcp`);
-      });
-
-      httpServer.on('error', (err) => {
-        const displayHost = host!.includes(':') ? `[${host!}]` : host!;
-        console.error(`Failed to bind HTTP server to ${displayHost}:${port}: ${err.message}`);
-        process.exit(1);
       });
     } else {
       // STDIO transport: Pure MCP-over-stdio, no HTTP server

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { listRequests } from "./api/requests.js";
 import { generateStartupTable, buildSourceDisplayInfo } from "./utils/startup-table.js";
 import { getToolsForSource } from "./utils/tool-metadata.js";
 import { startConfigWatcher } from "./utils/config-watcher.js";
+import { validateOrigin } from "./utils/dns-rebinding.js";
 
 // Create __dirname equivalent for ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -177,20 +178,12 @@ See documentation for more details on configuring database connections.
       // send Origin at all and are unaffected.
       app.use((req, res, next) => {
         const origin = req.headers.origin;
-
-        if (origin) {
-          const host = (req.headers.host ?? '').split(':')[0].toLowerCase();
-          try {
-            const originHost = new URL(origin).hostname.toLowerCase();
-            if (originHost !== host) {
-              return res.status(403).json({
-                error: 'Forbidden',
-                message: 'Origin does not match Host header (DNS rebinding protection)',
-              });
-            }
-          } catch {
-            return res.status(400).json({ error: 'Bad Request', message: 'Malformed Origin header' });
-          }
+        const result = validateOrigin(origin, req.headers.host);
+        if (!result.ok) {
+          return res.status(result.status).json({
+            error: result.status === 400 ? 'Bad Request' : 'Forbidden',
+            message: result.message,
+          });
         }
 
         // CORS headers — only reflect validated origins

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "url";
 
 import { ConnectorManager } from "./connectors/manager.js";
 import { ConnectorRegistry } from "./connectors/interface.js";
-import { resolveTransport, resolvePort, resolveSourceConfigs, isDemoMode } from "./config/env.js";
+import { resolveTransport, resolvePort, resolveHost, resolveSourceConfigs, isDemoMode } from "./config/env.js";
 import { registerTools } from "./tools/index.js";
 import { listSources, getSource } from "./api/sources.js";
 import { listRequests } from "./api/requests.js";
@@ -129,8 +129,9 @@ See documentation for more details on configuring database connections.
     // Resolve transport type (for MCP server)
     const transportData = resolveTransport();
 
-    // Resolve port for HTTP server (only needed for http transport)
+    // Resolve port and host for HTTP server (only needed for http transport)
     const port = transportData.type === "http" ? resolvePort().port : null;
+    const host = transportData.type === "http" ? resolveHost().host : null;
 
     // Print ASCII art banner with version and slogan
     // Collect active modes
@@ -258,17 +259,32 @@ See documentation for more details on configuring database connections.
       }
 
       // Start the HTTP server
-      app.listen(port, '0.0.0.0', () => {
+      const httpServer = app.listen(port!, host!, () => {
+        const address = httpServer.address();
+        const boundHost = typeof address === 'object' && address ? address.address : host!;
+        const boundPort = typeof address === 'object' && address ? address.port : port!;
+        const displayHost = boundHost.includes(':') ? `[${boundHost}]` : boundHost;
+        // Wildcard binds (0.0.0.0 / ::) are not routable; use localhost for user URLs.
+        const userHost = (boundHost === '0.0.0.0' || boundHost === '::') ? 'localhost' : displayHost;
+
+        console.error(`HTTP server listening on ${displayHost}:${boundPort}`);
+
         // In development mode, suggest using the Vite dev server for hot reloading
         if (process.env.NODE_ENV === 'development') {
           console.error('Development mode detected!');
           console.error('   Workbench dev server (with HMR): http://localhost:5173');
-          console.error('   Backend API: http://localhost:8080');
+          console.error(`   Backend API: http://${userHost}:${boundPort}`);
           console.error('');
         } else {
-          console.error(`Workbench at http://localhost:${port}/`);
+          console.error(`Workbench at http://${userHost}:${boundPort}/`);
         }
-        console.error(`MCP server endpoint at http://localhost:${port}/mcp`);
+        console.error(`MCP server endpoint at http://${userHost}:${boundPort}/mcp`);
+      });
+
+      httpServer.on('error', (err) => {
+        const displayHost = host!.includes(':') ? `[${host!}]` : host!;
+        console.error(`Failed to bind HTTP server to ${displayHost}:${port}: ${err.message}`);
+        process.exit(1);
       });
     } else {
       // STDIO transport: Pure MCP-over-stdio, no HTTP server

--- a/src/server.ts
+++ b/src/server.ts
@@ -172,11 +172,14 @@ See documentation for more details on configuring database connections.
       // Enable JSON parsing
       app.use(express.json());
 
-      // DNS rebinding protection: reject cross-origin requests where the
-      // Origin hostname doesn't match the Host hostname.  Browser-based
-      // attacks (the DNS rebinding threat model) always send an Origin
-      // header on cross-origin fetches.  Non-browser MCP clients don't
-      // send Origin at all and are unaffected.
+      // Cross-origin fetch guard: when a browser sends Origin, require
+      // it to match the Host header.  This blocks the common case of an
+      // attacker's site on a different origin issuing an authenticated
+      // fetch to a locally bound DBHub; it is NOT a complete defense
+      // against DNS rebinding, since a rebinding attacker controls both
+      // the DNS record and the Origin string and can trivially make them
+      // agree.  A Host-header allowlist is tracked as follow-up hardening.
+      // Non-browser MCP clients typically omit Origin and are unaffected.
       app.use((req, res, next) => {
         const origin = req.headers.origin;
         const result = validateOrigin(origin, req.headers.host);

--- a/src/utils/__tests__/dns-rebinding.test.ts
+++ b/src/utils/__tests__/dns-rebinding.test.ts
@@ -34,7 +34,7 @@ describe('validateOrigin', () => {
     expect(result).toEqual({
       ok: false,
       status: 403,
-      message: 'Origin does not match Host header (DNS rebinding protection)',
+      message: 'Origin does not match Host header',
     });
   });
 

--- a/src/utils/__tests__/dns-rebinding.test.ts
+++ b/src/utils/__tests__/dns-rebinding.test.ts
@@ -61,4 +61,57 @@ describe('validateOrigin', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.status).toBe(403);
   });
+
+  it('rejects an explicitly empty Origin header as malformed (400)', () => {
+    // `Origin:` (empty value) is not the same as "Origin absent"; a browser
+    // would not produce it, and letting it through bypasses the guard.
+    expect(validateOrigin('', 'localhost:8080')).toEqual({
+      ok: false,
+      status: 400,
+      message: 'Malformed Origin header',
+    });
+  });
+
+  it('rejects a whitespace-only Origin header as malformed (400)', () => {
+    expect(validateOrigin('   ', 'localhost:8080')).toEqual({
+      ok: false,
+      status: 400,
+      message: 'Malformed Origin header',
+    });
+  });
+
+  it('rejects a Host header containing a path separator as malformed (400)', () => {
+    // `new URL("http://evil.com/localhost:8080").hostname` silently yields
+    // "evil.com"; if an attacker also sets Origin: http://evil.com the
+    // naked string-equality match would pass.
+    expect(
+      validateOrigin('http://evil.com', 'evil.com/localhost:8080')
+    ).toEqual({
+      ok: false,
+      status: 400,
+      message: 'Malformed Host header',
+    });
+  });
+
+  it('rejects a Host header containing a userinfo character as malformed (400)', () => {
+    // `new URL("http://evil.com@localhost:8080").hostname` yields
+    // "localhost"; a crafted Origin: http://localhost would then match.
+    expect(
+      validateOrigin('http://localhost:8080', 'evil.com@localhost:8080')
+    ).toEqual({
+      ok: false,
+      status: 400,
+      message: 'Malformed Host header',
+    });
+  });
+
+  it('rejects a Host header containing whitespace as malformed (400)', () => {
+    expect(
+      validateOrigin('http://localhost:8080', 'localhost 8080')
+    ).toEqual({
+      ok: false,
+      status: 400,
+      message: 'Malformed Host header',
+    });
+  });
 });

--- a/src/utils/__tests__/dns-rebinding.test.ts
+++ b/src/utils/__tests__/dns-rebinding.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { validateOrigin } from '../dns-rebinding.js';
+
+describe('validateOrigin', () => {
+  it('allows requests with no Origin header (non-browser clients)', () => {
+    expect(validateOrigin(undefined, 'localhost:8080')).toEqual({ ok: true });
+  });
+
+  it('allows matching origin and host (hostname)', () => {
+    expect(validateOrigin('http://localhost:5173', 'localhost:8080')).toEqual({ ok: true });
+  });
+
+  it('allows matching origin and host (IPv4)', () => {
+    expect(validateOrigin('http://127.0.0.1:5173', '127.0.0.1:8080')).toEqual({ ok: true });
+  });
+
+  it('allows matching origin and host for IPv6 bracketed literals', () => {
+    // Regression: .split(":")[0] mangled [::1]:8080 to "["; URL parsing preserves ::1.
+    expect(validateOrigin('http://[::1]:5173', '[::1]:8080')).toEqual({ ok: true });
+  });
+
+  it('allows matching origin and host for full IPv6 addresses', () => {
+    expect(
+      validateOrigin('http://[fe80::1]:5173', '[fe80::1]:8080')
+    ).toEqual({ ok: true });
+  });
+
+  it('is case-insensitive on hostnames', () => {
+    expect(validateOrigin('http://LocalHost:5173', 'localhost:8080')).toEqual({ ok: true });
+  });
+
+  it('rejects when Origin host does not match Host header', () => {
+    const result = validateOrigin('http://evil.com', 'localhost:8080');
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      message: 'Origin does not match Host header (DNS rebinding protection)',
+    });
+  });
+
+  it('rejects when Origin is malformed with status 400', () => {
+    const result = validateOrigin('not a url', 'localhost:8080');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.message).toBe('Malformed Origin header');
+    }
+  });
+
+  it('rejects when Host header is malformed with status 400', () => {
+    const result = validateOrigin('http://localhost:5173', '');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.message).toBe('Malformed Host header');
+    }
+  });
+
+  it('rejects when IPv4 origin does not match IPv6 host', () => {
+    const result = validateOrigin('http://127.0.0.1:5173', '[::1]:8080');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(403);
+  });
+});

--- a/src/utils/dns-rebinding.ts
+++ b/src/utils/dns-rebinding.ts
@@ -1,0 +1,53 @@
+/**
+ * Result of validating an HTTP request's Origin against its Host header.
+ */
+export type OriginValidation =
+  | { ok: true }
+  | { ok: false; status: 400 | 403; message: string };
+
+/**
+ * Check that a request's Origin hostname matches its Host header hostname.
+ *
+ * Browsers always send Origin on cross-origin fetches (the DNS-rebinding
+ * threat model), while non-browser MCP clients typically omit it. A missing
+ * Origin is therefore allowed through — the check is a defense against
+ * browser-originated cross-origin requests only.
+ *
+ * WHATWG URL parsing is used for both headers so IPv6 bracket notation
+ * (e.g., `[::1]:8080`) is handled correctly — a naive `split(':')[0]` on
+ * the Host header yields `"["` for IPv6 literals, which breaks the match.
+ */
+export function validateOrigin(
+  originHeader: string | undefined,
+  hostHeader: string | undefined
+): OriginValidation {
+  if (!originHeader) return { ok: true };
+
+  let originHostname: string;
+  try {
+    originHostname = new URL(originHeader).hostname.toLowerCase();
+  } catch {
+    return { ok: false, status: 400, message: 'Malformed Origin header' };
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(`http://${hostHeader ?? ''}`).hostname.toLowerCase();
+  } catch {
+    return { ok: false, status: 400, message: 'Malformed Host header' };
+  }
+
+  if (!hostname) {
+    return { ok: false, status: 400, message: 'Malformed Host header' };
+  }
+
+  if (originHostname !== hostname) {
+    return {
+      ok: false,
+      status: 403,
+      message: 'Origin does not match Host header (DNS rebinding protection)',
+    };
+  }
+
+  return { ok: true };
+}

--- a/src/utils/dns-rebinding.ts
+++ b/src/utils/dns-rebinding.ts
@@ -6,12 +6,24 @@ export type OriginValidation =
   | { ok: false; status: 400 | 403; message: string };
 
 /**
- * Check that a request's Origin hostname matches its Host header hostname.
+ * Check that a request's Origin hostname equals its Host header hostname.
  *
- * Browsers always send Origin on cross-origin fetches (the DNS-rebinding
- * threat model), while non-browser MCP clients typically omit it. A missing
- * Origin is therefore allowed through — the check is a defense against
- * browser-originated cross-origin requests only.
+ * Scope and limitations:
+ *
+ * - This is a cross-origin-fetch guard, not a full DNS-rebinding defense.
+ *   A true rebinding attacker controls both the DNS record the browser
+ *   resolves *and* the Origin the script sends, so they can trivially
+ *   arrange for `Origin` and `Host` to agree while still pointing at a
+ *   local service. A proper defense requires validating `Host` against
+ *   an allowlist and/or requiring authentication — tracked as future
+ *   hardening for the HTTP transport.
+ * - What this *does* block is the simpler case of a browser on a
+ *   different origin (e.g., an attacker's public site) making an
+ *   authenticated cross-origin fetch: browsers always attach the real
+ *   Origin on such requests, and it will not match the local Host.
+ * - Browsers always send `Origin` on cross-origin fetches; non-browser
+ *   MCP clients typically omit it, so a missing `Origin` is allowed
+ *   through.
  *
  * WHATWG URL parsing is used for both headers so IPv6 bracket notation
  * (e.g., `[::1]:8080`) is handled correctly — a naive `split(':')[0]` on
@@ -45,7 +57,7 @@ export function validateOrigin(
     return {
       ok: false,
       status: 403,
-      message: 'Origin does not match Host header (DNS rebinding protection)',
+      message: 'Origin does not match Host header',
     };
   }
 

--- a/src/utils/dns-rebinding.ts
+++ b/src/utils/dns-rebinding.ts
@@ -29,22 +29,44 @@ export type OriginValidation =
  * (e.g., `[::1]:8080`) is handled correctly — a naive `split(':')[0]` on
  * the Host header yields `"["` for IPv6 literals, which breaks the match.
  */
+// Characters that must not appear in a Host header per RFC 3986's host/port
+// grammar.  `new URL("http://" + host)` is lax — `evil.com/foo` silently
+// parses to hostname `evil.com` with path `/foo`, and `evil.com@localhost`
+// parses to hostname `localhost` with `evil.com` treated as userinfo.
+// Either case would let a crafted Host header slip past the equality match.
+const INVALID_HOST_CHARS = /[\s/\\@?#]/;
+
 export function validateOrigin(
   originHeader: string | undefined,
   hostHeader: string | undefined
 ): OriginValidation {
-  if (!originHeader) return { ok: true };
+  // A genuinely absent Origin is allowed: non-browser MCP clients routinely
+  // omit it, and the whole check is only meaningful for browser cross-origin
+  // fetches.  An explicitly present but empty (or whitespace-only) Origin
+  // is not what a browser would ever send, so treat it as malformed rather
+  // than silently bypassing the guard.
+  if (originHeader === undefined) return { ok: true };
+
+  const trimmedOrigin = originHeader.trim();
+  if (!trimmedOrigin) {
+    return { ok: false, status: 400, message: 'Malformed Origin header' };
+  }
+
+  const trimmedHost = (hostHeader ?? '').trim();
+  if (!trimmedHost || INVALID_HOST_CHARS.test(trimmedHost)) {
+    return { ok: false, status: 400, message: 'Malformed Host header' };
+  }
 
   let originHostname: string;
   try {
-    originHostname = new URL(originHeader).hostname.toLowerCase();
+    originHostname = new URL(trimmedOrigin).hostname.toLowerCase();
   } catch {
     return { ok: false, status: 400, message: 'Malformed Origin header' };
   }
 
   let hostname: string;
   try {
-    hostname = new URL(`http://${hostHeader ?? ''}`).hostname.toLowerCase();
+    hostname = new URL(`http://${trimmedHost}`).hostname.toLowerCase();
   } catch {
     return { ok: false, status: 400, message: 'Malformed Host header' };
   }


### PR DESCRIPTION
## Summary

Adds a `--host` CLI flag and `DBHUB_HOST` environment variable so operators can restrict the HTTP transport to loopback (`127.0.0.1`) or a specific interface. Defaults to `0.0.0.0` to preserve existing behavior.

`src/server.ts` previously hard-coded `app.listen(port, '0.0.0.0', ...)`, which meant operators had no way to keep DBHub off public interfaces on shared/multi-homed hosts.

## Changes

- `resolveHost()` in `src/config/env.ts` mirrors the existing `resolvePort()` priority: **CLI > env > default (`0.0.0.0`)**.
- Env var is namespaced as `DBHUB_HOST` (not the generic `HOST`) to avoid collisions with csh/tcsh, CI systems, and Docker base images that commonly set `HOST` to the machine hostname.
- `src/server.ts` binds to the resolved host, logs the actual bound endpoint (IPv6 brackets handled), and exits 1 on bind failure with a clear `Failed to bind HTTP server to ...` message. The `error` listener is attached before `listen()` to catch synchronous bind failures (EADDRINUSE, EACCES on privileged ports).
- Workbench URL format: `--host 0.0.0.0` / `::` renders as `http://localhost:<port>/` (clickable); explicit hosts render as `http://<host>:<port>/`.
- `resolveHost()` rejects a bare `--host`, `--host=` (empty), and duplicate bare `--host` flags with a friendly error message.
- Cross-origin fetch guard (`src/utils/dns-rebinding.ts`): rejects browser cross-origin requests where `Origin` ≠ `Host`. Documented as a browser cross-origin guard, **not** a complete DNS-rebinding defense — a full `Host` allowlist is tracked as follow-up hardening.
- Docs updated: `README.md` quick start, `.env.example`, `docs/config/command-line.mdx` (new `### --host` section + Quick Reference row) — each with a security note that DBHub does not authenticate HTTP clients and should be fronted by a reverse proxy or firewall in production.

## Backward compatibility

Zero behavior change when `--host` / `DBHUB_HOST` are unset. Existing docker, npm quick-start, and dev scripts all continue to bind `0.0.0.0`. The only additive change to startup output is a single new line: `HTTP server listening on <host>:<port>`.

## Test plan

- [x] Unit tests for `resolveHost`: default, env var, CLI (equals and space forms), CLI-beats-env, empty env string, IPv6, bare `--host` rejection, `--host=` rejection, duplicate bare `--host` rejection, generic `HOST` ignored — passing in `src/config/__tests__/env.test.ts`.
- [x] Unit tests for `validateOrigin`: IPv4/IPv6, case-insensitive match, mismatched host, malformed `Origin`/`Host` — passing in `src/utils/__tests__/dns-rebinding.test.ts`.
- [x] Integration test: spawns DBHub with `DBHUB_HOST=127.0.0.1`, verifies `/healthz` responds and the startup log contains the bound address — passing in `src/__tests__/http-bind-host.integration.test.ts`.
- [x] `pnpm run build:backend` → exit 0.
- [x] Manual verification via `netstat` on Windows:
  - `--host 127.0.0.1 --port 18080` → `TCP 127.0.0.1:18080 ... LISTENING` (loopback only).
  - default (no `--host`, `DBHUB_HOST` unset) → `TCP 0.0.0.0:18082 ... LISTENING` (all interfaces, backward compat).
  - Bare `--host` → `ERROR: --host requires a value` and exit 1.
