### PR TITLE
fix: address review feedback on tables/views split in search_objects

### DIFF
--- a/src/connectors/__tests__/shared/integration-test-base.ts
+++ b/src/connectors/__tests__/shared/integration-test-base.ts
@@ -139,6 +139,19 @@ export abstract class IntegrationTestBase<TContainer extends TestContainer> {
         });
       }
 
+      it('should list views without overlapping tables', async () => {
+        // Verifies getViews() is wired and its query executes against the real
+        // database. getTables() (BASE TABLE only) and getViews() must be disjoint.
+        const tables = await this.connector.getTables();
+        const views = await this.connector.getViews();
+        expect(Array.isArray(views)).toBe(true);
+
+        const tableSet = new Set(tables);
+        for (const view of views) {
+          expect(tableSet.has(view)).toBe(false);
+        }
+      });
+
       it('should check if table exists', async () => {
         const firstTable = this.config.expectedTables[0];
         expect(await this.connector.tableExists(firstTable)).toBe(true);

--- a/src/tools/__tests__/search-objects.test.ts
+++ b/src/tools/__tests__/search-objects.test.ts
@@ -17,6 +17,7 @@ const createMockConnector = (id: ConnectorType = 'sqlite'): Connector => ({
   clone: vi.fn(),
   getSchemas: vi.fn(),
   getTables: vi.fn(),
+  getViews: vi.fn(),
   tableExists: vi.fn(),
   getTableSchema: vi.fn(),
   getTableIndexes: vi.fn(),
@@ -426,6 +427,155 @@ describe('search_database_objects tool', () => {
     });
   });
 
+  describe('search views', () => {
+    beforeEach(() => {
+      vi.mocked(mockConnector.getSchemas).mockResolvedValue(['public']);
+      vi.mocked(mockConnector.getViews).mockResolvedValue([
+        'active_users',
+        'user_summary',
+        'recent_orders',
+      ]);
+    });
+
+    it('should search views with pattern', async () => {
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'view',
+          pattern: 'user%',
+          detail_level: 'names',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.count).toBe(1);
+      expect(parsed.data.results).toEqual([{ name: 'user_summary', schema: 'public' }]);
+    });
+
+    it('should list all views when pattern is omitted', async () => {
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'view',
+          detail_level: 'names',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.count).toBe(3);
+      expect(parsed.data.results.map((r: any) => r.name)).toEqual([
+        'active_users',
+        'user_summary',
+        'recent_orders',
+      ]);
+    });
+
+    it('should filter views by schema parameter', async () => {
+      vi.mocked(mockConnector.getSchemas).mockResolvedValue(['public', 'private']);
+      vi.mocked(mockConnector.getViews).mockImplementation(async (schema) => {
+        if (schema === 'public') return ['active_users'];
+        if (schema === 'private') return ['secret_view'];
+        return [];
+      });
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'view',
+          pattern: '%',
+          schema: 'public',
+          detail_level: 'names',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.count).toBe(1);
+      expect(mockConnector.getViews).toHaveBeenCalledWith('public');
+      expect(mockConnector.getViews).not.toHaveBeenCalledWith('private');
+    });
+
+    it('should return summary with column count and comment', async () => {
+      vi.mocked(mockConnector.getViews).mockResolvedValue(['active_users']);
+      const columns: TableColumn[] = [
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+        { column_name: 'name', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: null },
+      ];
+      vi.mocked(mockConnector.getTableSchema).mockResolvedValue(columns);
+      mockConnector.getTableComment = vi.fn().mockResolvedValue('Users with recent activity');
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'view',
+          pattern: 'active_users',
+          detail_level: 'summary',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results[0]).toEqual({
+        name: 'active_users',
+        schema: 'public',
+        column_count: 2,
+        comment: 'Users with recent activity',
+      });
+    });
+
+    it('should return full details with columns and an empty indexes array', async () => {
+      vi.mocked(mockConnector.getViews).mockResolvedValue(['active_users']);
+      const columns: TableColumn[] = [
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+      ];
+      vi.mocked(mockConnector.getTableSchema).mockResolvedValue(columns);
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'view',
+          pattern: 'active_users',
+          detail_level: 'full',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results[0]).toMatchObject({
+        name: 'active_users',
+        schema: 'public',
+        column_count: 1,
+        indexes: [],
+        columns: [
+          { name: 'id', type: 'INTEGER', nullable: false, default: null },
+        ],
+      });
+    });
+
+    it('should not query indexes for views in full detail', async () => {
+      vi.mocked(mockConnector.getViews).mockResolvedValue(['active_users']);
+      vi.mocked(mockConnector.getTableSchema).mockResolvedValue([
+        { column_name: 'id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+      ]);
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      await handler(
+        {
+          object_type: 'view',
+          pattern: 'active_users',
+          detail_level: 'full',
+        },
+        null
+      );
+
+      // getTableIndexes throws for views on some engines; it must not be called.
+      expect(mockConnector.getTableIndexes).not.toHaveBeenCalled();
+    });
+  });
+
   describe('search columns', () => {
     beforeEach(() => {
       vi.mocked(mockConnector.getSchemas).mockResolvedValue(['public']);
@@ -467,6 +617,62 @@ describe('search_database_objects tool', () => {
         { name: 'id', table: 'orders', schema: 'public' },
         { name: 'user_id', table: 'orders', schema: 'public' },
       ]);
+    });
+
+    it('should also search columns of views', async () => {
+      vi.mocked(mockConnector.getTables).mockResolvedValue(['users']);
+      vi.mocked(mockConnector.getViews).mockResolvedValue(['active_users']);
+
+      vi.mocked(mockConnector.getTableSchema).mockImplementation(async (object) => {
+        if (object === 'users')
+          return [
+            { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+          ];
+        if (object === 'active_users')
+          return [
+            { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+          ];
+        return [];
+      });
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'column',
+          pattern: 'user_id',
+          detail_level: 'names',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.count).toBe(2);
+      expect(parsed.data.results).toEqual([
+        { name: 'user_id', table: 'users', schema: 'public' },
+        { name: 'user_id', table: 'active_users', schema: 'public' },
+      ]);
+    });
+
+    it('should still return table columns when getViews is unsupported', async () => {
+      vi.mocked(mockConnector.getTables).mockResolvedValue(['users']);
+      vi.mocked(mockConnector.getViews).mockRejectedValue(new Error('views not supported'));
+      vi.mocked(mockConnector.getTableSchema).mockResolvedValue([
+        { column_name: 'email', data_type: 'TEXT', is_nullable: 'YES', column_default: null, description: null },
+      ]);
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        {
+          object_type: 'column',
+          pattern: 'email',
+          detail_level: 'names',
+        },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.count).toBe(1);
+      expect(parsed.data.results).toEqual([{ name: 'email', table: 'users', schema: 'public' }]);
     });
 
     it('should return column details in summary level', async () => {

--- a/src/tools/__tests__/search-objects.test.ts
+++ b/src/tools/__tests__/search-objects.test.ts
@@ -623,17 +623,10 @@ describe('search_database_objects tool', () => {
       vi.mocked(mockConnector.getTables).mockResolvedValue(['users']);
       vi.mocked(mockConnector.getViews).mockResolvedValue(['active_users']);
 
-      vi.mocked(mockConnector.getTableSchema).mockImplementation(async (object) => {
-        if (object === 'users')
-          return [
-            { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
-          ];
-        if (object === 'active_users')
-          return [
-            { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
-          ];
-        return [];
-      });
+      // Both the table and the view expose a user_id column.
+      vi.mocked(mockConnector.getTableSchema).mockResolvedValue([
+        { column_name: 'user_id', data_type: 'INTEGER', is_nullable: 'NO', column_default: null, description: null },
+      ]);
 
       const handler = createSearchDatabaseObjectsToolHandler();
       const result = await handler(

--- a/src/tools/search-objects.ts
+++ b/src/tools/search-objects.ts
@@ -389,16 +389,14 @@ async function searchColumns(
         tablesToSearch = [tableFilter];
       } else {
         // Otherwise search all tables AND views in the schema. Views are queryable
-        // objects with columns, so column discovery should cover them too. getViews()
-        // may be unsupported for some connectors/schemas, so degrade gracefully.
-        const tables = await connector.getTables(schemaName);
-        let views: string[] = [];
-        try {
-          views = (await connector.getViews(schemaName)) ?? [];
-        } catch {
-          // Connector/schema doesn't expose views; continue with tables only
-        }
-        tablesToSearch = [...tables, ...views];
+        // objects with columns, so column discovery should cover them too. The two
+        // lookups are independent, so run them concurrently; getViews() may be
+        // unsupported for some connectors/schemas, so degrade to no views.
+        const [tables, views] = await Promise.all([
+          connector.getTables(schemaName),
+          Promise.resolve(connector.getViews(schemaName)).catch(() => [] as string[]),
+        ]);
+        tablesToSearch = [...tables, ...(views ?? [])];
       }
 
       for (const tableName of tablesToSearch) {

--- a/src/tools/search-objects.ts
+++ b/src/tools/search-objects.ts
@@ -315,9 +315,12 @@ async function searchViews(
           }
         } else {
           // full detail
+          // Note: indexes are intentionally not queried for views. Non-materialized
+          // views generally don't expose meaningful indexes, and on some engines
+          // getTableIndexes() throws for a view, which would otherwise discard the
+          // columns/comment already fetched and degrade the whole result to an error.
           try {
             const columns = await connector.getTableSchema(viewName, schemaName);
-            const indexes = await connector.getTableIndexes(viewName, schemaName);
             const comment = await getTableComment(connector, viewName, schemaName);
 
             results.push({
@@ -332,12 +335,7 @@ async function searchViews(
                 default: col.column_default,
                 ...(col.description ? { description: col.description } : {}),
               })),
-              indexes: indexes.map((idx: any) => ({
-                name: idx.index_name,
-                columns: idx.column_names,
-                unique: idx.is_unique,
-                primary: idx.is_primary,
-              })),
+              indexes: [],
             });
           } catch (error) {
             results.push({
@@ -379,19 +377,28 @@ async function searchColumns(
     schemasToSearch = await connector.getSchemas();
   }
 
-  // Search columns in tables across schemas
+  // Search columns in tables and views across schemas
   for (const schemaName of schemasToSearch) {
     if (results.length >= limit) break;
 
     try {
-      // Get tables to search
+      // Get tables (and views) to search
       let tablesToSearch: string[];
       if (tableFilter) {
-        // If table filter is specified, only search that table
+        // If table filter is specified, only search that table/view
         tablesToSearch = [tableFilter];
       } else {
-        // Otherwise search all tables in the schema
-        tablesToSearch = await connector.getTables(schemaName);
+        // Otherwise search all tables AND views in the schema. Views are queryable
+        // objects with columns, so column discovery should cover them too. getViews()
+        // may be unsupported for some connectors/schemas, so degrade gracefully.
+        const tables = await connector.getTables(schemaName);
+        let views: string[] = [];
+        try {
+          views = (await connector.getViews(schemaName)) ?? [];
+        } catch {
+          // Connector/schema doesn't expose views; continue with tables only
+        }
+        tablesToSearch = [...tables, ...views];
       }
 
       for (const tableName of tablesToSearch) {


### PR DESCRIPTION
## Description

Follow-up to #325 ("distinguish tables from views in `search_objects`"). That PR was merged with three unaddressed [Copilot review comments](https://github.com/bytebase/dbhub/pull/325#pullrequestreview-4444559641); this PR resolves all three.

## Changes

### 1. Don't query indexes for views (correctness)
`searchViews()` full-detail mode called `getTableIndexes()` on views. On engines where that throws for a (non-materialized) view, the entire view result fell into the `catch` and degraded to an `error` response — **discarding the columns and comment that were already successfully fetched**. Views don't expose meaningful indexes, so we skip the query and return `indexes: []`.

### 2. Column search now covers views again (regression fix)
Excluding views from `getTables()` in #325 silently stopped `object_type="column"` from discovering columns belonging to views (column search enumerates `getTables()`). `searchColumns()` now iterates both `getTables()` **and** `getViews()`, degrading gracefully when a connector/schema doesn't support views.

### 3. Test coverage for the view branch
- Unit tests for `object_type="view"`: pattern match, list-all, schema filter, `summary`, `full`, and an assertion that `getTableIndexes` is **not** called for views.
- Unit tests proving column search now includes view columns and still returns table columns when `getViews()` is unsupported.
- A shared integration assertion (runs across all connectors) that `getTables()` and `getViews()` are disjoint.

## Testing

- `pnpm test` — all 770 unit tests pass (integration suites skipped locally: no Docker).
- `pnpm test src/tools/__tests__/search-objects.test.ts` — 43 pass.
- `pnpm test src/connectors/__tests__/sqlite.integration.test.ts` — 39 pass (exercises the new disjoint assertion without Docker).
- `pnpm run build` — compiles with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)