### PR TITLE
fix: correct +09:00 timezone integration test assertion

### DIFF
--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1091,6 +1091,20 @@ timezone = "Asia/Seoul"
         expect(() => loadTomlConfig()).toThrow('invalid timezone');
       });
 
+      it('should throw error for non-string timezone (TOML array)', () => {
+        // ["local"] coerces to the string "local" via RegExp.test(), so the
+        // typeof guard is required to reject it before it reaches the driver.
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+timezone = ["local"]
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('invalid timezone');
+      });
+
       it('should work without timezone (optional field)', () => {
         const tomlContent = `
 [[sources]]

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -457,8 +457,14 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
         `Configuration file ${configPath}: source '${source.id}' has 'timezone' but it is only supported for MySQL and MariaDB sources.`
       );
     }
-    // Accepted by mysql2/mariadb drivers: "local", "Z", or "±HH:MM" (e.g., "+09:00")
-    if (!/^(?:local|Z|[+-]\d\d:\d\d)$/.test(source.timezone)) {
+    // Accepted by mysql2/mariadb drivers: "local", "Z", or "±HH:MM" (e.g., "+09:00").
+    // The typeof guard is required: TOML can yield non-strings (e.g. arrays), and
+    // RegExp.test() would coerce a single-element array like ["local"] to a passing
+    // string before it reaches the driver as a non-string value.
+    if (
+      typeof source.timezone !== "string" ||
+      !/^(?:local|Z|[+-]\d\d:\d\d)$/.test(source.timezone)
+    ) {
       throw new Error(
         `Configuration file ${configPath}: source '${source.id}' has invalid timezone '${source.timezone}'. ` +
           `Must be "local", "Z" (UTC), or an offset like "+09:00".`

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -458,10 +458,7 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
       );
     }
     // Accepted by mysql2/mariadb drivers: "local", "Z", or "±HH:MM" (e.g., "+09:00")
-    if (
-      typeof source.timezone !== "string" ||
-      !/^(?:local|Z|[+-]\d\d:\d\d)$/.test(source.timezone)
-    ) {
+    if (!/^(?:local|Z|[+-]\d\d:\d\d)$/.test(source.timezone)) {
       throw new Error(
         `Configuration file ${configPath}: source '${source.id}' has invalid timezone '${source.timezone}'. ` +
           `Must be "local", "Z" (UTC), or an offset like "+09:00".`

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -407,7 +407,8 @@ describe('MySQL Connector Integration Tests', () => {
       const connector = new MySQLConnector();
       try {
         // With timezone "+09:00", the driver reads the naive DATETIME as KST and
-        // produces the correct UTC instant: 02:31:23 KST == 17:31:23 UTC.
+        // produces the correct UTC instant. KST is UTC+9, so 02:31:23 on Sep 29
+        // is 17:31:23 UTC on the previous day (Sep 28).
         await connector.connect(mysqlTest.connectionString, undefined, {
           timezone: '+09:00',
         });
@@ -419,7 +420,7 @@ describe('MySQL Connector Integration Tests', () => {
 
         expect(result.rows).toHaveLength(1);
         const iso = new Date(result.rows[0].dt as string | Date).toISOString();
-        expect(iso).toBe('2025-09-29T17:31:23.000Z');
+        expect(iso).toBe('2025-09-28T17:31:23.000Z');
       } finally {
         await connector.disconnect();
       }


### PR DESCRIPTION
## Summary

Follow-up to #321 (`timezone` source option for MySQL/MariaDB). The main fix is a wrong test assertion; the validation code is left functionally unchanged.

## The bug

The MySQL integration test asserted the wrong UTC instant. KST is UTC+9, so the naive DATETIME `2025-09-29 02:31:23` interpreted as `+09:00` is **`2025-09-28T17:31:23Z`** (the previous day), not `2025-09-29T17:31:23Z`.

mysql2's `parseDateTime` does `new Date(\`${str}${timezone}\`)`, which yields the previous-day instant:

```
'2025-09-29 02:31:23' + '+09:00'  →  2025-09-28T17:31:23.000Z
```

Because the old expected value is never producible by the driver, the test would have **failed against a real container** — indicating the Testcontainers integration suite was not run before #321 merged. The same off-by-one-day miscalculation appears in #321's description table (immutable history, nothing to fix there). The `"Z"` test was already correct and is unchanged.

## Validation hardening

While here, the timezone validation in `toml-loader.ts` is left intact but gains:
- A comment explaining why the `typeof source.timezone !== "string"` guard is **required** — TOML can yield non-strings, and `RegExp.test()` coerces a single-element array like `["local"]` to a passing string, which would otherwise reach the driver as a non-string.
- A regression test for that `["local"]` array case.

(An earlier revision of this PR briefly dropped the guard; review correctly flagged the resulting hole, so it was restored. The net diff to the validation logic is therefore zero — only the comment and the new test are added.)

## Testing

- `pnpm test src/config/__tests__/toml-loader.test.ts` — 109 pass, including the new array-rejection case and the existing invalid-format (`Asia/Seoul`) case.
- The corrected `+09:00` assertion was verified against mysql2's exact `parseDateTime` logic. The full integration test still requires Docker to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)