### PR TITLE
refactor: structured SQLResult.messages (DatabaseMessage[])

### DIFF
--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -584,7 +584,7 @@ describe('SQL Server Connector Integration Tests', () => {
       expect(result.rows[0].value).toBe(1);
       expect(result.messages).toBeDefined();
       expect(result.messages!.length).toBeGreaterThan(0);
-      expect(result.messages).toContain('hello from sql server');
+      expect(result.messages!.some(msg => msg.text === 'hello from sql server')).toBe(true);
     });
 
     it('should capture SET STATISTICS TIME output in messages', async () => {
@@ -598,7 +598,7 @@ describe('SQL Server Connector Integration Tests', () => {
       expect(result.messages!.length).toBeGreaterThan(0);
       // STATISTICS TIME emits messages containing "CPU time" and "elapsed time"
       const hasTimingMessage = result.messages!.some(
-        msg => msg.includes('CPU time') || msg.includes('elapsed time')
+        msg => msg.text.includes('CPU time') || msg.text.includes('elapsed time')
       );
       expect(hasTimingMessage).toBe(true);
     });

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -7,11 +7,28 @@ export type ConnectorType = "postgres" | "mysql" | "mariadb" | "sqlite" | "sqlse
  * Database Connector Interface
  * This defines the contract that all database connectors must implement.
  */
+/**
+ * An informational (non-error) message emitted by the database during query
+ * execution, e.g. SQL Server STATISTICS TIME/IO and PRINT output, or
+ * PostgreSQL NOTICE/WARNING. Modeled to be cross-database: only `text` is
+ * guaranteed, the rest are populated when the driver exposes them.
+ */
+export interface DatabaseMessage {
+  /** Human-readable message text */
+  text: string;
+  /** Severity indicator where available; interpret per database (PostgreSQL: level name like NOTICE/WARNING; SQL Server: numeric severity class as a string) */
+  severity?: string;
+  /** Database-specific message code (PostgreSQL: SQLSTATE; SQL Server: message number) */
+  code?: string | number;
+  /** 1-based line number within the SQL batch that produced the message, when reported */
+  line?: number;
+}
+
 export interface SQLResult {
   rows: any[];
   rowCount: number;
   /** Informational messages from the database (e.g. SQL Server STATISTICS TIME/IO, PRINT output) */
-  messages?: string[];
+  messages?: DatabaseMessage[];
 }
 
 export interface TableColumn {

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -5,6 +5,7 @@ import {
   ConnectorRegistry,
   DSNParser,
   SQLResult,
+  DatabaseMessage,
   TableColumn,
   TableIndex,
   StoredProcedure,
@@ -610,10 +611,19 @@ export class SQLServerConnector implements Connector {
 
       // Create request and collect informational messages (e.g. SET STATISTICS TIME/IO, PRINT)
       const request = this.connection.request();
-      const messages: string[] = [];
-      request.on('info', (info: { message: string }) => {
-        messages.push(info.message);
-      });
+      const messages: DatabaseMessage[] = [];
+      request.on(
+        'info',
+        (info: { message: string; number?: number; class?: number; lineNumber?: number }) => {
+          messages.push({
+            text: info.message,
+            // SQL Server reports severity as a numeric class; info messages are < 10.
+            severity: info.class !== undefined ? String(info.class) : undefined,
+            code: info.number,
+            line: info.lineNumber,
+          });
+        }
+      );
 
       if (parameters && parameters.length > 0) {
         // SQL Server uses @p1, @p2, etc. for parameters


### PR DESCRIPTION
## Summary

Follow-up to #307. That PR added `SQLResult.messages?: string[]` to surface SQL Server informational output (`SET STATISTICS TIME/IO`, `PRINT`, warnings) to MCP clients. This PR promotes that field from a bare `string[]` to a structured `DatabaseMessage[]` so per-message metadata is preserved instead of flattened away.

## Why

`string[]` is lossy. The `mssql` `info` event carries `message`, `class` (severity), `number`, and `lineNumber` — all discarded by the string form. Most importantly, **severity** lets a client tell a benign `PRINT` from an actual warning.

It's also a genuinely cross-database concept, not a SQL-Server quirk: PostgreSQL emits `NOTICE`/`WARNING` and MySQL/MariaDB emit warnings. Doing the structured shape now — while there's exactly one producer — means those connectors can populate the same type later **without a breaking interface change**.

## Changes

- **`src/connectors/interface.ts`**: add `DatabaseMessage { text; severity?; code?; line? }`; `SQLResult.messages` is now `DatabaseMessage[]`. Only `text` is guaranteed — the rest are populated when the driver exposes them.
- **`src/connectors/sqlserver/index.ts`**: map the `info` event into `DatabaseMessage` (text/severity/code/line) instead of pushing the raw string.
- **`src/tools/execute-sql.ts`**: unchanged — it already forwards `result.messages` as-is, so clients now receive the structured objects automatically.
- **`src/connectors/__tests__/sqlserver.integration.test.ts`**: assertions updated to read `.text`.

## Notes

- Backward-compatible at the wire level only in spirit — the `messages` field shape changes from `string[]` to objects, but #307 has not shipped in a release yet, so no consumers depend on the old form.
- `severity` is intentionally a general `string` (PG level name vs. SQL Server numeric class as a string), documented per-engine, rather than a SQL-Server-specific field name.

## Verification

- `npx tsc --noEmit`: zero new errors (135 pre-existing on both `main` and this branch; CI builds via tsup).
- `pnpm run build`: ✓
- Unit tests: 668/668 pass.
- SQL Server integration tests require Docker and were not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)