### PR TITLE
feat: support timezone option for MySQL/MariaDB in TOML config

### DIFF
--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -105,6 +105,12 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # id = "local_mysql"
 # dsn = "mysql://root:mysql@localhost:3306/myapp"
 
+# MySQL with explicit timezone for DATETIME interpretation (MySQL/MariaDB only)
+# [[sources]]
+# id = "local_mysql_tz"
+# dsn = "mysql://root:mysql@localhost:3306/myapp"
+# timezone = "+09:00"       # How the driver interprets DATETIME values: "Z", "local", or "±HH:MM"
+
 # MySQL on AWS RDS with IAM authentication (no password in config)
 # [[sources]]
 # id = "rds_mysql_iam"
@@ -313,6 +319,7 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #   dsn = "..."                # Connection string (or use individual params below)
 #   lazy = true                # Defer connection until first query (default: false)
 #   search_path = "schema1,public"  # PostgreSQL only: comma-separated schemas
+#   timezone = "+09:00"         # MySQL/MariaDB only: "Z", "local", or "±HH:MM"
 #   aws_iam_auth = true         # Optional: enable AWS RDS IAM auth (postgres/mysql/mariadb)
 #   aws_region = "eu-west-1"    # Required when aws_iam_auth = true
 #

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -416,6 +416,27 @@ Sources define database connections. Each source represents a database that DBHu
   </Note>
 </ParamField>
 
+### timezone
+
+<ParamField path="timezone" type="string">
+  Controls how the driver interprets `DATETIME` values. Accepts `"Z"` (UTC), `"local"`, or an offset such as `"+09:00"`.
+
+  **MySQL / MariaDB only.**
+
+  ```toml
+  [[sources]]
+  id = "production"
+  dsn = "mysql://user:pass@localhost:3306/mydb"
+  timezone = "+09:00"
+  ```
+
+  Passed through to the underlying driver's `timezone` connection option. `DATETIME` is timezone-naive, so the driver needs to know which timezone the stored values represent in order to build the correct `Date`. When unset, the driver defaults to `"local"` (the host's timezone), which yields an incorrect instant whenever the host timezone differs from the data's. Set this to the timezone the `DATETIME` values are stored in (e.g. `"+09:00"`) so they are converted to the correct UTC instant.
+
+  <Note>
+  This option is **only available via TOML**. It is not supported as a DSN query parameter.
+  </Note>
+</ParamField>
+
 ### SSH Tunnel Options
 
 <ParamField path="ssh_*" type="group">
@@ -715,6 +736,7 @@ default = 10
 | `authentication` | string | ❌ | SQL Server auth method |
 | `domain` | string | ❌ | Windows domain (NTLM) |
 | `search_path` | string | ❌ | PostgreSQL schema search path (comma-separated) |
+| `timezone` | string | ❌ | MySQL/MariaDB: `Z`, `local`, or offset like `+09:00` |
 | `ssh_host` | string | ❌ | SSH server hostname |
 | `ssh_port` | number | ❌ | SSH server port (default: 22) |
 | `ssh_user` | string | ❌ | SSH username |

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1035,6 +1035,77 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
         expect(result?.sources[0].search_path).toBeUndefined();
       });
     });
+
+    describe('timezone validation', () => {
+      it('should accept timezone for MySQL source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+timezone = "+09:00"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].timezone).toBe('+09:00');
+      });
+
+      it('should accept "Z" timezone for MariaDB source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mariadb://user:pass@localhost:3306/testdb"
+timezone = "Z"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].timezone).toBe('Z');
+      });
+
+      it('should throw error when timezone is used with non-MySQL/MariaDB source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+timezone = "+09:00"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('only supported for MySQL and MariaDB');
+      });
+
+      it('should throw error for invalid timezone format', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+timezone = "Asia/Seoul"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('invalid timezone');
+      });
+
+      it('should work without timezone (optional field)', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].timezone).toBeUndefined();
+      });
+    });
+
   });
 
   describe('buildDSNFromSource', () => {

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -450,6 +450,25 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
 
   }
 
+  // Validate timezone (MySQL/MariaDB only)
+  if (source.timezone !== undefined) {
+    if (source.type !== "mysql" && source.type !== "mariadb") {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has 'timezone' but it is only supported for MySQL and MariaDB sources.`
+      );
+    }
+    // Accepted by mysql2/mariadb drivers: "local", "Z", or "±HH:MM" (e.g., "+09:00")
+    if (
+      typeof source.timezone !== "string" ||
+      !/^(?:local|Z|[+-]\d\d:\d\d)$/.test(source.timezone)
+    ) {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has invalid timezone '${source.timezone}'. ` +
+          `Must be "local", "Z" (UTC), or an offset like "+09:00".`
+      );
+    }
+  }
+
   // Reject readonly and max_rows at source level (they should be set on tools instead)
   if ((source as any).readonly !== undefined) {
     throw new Error(

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -396,9 +396,53 @@ describe('MySQL Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id',
         {}
       );
-      
+
       // Should return all users (at least the original 3 plus any added in previous tests)
       expect(result.rows.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('timezone configuration', () => {
+    it('should interpret DATETIME using the configured timezone offset', async () => {
+      const connector = new MySQLConnector();
+      try {
+        // With timezone "+09:00", the driver reads the naive DATETIME as KST and
+        // produces the correct UTC instant: 02:31:23 KST == 17:31:23 UTC.
+        await connector.connect(mysqlTest.connectionString, undefined, {
+          timezone: '+09:00',
+        });
+
+        const result = await connector.executeSQL(
+          "SELECT CAST('2025-09-29 02:31:23' AS DATETIME) AS dt",
+          {}
+        );
+
+        expect(result.rows).toHaveLength(1);
+        const iso = new Date(result.rows[0].dt as string | Date).toISOString();
+        expect(iso).toBe('2025-09-29T17:31:23.000Z');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should treat DATETIME as UTC when timezone is "Z"', async () => {
+      const connector = new MySQLConnector();
+      try {
+        await connector.connect(mysqlTest.connectionString, undefined, {
+          timezone: 'Z',
+        });
+
+        const result = await connector.executeSQL(
+          "SELECT CAST('2025-09-29 02:31:23' AS DATETIME) AS dt",
+          {}
+        );
+
+        expect(result.rows).toHaveLength(1);
+        const iso = new Date(result.rows[0].dt as string | Date).toISOString();
+        expect(iso).toBe('2025-09-29T02:31:23.000Z');
+      } finally {
+        await connector.disconnect();
+      }
     });
   });
 });

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -73,6 +73,12 @@ export interface ConnectorConfig {
    * Sets the session search_path and uses the first schema as default for discovery methods.
    */
   searchPath?: string;
+  /**
+   * MySQL/MariaDB timezone setting.
+   * Controls how the driver interprets DATETIME values: "Z" (UTC), "local", or "±HH:MM" (e.g., "+09:00").
+   * Passed through to the mysql2 `timezone` connection option.
+   */
+  timezone?: string;
 }
 
 /**

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -241,6 +241,10 @@ export class ConnectorManager {
     if (source.search_path) {
       config.searchPath = source.search_path;
     }
+    // Pass timezone for MySQL/MariaDB
+    if (source.timezone) {
+      config.timezone = source.timezone;
+    }
 
     // Connect to the database with config and optional init script
     await connector.connect(actualDSN, source.init_script, config);

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -57,6 +57,10 @@ class MariadbDSNParser implements DSNParser {
         ...(queryTimeoutSeconds !== undefined && {
           queryTimeout: queryTimeoutSeconds * 1000
         }),
+        // Controls how the driver interprets DATETIME values ("Z", "local", or "±HH:MM").
+        ...(config?.timezone !== undefined && {
+          timezone: config.timezone
+        }),
       };
 
       // Handle query parameters

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -29,6 +29,8 @@ import { quoteIdentifier } from "../../utils/identifier-quoter.js";
 class MySQLDSNParser implements DSNParser {
   async parse(dsn: string, config?: ConnectorConfig): Promise<mysql.ConnectionOptions> {
     const connectionTimeoutSeconds = config?.connectionTimeoutSeconds;
+    // Capture this before the local `config` (mysql.ConnectionOptions) shadows the param below
+    const timezone = config?.timezone;
     // Basic validation
     if (!this.isValidDSN(dsn)) {
       const obfuscatedDSN = obfuscateDSNPassword(dsn);
@@ -71,6 +73,13 @@ class MySQLDSNParser implements DSNParser {
       if (connectionTimeoutSeconds !== undefined) {
         // mysql2 library expects connectTimeout in milliseconds
         config.connectTimeout = connectionTimeoutSeconds * 1000;
+      }
+
+      // Apply timezone if specified: controls how mysql2 interprets DATETIME values
+      // ("Z", "local", or "±HH:MM"). Without it, mysql2 assumes "local", which can
+      // produce an incorrect instant when the server timezone differs from the data's.
+      if (timezone !== undefined) {
+        config.timezone = timezone;
       }
 
       // Auto-detect AWS IAM authentication tokens and configure cleartext plugin

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -55,6 +55,7 @@ export interface SourceConfig extends ConnectionParams, SSHConfig {
   init_script?: string; // Optional SQL script to run on connection (for demo mode or initialization)
   lazy?: boolean; // Defer connection until first query (default: false)
   search_path?: string; // Comma-separated list of schemas for PostgreSQL search_path (e.g., "myschema,public")
+  timezone?: string; // MySQL/MariaDB: how the driver interprets DATETIME values. "Z" (UTC), "local", or "±HH:MM" (e.g., "+09:00")
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a `timezone` source option for MySQL/MariaDB, mirroring PostgreSQL's `search_path` (#250). Passed through to the driver's native `timezone` option (`mysql2` / `mariadb`) — already supported, just not surfaced by DBHub.

## Why

MySQL `DATETIME` is timezone-naive. With no config the driver assumes `"local"` (host TZ), so a value stored in another zone yields the wrong instant — and the ISO output's trailing `Z` falsely implies UTC:

| config | `2025-09-29 02:31:23` (stored KST) → `toISOString()` |
| --- | --- |
| default (`local`, host=UTC) | `…T02:31:23.000Z` ❌ wrong |
| `timezone = "+09:00"` | `…T17:31:23.000Z` ✅ correct |

## Usage

```toml
[[sources]]
id = "my_mysql"
dsn = "mysql://user:pass@localhost:3306/mydb"
timezone = "+09:00"   # "Z", "local", or "±HH:MM"
```

TOML-only, like `search_path` (not a DSN query parameter).

## Changes

Wires `timezone` through config types → connector manager → `mysql2`/`mariadb` connection options, with TOML validation (MySQL/MariaDB only; `Z` / `local` / `±HH:MM`). Adds 5 loader unit tests plus integration tests asserting the correct UTC instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)