### PR TITLE
Fix: block dangerous administrative functions in readonly mode

### DIFF
--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -266,4 +266,131 @@ describe("isReadOnlySQL", () => {
       expect(isReadOnlySQL("/*M! DROP TABLE users */", "mysql")).toBe(false);
     });
   });
+
+  describe("dangerous function blocking", () => {
+    // PostgreSQL filesystem functions
+    it("should reject pg_read_file", () => {
+      expect(isReadOnlySQL("SELECT pg_read_file('/etc/passwd', 0, 100)", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_read_binary_file", () => {
+      expect(isReadOnlySQL("SELECT pg_read_binary_file('/etc/shadow')", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_ls_dir", () => {
+      expect(isReadOnlySQL("SELECT pg_ls_dir('/etc')", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_stat_file", () => {
+      expect(isReadOnlySQL("SELECT pg_stat_file('/etc/passwd')", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_ls_waldir", () => {
+      expect(isReadOnlySQL("SELECT pg_ls_waldir()", "postgres")).toBe(false);
+    });
+
+    // PostgreSQL configuration and connection management
+    it("should reject set_config", () => {
+      expect(isReadOnlySQL("SELECT set_config('log_statement', 'none', false)", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_terminate_backend", () => {
+      expect(isReadOnlySQL("SELECT pg_terminate_backend(12345)", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_cancel_backend", () => {
+      expect(isReadOnlySQL("SELECT pg_cancel_backend(12345)", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_reload_conf", () => {
+      expect(isReadOnlySQL("SELECT pg_reload_conf()", "postgres")).toBe(false);
+    });
+
+    // PostgreSQL large object and file write functions
+    it("should reject lo_export", () => {
+      expect(isReadOnlySQL("SELECT lo_export(12345, '/tmp/evil.sh')", "postgres")).toBe(false);
+    });
+
+    it("should reject lo_import", () => {
+      expect(isReadOnlySQL("SELECT lo_import('/etc/passwd')", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_file_write", () => {
+      expect(isReadOnlySQL("SELECT pg_file_write('/tmp/x', 'data', false)", "postgres")).toBe(false);
+    });
+
+    // PostgreSQL dblink
+    it("should reject dblink_exec", () => {
+      expect(isReadOnlySQL("SELECT dblink_exec('host=evil.com', 'DROP TABLE users')", "postgres")).toBe(false);
+    });
+
+    it("should reject dblink", () => {
+      expect(isReadOnlySQL("SELECT * FROM dblink('host=evil.com', 'SELECT secret FROM keys') AS t(s text)", "postgres")).toBe(false);
+    });
+
+    // PostgreSQL functions inside WITH/subqueries
+    it("should reject pg_read_file inside a CTE", () => {
+      expect(isReadOnlySQL("WITH data AS (SELECT pg_read_file('/etc/passwd')) SELECT * FROM data", "postgres")).toBe(false);
+    });
+
+    it("should reject pg_read_file in subquery", () => {
+      expect(isReadOnlySQL("SELECT * FROM (SELECT pg_read_file('/etc/hosts')) AS t", "postgres")).toBe(false);
+    });
+
+    // Ensure normal functions are NOT blocked
+    it("should allow normal aggregate functions", () => {
+      expect(isReadOnlySQL("SELECT count(*), avg(salary) FROM employees", "postgres")).toBe(true);
+    });
+
+    it("should allow string functions", () => {
+      expect(isReadOnlySQL("SELECT upper(name), length(name) FROM users", "postgres")).toBe(true);
+    });
+
+    it("should allow pg_catalog queries", () => {
+      expect(isReadOnlySQL("SELECT * FROM pg_catalog.pg_tables", "postgres")).toBe(true);
+    });
+
+    it("should allow current_setting (read-only counterpart of set_config)", () => {
+      expect(isReadOnlySQL("SELECT current_setting('server_version')", "postgres")).toBe(true);
+    });
+
+    // MySQL/MariaDB dangerous functions
+    it("should reject LOAD_FILE in MySQL", () => {
+      expect(isReadOnlySQL("SELECT load_file('/etc/passwd')", "mysql")).toBe(false);
+    });
+
+    it("should reject LOAD_FILE in MariaDB", () => {
+      expect(isReadOnlySQL("SELECT load_file('/etc/passwd')", "mariadb")).toBe(false);
+    });
+
+    it("should reject SELECT INTO OUTFILE in MySQL", () => {
+      expect(isReadOnlySQL("SELECT * FROM users INTO OUTFILE '/tmp/dump.csv'", "mysql")).toBe(false);
+    });
+
+    it("should reject SELECT INTO DUMPFILE in MySQL", () => {
+      expect(isReadOnlySQL("SELECT * FROM users INTO DUMPFILE '/tmp/dump.bin'", "mysql")).toBe(false);
+    });
+
+    // SQL Server dangerous functions
+    it("should reject xp_cmdshell in SQL Server", () => {
+      expect(isReadOnlySQL("SELECT * FROM xp_cmdshell('whoami')", "sqlserver")).toBe(false);
+    });
+
+    it("should reject xp_dirtree in SQL Server", () => {
+      expect(isReadOnlySQL("SELECT * FROM xp_dirtree('C:\\')", "sqlserver")).toBe(false);
+    });
+
+    it("should reject OPENROWSET in SQL Server", () => {
+      expect(isReadOnlySQL("SELECT * FROM openrowset('SQLOLEDB','server';'user';'pass','SELECT 1')", "sqlserver")).toBe(false);
+    });
+
+    // Cross-dialect: dangerous PG functions should NOT be blocked for other dialects
+    it("should not block pg_read_file in MySQL (not a MySQL function)", () => {
+      expect(isReadOnlySQL("SELECT pg_read_file FROM some_table", "mysql")).toBe(true);
+    });
+
+    it("should not block load_file in PostgreSQL (not a PG function)", () => {
+      expect(isReadOnlySQL("SELECT load_file FROM some_table", "postgres")).toBe(true);
+    });
+  });
 });

--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -384,12 +384,24 @@ describe("isReadOnlySQL", () => {
       expect(isReadOnlySQL("SELECT * FROM openrowset('SQLOLEDB','server';'user';'pass','SELECT 1')", "sqlserver")).toBe(false);
     });
 
+    it("should reject dblink_send_query", () => {
+      expect(isReadOnlySQL("SELECT dblink_send_query('conn', 'DROP TABLE users')", "postgres")).toBe(false);
+    });
+
+    it("should reject openquery in SQL Server", () => {
+      expect(isReadOnlySQL("SELECT * FROM openquery(linked_srv, 'SELECT secret FROM keys')", "sqlserver")).toBe(false);
+    });
+
     // Cross-dialect: dangerous PG functions should NOT be blocked for other dialects
     it("should not block pg_read_file in MySQL (not a MySQL function)", () => {
       expect(isReadOnlySQL("SELECT pg_read_file FROM some_table", "mysql")).toBe(true);
     });
 
-    it("should not block load_file in PostgreSQL (not a PG function)", () => {
+    it("should not block load_file as a column name in MySQL", () => {
+      expect(isReadOnlySQL("SELECT load_file FROM some_table", "mysql")).toBe(true);
+    });
+
+    it("should not block load_file as a column name in PostgreSQL", () => {
       expect(isReadOnlySQL("SELECT load_file FROM some_table", "postgres")).toBe(true);
     });
   });

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -15,6 +15,21 @@ export const allowedKeywords: Record<ConnectorType, string[]> = {
 };
 
 /**
+ * Dangerous functions that can perform privileged operations (file I/O,
+ * connection management, configuration changes) despite appearing in
+ * read-only SELECT statements. These are gated by database role privileges
+ * at the server level, but should also be blocked by the readonly keyword
+ * check as a defence-in-depth measure.
+ */
+const dangerousFunctions: Record<ConnectorType, RegExp | null> = {
+  postgres: /\b(?:pg_read_file|pg_read_binary_file|pg_ls_dir|pg_ls_logdir|pg_ls_waldir|pg_ls_tmpdir|pg_ls_archive_statusdir|pg_stat_file|pg_terminate_backend|pg_cancel_backend|pg_reload_conf|pg_rotate_logfile|set_config|dblink|dblink_exec|dblink_connect|lo_export|lo_import|pg_file_write|pg_file_rename|pg_file_unlink)\s*\(/i,
+  mysql: /\b(?:load_file|into\s+(?:outfile|dumpfile))\b/i,
+  mariadb: /\b(?:load_file|into\s+(?:outfile|dumpfile))\b/i,
+  sqlite: null,
+  sqlserver: /\b(?:xp_cmdshell|xp_fileexist|xp_dirtree|xp_subdirs|xp_fixeddrives|openrowset|opendatasource|bulk\s+insert)\s*\(/i,
+};
+
+/**
  * Keywords that indicate data-modifying operations.
  * Used to detect DML/DDL hidden inside CTEs or other constructs.
  */
@@ -115,6 +130,13 @@ function checkReadOnly(cleanedSQL: string, connectorType: ConnectorType | string
         return false;
       }
     }
+  }
+
+  // Block dangerous functions that can perform filesystem I/O or
+  // configuration changes despite being inside a valid SELECT statement.
+  const dangerousPattern = dangerousFunctions[connectorType as ConnectorType];
+  if (dangerousPattern && dangerousPattern.test(cleanedSQL)) {
+    return false;
   }
 
   return true;

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -22,11 +22,11 @@ export const allowedKeywords: Record<ConnectorType, string[]> = {
  * check as a defence-in-depth measure.
  */
 const dangerousFunctions: Record<ConnectorType, RegExp | null> = {
-  postgres: /\b(?:pg_read_file|pg_read_binary_file|pg_ls_dir|pg_ls_logdir|pg_ls_waldir|pg_ls_tmpdir|pg_ls_archive_statusdir|pg_stat_file|pg_terminate_backend|pg_cancel_backend|pg_reload_conf|pg_rotate_logfile|set_config|dblink|dblink_exec|dblink_connect|lo_export|lo_import|pg_file_write|pg_file_rename|pg_file_unlink)\s*\(/i,
-  mysql: /\b(?:load_file|into\s+(?:outfile|dumpfile))\b/i,
-  mariadb: /\b(?:load_file|into\s+(?:outfile|dumpfile))\b/i,
+  postgres: /\b(?:pg_read_file|pg_read_binary_file|pg_ls_dir|pg_ls_logdir|pg_ls_waldir|pg_ls_tmpdir|pg_ls_archive_statusdir|pg_ls_replslotdir|pg_ls_logicalmapdir|pg_ls_logicalsnapdir|pg_stat_file|pg_terminate_backend|pg_cancel_backend|pg_reload_conf|pg_rotate_logfile|set_config|dblink|dblink_exec|dblink_connect|dblink_send_query|lo_export|lo_import|pg_file_write|pg_file_rename|pg_file_unlink)\s*\(/i,
+  mysql: /\b(?:load_file\s*\(|into\s+(?:outfile|dumpfile))/i,
+  mariadb: /\b(?:load_file\s*\(|into\s+(?:outfile|dumpfile))/i,
   sqlite: null,
-  sqlserver: /\b(?:xp_cmdshell|xp_fileexist|xp_dirtree|xp_subdirs|xp_fixeddrives|openrowset|opendatasource|bulk\s+insert)\s*\(/i,
+  sqlserver: /\b(?:xp_cmdshell|xp_fileexist|xp_dirtree|xp_subdirs|xp_fixeddrives|openrowset|opendatasource|openquery|bulk\s+insert)\s*\(/i,
 };
 
 /**


### PR DESCRIPTION
While looking at the readonly implementation, I noticed that PostgreSQL administrative functions like `pg_read_file()`, `pg_ls_dir()`, and `set_config()` pass right through the keyword check — they are valid SELECT statements and do not contain any mutating keywords. PostgreSQL's `default_transaction_read_only=on` does not help here either since these functions are gated by role privileges, not transaction mode.

In practice, this means a user connecting with superuser (which is common in quick setups and demos) can read arbitrary files from the server filesystem even with `readonly = true`.

This is a different class of issue from #275 (CTEs) and #284 (conditional comments) — those hid DML inside creative syntax. This one uses perfectly normal SELECT statements that happen to call privileged functions.

### The fix

A per-dialect denylist of known dangerous functions, checked after the existing keyword validation passes. The regex matches function names followed by `(` to avoid false positives on identifiers or column names that happen to share a name with these functions.

Covered dialects:
- **PostgreSQL**: `pg_read_file`, `pg_ls_dir`, `pg_stat_file`, `set_config`, `pg_terminate_backend`, `dblink_exec`, `lo_export`, and others
- **MySQL/MariaDB**: `load_file`, `INTO OUTFILE/DUMPFILE`
- **SQL Server**: `xp_cmdshell`, `xp_dirtree`, `openrowset`, `opendatasource`

Normal functions (aggregates, string ops, `current_setting`, `pg_catalog` queries) are not affected.

### Reproduction

```toml
[[sources]]
id = "default"
dsn = "postgres://postgres:password@localhost:5432/mydb"

[[tools]]
name = "execute_sql"
source = "default"
readonly = true
```

```json
{"method":"tools/call","params":{"name":"execute_sql","arguments":{"sql":"SELECT pg_read_file('/etc/passwd', 0, 200)"}}}
```

Before this fix: returns file contents. After: rejected with the standard readonly error message.

### Testing

- 29 new unit tests covering all blocked functions plus false-positive checks for safe functions
- All 689 existing unit tests pass unchanged
- Verified end-to-end against PostgreSQL 16

### A note on scope

I understand the docs say readonly is not a security boundary, and using a restricted database role is the proper defence. That said, the keyword check already blocks INSERT/DELETE/DROP regardless of connection privileges, so it felt consistent to also block functions with equivalent impact.