### PR TITLE
feat: distinguish tables from views in `search_objects` tool

### DIFF
--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -138,9 +138,20 @@ export interface Connector {
    *   - SQL Server: 'dbo' schema
    *   - MySQL: Current active database from connection (DATABASE())
    *   - SQLite: Main database (schema concept doesn't exist in SQLite)
-   * @returns Promise with array of table names
+   * @returns Promise with array of table names (excludes views)
    */
   getTables(schema?: string): Promise<string[]>;
+
+  /**
+   * Get all views in the database or in a specific schema
+   * @param schema Optional schema name. If not provided, implementation should use the default schema:
+   *   - PostgreSQL: 'public' schema
+   *   - SQL Server: 'dbo' schema
+   *   - MySQL: Current active database from connection (DATABASE())
+   *   - SQLite: Main database (schema concept doesn't exist in SQLite)
+   * @returns Promise with array of view names
+   */
+  getViews(schema?: string): Promise<string[]>;
 
   /**
    * Get schema information for a specific table

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -179,12 +179,13 @@ export class MariaDBConnector implements Connector {
 
       const queryParams = schema ? [schema] : [];
 
-      // Get all tables from the specified schema or current database
+      // Get all tables from the specified schema or current database (excludes views)
       const rows = await this.pool.query(
         `
-        SELECT TABLE_NAME 
-        FROM INFORMATION_SCHEMA.TABLES 
+        SELECT TABLE_NAME
+        FROM INFORMATION_SCHEMA.TABLES
         ${schemaClause}
+        AND TABLE_TYPE = 'BASE TABLE'
         ORDER BY TABLE_NAME
       `,
         queryParams
@@ -193,6 +194,33 @@ export class MariaDBConnector implements Connector {
       return rows.map((row) => row.TABLE_NAME);
     } catch (error) {
       console.error("Error getting tables:", error);
+      throw error;
+    }
+  }
+
+  async getViews(schema?: string): Promise<string[]> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+
+    try {
+      const schemaClause = schema ? "WHERE TABLE_SCHEMA = ?" : "WHERE TABLE_SCHEMA = DATABASE()";
+      const queryParams = schema ? [schema] : [];
+
+      const rows = await this.pool.query(
+        `
+        SELECT TABLE_NAME
+        FROM INFORMATION_SCHEMA.TABLES
+        ${schemaClause}
+        AND TABLE_TYPE = 'VIEW'
+        ORDER BY TABLE_NAME
+      `,
+        queryParams
+      ) as any[];
+
+      return rows.map((row) => row.TABLE_NAME);
+    } catch (error) {
+      console.error("Error getting views:", error);
       throw error;
     }
   }

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -187,12 +187,13 @@ export class MySQLConnector implements Connector {
 
       const queryParams = schema ? [schema] : [];
 
-      // Get all tables from the specified schema or current database
+      // Get all tables from the specified schema or current database (excludes views)
       const [rows] = (await this.pool.query(
         `
-        SELECT TABLE_NAME 
-        FROM INFORMATION_SCHEMA.TABLES 
+        SELECT TABLE_NAME
+        FROM INFORMATION_SCHEMA.TABLES
         ${schemaClause}
+        AND TABLE_TYPE = 'BASE TABLE'
         ORDER BY TABLE_NAME
       `,
         queryParams
@@ -201,6 +202,33 @@ export class MySQLConnector implements Connector {
       return rows.map((row) => row.TABLE_NAME);
     } catch (error) {
       console.error("Error getting tables:", error);
+      throw error;
+    }
+  }
+
+  async getViews(schema?: string): Promise<string[]> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+
+    try {
+      const schemaClause = schema ? "WHERE TABLE_SCHEMA = ?" : "WHERE TABLE_SCHEMA = DATABASE()";
+      const queryParams = schema ? [schema] : [];
+
+      const [rows] = (await this.pool.query(
+        `
+        SELECT TABLE_NAME
+        FROM INFORMATION_SCHEMA.TABLES
+        ${schemaClause}
+        AND TABLE_TYPE = 'VIEW'
+        ORDER BY TABLE_NAME
+      `,
+        queryParams
+      )) as [any[], any];
+
+      return rows.map((row) => row.TABLE_NAME);
+    } catch (error) {
+      console.error("Error getting views:", error);
       throw error;
     }
   }

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -242,6 +242,33 @@ export class PostgresConnector implements Connector {
         SELECT table_name
         FROM information_schema.tables
         WHERE table_schema = $1
+        AND table_type = 'BASE TABLE'
+        ORDER BY table_name
+      `,
+        [schemaToUse]
+      );
+
+      return result.rows.map((row) => row.table_name);
+    } finally {
+      client.release();
+    }
+  }
+
+  async getViews(schema?: string): Promise<string[]> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+
+    const client = await this.pool.connect();
+    try {
+      const schemaToUse = schema || this.defaultSchema;
+
+      const result = await client.query(
+        `
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = $1
+        AND table_type = 'VIEW'
         ORDER BY table_name
       `,
         [schemaToUse]

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -217,6 +217,29 @@ export class SQLiteConnector implements Connector {
     }
   }
 
+  async getViews(schema?: string): Promise<string[]> {
+    if (!this.db) {
+      throw new Error("Not connected to SQLite database");
+    }
+
+    // In SQLite, schema parameter is ignored since SQLite doesn't have schemas like PostgreSQL
+    try {
+      const rows = this.db
+        .prepare(
+          `
+        SELECT name FROM sqlite_master
+        WHERE type='view' AND name NOT LIKE 'sqlite_%'
+        ORDER BY name
+      `
+        )
+        .all() as SQLiteTableNameRow[];
+
+      return rows.map((row) => row.name);
+    } catch (error) {
+      throw error;
+    }
+  }
+
   async tableExists(tableName: string, schema?: string): Promise<boolean> {
     if (!this.db) {
       throw new Error("Not connected to SQLite database");

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -234,6 +234,7 @@ export class SQLServerConnector implements Connector {
           SELECT TABLE_NAME
           FROM INFORMATION_SCHEMA.TABLES
           WHERE TABLE_SCHEMA = @schema
+          AND TABLE_TYPE = 'BASE TABLE'
           ORDER BY TABLE_NAME
       `;
 
@@ -242,6 +243,32 @@ export class SQLServerConnector implements Connector {
       return result.recordset.map((row: { TABLE_NAME: any }) => row.TABLE_NAME);
     } catch (error) {
       throw new Error(`Failed to get tables: ${(error as Error).message}`);
+    }
+  }
+
+  async getViews(schema?: string): Promise<string[]> {
+    if (!this.connection) {
+      throw new Error("Not connected to SQL Server database");
+    }
+
+    try {
+      const schemaToUse = schema || "dbo";
+
+      const request = this.connection.request().input("schema", sql.VarChar, schemaToUse);
+
+      const query = `
+          SELECT TABLE_NAME
+          FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = @schema
+          AND TABLE_TYPE = 'VIEW'
+          ORDER BY TABLE_NAME
+      `;
+
+      const result = await request.query(query);
+
+      return result.recordset.map((row: { TABLE_NAME: any }) => row.TABLE_NAME);
+    } catch (error) {
+      throw new Error(`Failed to get views: ${(error as Error).message}`);
     }
   }
 

--- a/src/tools/search-objects.ts
+++ b/src/tools/search-objects.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Object types that can be searched
  */
-export type DatabaseObjectType = "schema" | "table" | "column" | "procedure" | "function" | "index";
+export type DatabaseObjectType = "schema" | "table" | "view" | "column" | "procedure" | "function" | "index";
 
 /**
  * Detail level for search results
@@ -24,7 +24,7 @@ export type DetailLevel = "names" | "summary" | "full";
 // Schema for search_objects tool (unified search and list)
 export const searchDatabaseObjectsSchema = {
   object_type: z
-    .enum(["schema", "table", "column", "procedure", "function", "index"])
+    .enum(["schema", "table", "view", "column", "procedure", "function", "index"])
     .describe("Object type to search"),
   pattern: z
     .string()
@@ -242,6 +242,106 @@ async function searchTables(
           } catch (error) {
             results.push({
               name: tableName,
+              schema: schemaName,
+              error: `Unable to fetch full details: ${(error as Error).message}`,
+            });
+          }
+        }
+      }
+    } catch (error) {
+      // Skip schemas we can't access
+      continue;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Search for views
+ */
+async function searchViews(
+  connector: Connector,
+  pattern: string,
+  schemaFilter: string | undefined,
+  detailLevel: DetailLevel,
+  limit: number
+): Promise<any[]> {
+  const regex = likePatternToRegex(pattern);
+  const results: any[] = [];
+
+  // Get schemas to search
+  let schemasToSearch: string[];
+  if (schemaFilter) {
+    schemasToSearch = [schemaFilter];
+  } else {
+    schemasToSearch = await connector.getSchemas();
+  }
+
+  // Search views in each schema
+  for (const schemaName of schemasToSearch) {
+    if (results.length >= limit) break;
+
+    try {
+      const views = await connector.getViews(schemaName);
+      const matched = views.filter((view: string) => regex.test(view));
+
+      for (const viewName of matched) {
+        if (results.length >= limit) break;
+
+        if (detailLevel === "names") {
+          results.push({
+            name: viewName,
+            schema: schemaName,
+          });
+        } else if (detailLevel === "summary") {
+          // Get column count for summary
+          try {
+            const columns = await connector.getTableSchema(viewName, schemaName);
+            const comment = await getTableComment(connector, viewName, schemaName);
+
+            results.push({
+              name: viewName,
+              schema: schemaName,
+              column_count: columns.length,
+              ...(comment ? { comment } : {}),
+            });
+          } catch (error) {
+            results.push({
+              name: viewName,
+              schema: schemaName,
+              column_count: null,
+            });
+          }
+        } else {
+          // full detail
+          try {
+            const columns = await connector.getTableSchema(viewName, schemaName);
+            const indexes = await connector.getTableIndexes(viewName, schemaName);
+            const comment = await getTableComment(connector, viewName, schemaName);
+
+            results.push({
+              name: viewName,
+              schema: schemaName,
+              column_count: columns.length,
+              ...(comment ? { comment } : {}),
+              columns: columns.map((col: any) => ({
+                name: col.column_name,
+                type: col.data_type,
+                nullable: col.is_nullable === "YES",
+                default: col.column_default,
+                ...(col.description ? { description: col.description } : {}),
+              })),
+              indexes: indexes.map((idx: any) => ({
+                name: idx.index_name,
+                columns: idx.column_names,
+                unique: idx.is_unique,
+                primary: idx.is_primary,
+              })),
+            });
+          } catch (error) {
+            results.push({
+              name: viewName,
               schema: schemaName,
               error: `Unable to fetch full details: ${(error as Error).message}`,
             });
@@ -554,6 +654,9 @@ export function createSearchDatabaseObjectsToolHandler(sourceId?: string) {
           break;
         case "table":
           results = await searchTables(connector, pattern, schema, detail_level, limit);
+          break;
+        case "view":
+          results = await searchViews(connector, pattern, schema, detail_level, limit);
           break;
         case "column":
           results = await searchColumns(connector, pattern, schema, table, detail_level, limit);


### PR DESCRIPTION
## Description

Previously, the `table` object_type in `search_objects` returned both tables and views, making it impossible to query them separately.

## Why this matters

Tables and views are fundamentally different database objects:

- Tables store data physically; views are virtual, defined by queries
- Most views are **not writable** — AI agents may attempt `INSERT INTO` a view and get errors
- Indexes and row counts are meaningful for tables but not for views
- AI agents exploring a database need to know the difference to make correct decisions

## Changes

- Add `getViews(schema?)` method to the `Connector` interface (`src/connectors/interface.ts`)
- Update `getTables()` across all connectors to filter by `BASE TABLE`, excluding views from results
- Add `getViews()` implementations for PostgreSQL, MySQL, MariaDB, SQL Server, and SQLite
- Add `view` as a new `object_type` option in the `search_objects` tool, with full support for `names`/`summary`/`full` detail levels

## Affected files

| File | Change |
|------|--------|
| `src/connectors/interface.ts` | Add `getViews()` to Connector interface |
| `src/connectors/mysql/index.ts` | `getTables()` filter + `getViews()` |
| `src/connectors/postgres/index.ts` | `getTables()` filter + `getViews()` |
| `src/connectors/mariadb/index.ts` | `getTables()` filter + `getViews()` |
| `src/connectors/sqlserver/index.ts` | `getTables()` filter + `getViews()` |
| `src/connectors/sqlite/index.ts` | `getViews()` only (`getTables()` was already correct) |
| `src/tools/search-objects.ts` | Add `"view"` type + `searchViews()` function |

## Scope

This change is limited to the MCP tools layer (`search_objects` tool) and the database connector layer. No changes to:

- Frontend
- HTTP transport / API endpoints
- `execute_sql` tool
- Configuration system (TOML, env vars, CLI)
- SSH tunnel support
- Docker / deployment

## Testing

- `pnpm run build:backend` compiles successfully with zero errors
- Manual testing on MySQL confirmed `getTables()` no longer returns views and `getViews()` works correctly
- Integration tests for other connectors would require Docker (Testcontainers) environment

## Usage

```
# Before: table type returned both tables and views mixed together
search_objects(object_type="table")

# After: explicitly query tables only
search_objects(object_type="table")

# After: explicitly query views only
search_objects(object_type="view")
```

---

This PR closes #324.