### PR TITLE
feat: migrate SQLite connector to built-in node:sqlite (#317)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Get pnpm store directory
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Get pnpm store directory

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker run --rm --init \
    --dsn "postgres://user:password@localhost:5432/dbname?sslmode=disable"
 ```
 
-**NPM:**
+**NPM:** (requires Node.js >= 22.5.0)
 
 ```bash
 npx @bytebase/dbhub@latest --transport http --port 8080 --dsn "postgres://user:password@localhost:5432/dbname?sslmode=disable"
@@ -103,6 +103,8 @@ Connect to multiple databases simultaneously using TOML configuration files. Per
 See [Multi-Database Configuration](https://dbhub.ai/config/toml) for complete setup instructions.
 
 ## Development
+
+Requires Node.js >= 22.5.0 (DBHub uses the built-in `node:sqlite` module).
 
 ```bash
 # Install dependencies

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -51,10 +51,11 @@ Available driver packages:
 - `mysql2` — MySQL
 - `mariadb` — MariaDB
 - `mssql` — SQL Server
-- `better-sqlite3` — SQLite
+
+SQLite uses the built-in `node:sqlite` module (Node.js 22.5+), so it requires no driver package or native compilation and is always available.
 
 <Note>
-When a driver is not installed or a required dependency is missing (e.g., a transitive dependency like `@azure/core-client` for the SQL Server driver), DBHub will skip that connector at startup and log a message. All other connectors will work normally. Note that `--demo` mode requires the `better-sqlite3` driver.
+When a driver is not installed or a required dependency is missing (e.g., a transitive dependency like `@azure/core-client` for the SQL Server driver), DBHub will skip that connector at startup and log a message. All other connectors will work normally. SQLite (including `--demo` mode) needs no extra driver — it relies on the built-in `node:sqlite` module.
 </Note>
 
 ## Docker

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -4,6 +4,10 @@ title: "Installation"
 
 ## npm
 
+<Note>
+The npm method requires **Node.js >= 22.5.0** (DBHub uses Node's built-in `node:sqlite` module). The Docker image bundles a compatible Node runtime, so no local Node install is needed when running via Docker.
+</Note>
+
 <Tabs>
   <Tab title="npx">
     ```bash

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,7 +7,7 @@ This guide will walk you through setting up DBHub and connecting it to an AI too
 ## Prerequisites
 
 Before starting, ensure you have:
-- Node.js 20+ installed (for NPM method) **OR** Docker installed
+- Node.js 22.5+ installed (for NPM method) **OR** Docker installed
 - Access to an AI tool (Claude Desktop, Claude Code, Cursor, or VS Code)
 - Optionally: A PostgreSQL, MySQL, or other supported database
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:build": "node scripts/smoke-test-build.mjs"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.5.0"
   },
   "keywords": [],
   "author": "",
@@ -51,7 +51,6 @@
   "optionalDependencies": {
     "@aws-sdk/rds-signer": "^3.1001.0",
     "@azure/identity": "^4.8.0",
-    "better-sqlite3": "^11.9.0",
     "mariadb": "^3.4.0",
     "mssql": "^11.0.1",
     "mysql2": "^3.13.0",
@@ -62,7 +61,6 @@
     "@testcontainers/mssqlserver": "^11.0.3",
     "@testcontainers/mysql": "^11.0.3",
     "@testcontainers/postgresql": "^11.0.3",
-    "@types/better-sqlite3": "^7.6.12",
     "@types/express": "^4.17.21",
     "@types/mssql": "^9.1.7",
     "@types/node": "^22.13.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^11.0.3
         version: 11.0.3
-      '@types/better-sqlite3':
-        specifier: ^7.6.12
-        version: 7.6.13
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.23
@@ -97,9 +94,6 @@ importers:
       '@azure/identity':
         specifier: ^4.8.0
         version: 4.10.1
-      better-sqlite3:
-        specifier: ^11.9.0
-        version: 11.10.0
       mariadb:
         specifier: ^3.4.0
         version: 3.4.2
@@ -1229,9 +1223,6 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  '@types/better-sqlite3@7.6.13':
-    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
-
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -1496,12 +1487,6 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -1741,14 +1726,6 @@ packages:
       supports-color:
         optional: true
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
-
   default-browser-id@5.0.0:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
     engines: {node: '>=18'}
@@ -1884,10 +1861,6 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
@@ -1938,9 +1911,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
@@ -2006,9 +1976,6 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
-
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -2066,9 +2033,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2360,10 +2324,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
@@ -2371,9 +2331,6 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -2420,9 +2377,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   native-duplexpair@1.0.0:
     resolution: {integrity: sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==}
 
@@ -2433,10 +2387,6 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  node-abi@3.75.0:
-    resolution: {integrity: sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==}
-    engines: {node: '>=10'}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -2597,12 +2547,6 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
@@ -2656,10 +2600,6 @@ packages:
   raw-body@3.0.0:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -2834,12 +2774,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2911,10 +2845,6 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
 
   strnum@2.2.0:
     resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
@@ -3062,9 +2992,6 @@ packages:
     resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
@@ -4815,10 +4742,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@types/better-sqlite3@7.6.13':
-    dependencies:
-      '@types/node': 22.15.31
-
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -5118,17 +5041,6 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-sqlite3@11.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-    optional: true
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-    optional: true
-
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -5375,14 +5287,6 @@ snapshots:
     optionalDependencies:
       supports-color: 10.2.2
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-    optional: true
-
-  deep-extend@0.6.0:
-    optional: true
-
   default-browser-id@5.0.0: {}
 
   default-browser@5.2.1:
@@ -5521,9 +5425,6 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.2
 
-  expand-template@2.0.3:
-    optional: true
-
   expect-type@1.2.2: {}
 
   express-rate-limit@7.5.0(express@5.1.0):
@@ -5621,9 +5522,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  file-uri-to-path@1.0.0:
-    optional: true
-
   finalhandler@1.3.1:
     dependencies:
       debug: 2.6.9
@@ -5704,9 +5602,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-from-package@0.0.0:
-    optional: true
-
   glob@10.4.5:
     dependencies:
       foreground-child: 3.3.1
@@ -5765,9 +5660,6 @@ snapshots:
   index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
-
-  ini@1.3.8:
-    optional: true
 
   ipaddr.js@1.9.1: {}
 
@@ -5994,9 +5886,6 @@ snapshots:
 
   mime@1.6.0: {}
 
-  mimic-response@3.1.0:
-    optional: true
-
   minimatch@5.1.6:
     dependencies:
       brace-expansion: 2.0.2
@@ -6004,9 +5893,6 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
-
-  minimist@1.2.8:
-    optional: true
 
   minipass@7.1.2: {}
 
@@ -6066,19 +5952,11 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
-
   native-duplexpair@1.0.0: {}
 
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
-
-  node-abi@3.75.0:
-    dependencies:
-      semver: 7.7.2
-    optional: true
 
   node-releases@2.0.27: {}
 
@@ -6218,22 +6096,6 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.0.4
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.75.0
-      pump: 3.0.2
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.3
-      tunnel-agent: 0.6.0
-    optional: true
-
   prettier@3.5.3: {}
 
   process-nextick-args@2.0.1: {}
@@ -6300,14 +6162,6 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       unpipe: 1.0.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
-    optional: true
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -6537,16 +6391,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-    optional: true
-
   source-map-js@1.2.1: {}
 
   source-map@0.8.0-beta.0:
@@ -6620,9 +6464,6 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
-
-  strip-json-comments@2.0.1:
-    optional: true
 
   strnum@2.2.0:
     optional: true
@@ -6820,11 +6661,6 @@ snapshots:
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
 
   tw-animate-css@1.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,12 +2,8 @@ packages:
   - '.'
   - 'frontend'
 
-approvedBuilds:
-  - better-sqlite3
 ignoredBuiltDependencies:
   - cpu-features
   - esbuild
   - protobufjs
   - ssh2
-onlyBuiltDependencies:
-  - better-sqlite3

--- a/src/connectors/__tests__/sqlite.integration.test.ts
+++ b/src/connectors/__tests__/sqlite.integration.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { SQLiteConnector } from '../sqlite/index.js';
 import { IntegrationTestBase, type TestContainer, type DatabaseTestConfig } from './shared/integration-test-base.js';
 import type { Connector } from '../interface.js';
-import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -130,12 +130,13 @@ export class SQLiteConnector implements Connector {
   }
 
   /**
-   * Prepare a statement with BigInt reads enabled.
+   * Prepare a user-facing query statement with BigInt reads enabled, so 64-bit
+   * integer values in the result rows keep full precision.
    *
-   * better-sqlite3 exposed a connection-level `defaultSafeIntegers(true)` to
-   * return all integers as BigInt (preserving precision for large values).
-   * `node:sqlite` only offers this per-statement via `setReadBigInts`, so we
-   * centralize it here to keep behavior identical across the connector.
+   * better-sqlite3 exposed this connection-wide via `defaultSafeIntegers(true)`;
+   * `node:sqlite` only offers it per-statement via `setReadBigInts`. This is for
+   * `executeSQL` only — schema introspection reads small integer flags and uses
+   * `queryAll`/`queryOne` (plain numbers) so comparisons like `=== 1` work.
    */
   private prepare(sql: string): StatementSync {
     if (!this.db) {
@@ -144,6 +145,27 @@ export class SQLiteConnector implements Connector {
     const statement = this.db.prepare(sql);
     statement.setReadBigInts(true);
     return statement;
+  }
+
+  /**
+   * Run an introspection query and return all rows. Integers come back as plain
+   * numbers (no `setReadBigInts`), which is what the schema-reading callers need
+   * for boolean flag comparisons. node:sqlite types `.all()` as a generic record
+   * array, so the result is cast to the caller's expected row shape.
+   */
+  private queryAll<T>(sql: string, ...params: any[]): T[] {
+    if (!this.db) {
+      throw new Error("Not connected to SQLite database");
+    }
+    return this.db.prepare(sql).all(...params) as unknown as T[];
+  }
+
+  /** Run an introspection query and return a single row (or undefined). */
+  private queryOne<T>(sql: string, ...params: any[]): T | undefined {
+    if (!this.db) {
+      throw new Error("Not connected to SQLite database");
+    }
+    return this.db.prepare(sql).get(...params) as unknown as T | undefined;
   }
 
   /**
@@ -235,15 +257,11 @@ export class SQLiteConnector implements Connector {
     // You could use 'schema.table' syntax if you have attached databases, but we're
     // accessing the 'main' database by default
     try {
-      const rows = this.db
-        .prepare(
-          `
-        SELECT name FROM sqlite_master 
+      const rows = this.queryAll<SQLiteTableNameRow>(`
+        SELECT name FROM sqlite_master
         WHERE type='table' AND name NOT LIKE 'sqlite_%'
         ORDER BY name
-      `
-        )
-        .all() as unknown as SQLiteTableNameRow[];
+      `);
 
       return rows.map((row) => row.name);
     } catch (error) {
@@ -258,15 +276,11 @@ export class SQLiteConnector implements Connector {
 
     // In SQLite, schema parameter is ignored since SQLite doesn't have schemas like PostgreSQL
     try {
-      const rows = this.db
-        .prepare(
-          `
+      const rows = this.queryAll<SQLiteTableNameRow>(`
         SELECT name FROM sqlite_master
         WHERE type='view' AND name NOT LIKE 'sqlite_%'
         ORDER BY name
-      `
-        )
-        .all() as unknown as SQLiteTableNameRow[];
+      `);
 
       return rows.map((row) => row.name);
     } catch (error) {
@@ -282,14 +296,13 @@ export class SQLiteConnector implements Connector {
     // In SQLite, schema parameter is ignored since there's only one schema per database file
     // All tables exist in a single namespace within the SQLite database
     try {
-      const row = this.db
-        .prepare(
-          `
-        SELECT name FROM sqlite_master 
+      const row = this.queryOne<SQLiteTableNameRow>(
+        `
+        SELECT name FROM sqlite_master
         WHERE type='table' AND name = ?
-      `
-        )
-        .get(tableName) as unknown as SQLiteTableNameRow | undefined;
+      `,
+        tableName
+      );
 
       return !!row;
     } catch (error) {
@@ -305,26 +318,25 @@ export class SQLiteConnector implements Connector {
     // In SQLite, schema parameter is ignored (no schema concept)
     try {
       // Get all indexes for the specified table
-      const indexInfoRows = this.db
-        .prepare(
-          `
-        SELECT 
+      const indexInfoRows = this.queryAll<{ index_name: string; is_unique: number }>(
+        `
+        SELECT
           name as index_name,
           0 as is_unique
-        FROM sqlite_master 
-        WHERE type = 'index' 
+        FROM sqlite_master
+        WHERE type = 'index'
         AND tbl_name = ?
-      `
-        )
-        .all(tableName) as unknown as { index_name: string; is_unique: number }[];
+      `,
+        tableName
+      );
 
       // Get unique info from PRAGMA index_list which provides the unique flag
       // Note: PRAGMA commands require proper identifier quoting for special characters
       const quotedTableName = quoteIdentifier(tableName, "sqlite");
-      const indexListRows = this.db
-        .prepare(`PRAGMA index_list(${quotedTableName})`)
-        .all() as unknown as { name: string; unique: number }[];
-      
+      const indexListRows = this.queryAll<{ name: string; unique: number }>(
+        `PRAGMA index_list(${quotedTableName})`
+      );
+
       // Create a map of index names to unique status
       const indexUniqueMap = new Map<string, boolean>();
       for (const indexListRow of indexListRows) {
@@ -332,9 +344,7 @@ export class SQLiteConnector implements Connector {
       }
 
       // Get the primary key info
-      const tableInfo = this.db
-        .prepare(`PRAGMA table_info(${quotedTableName})`)
-        .all() as unknown as SQLiteTableInfo[];
+      const tableInfo = this.queryAll<SQLiteTableInfo>(`PRAGMA table_info(${quotedTableName})`);
 
       // Find primary key columns
       const pkColumns = tableInfo.filter((col) => col.pk > 0).map((col) => col.name);
@@ -345,11 +355,9 @@ export class SQLiteConnector implements Connector {
       for (const indexInfo of indexInfoRows) {
         // Get the columns for this index
         const quotedIndexName = quoteIdentifier(indexInfo.index_name, "sqlite");
-        const indexDetailRows = this.db
-          .prepare(`PRAGMA index_info(${quotedIndexName})`)
-          .all() as unknown as {
-          name: string;
-        }[];
+        const indexDetailRows = this.queryAll<{ name: string }>(
+          `PRAGMA index_info(${quotedIndexName})`
+        );
         const columnNames = indexDetailRows.map((row) => row.name);
 
         results.push({
@@ -387,7 +395,7 @@ export class SQLiteConnector implements Connector {
     // 3. The PRAGMA commands operate on the current database connection
     try {
       const quotedTableName = quoteIdentifier(tableName, "sqlite");
-      const rows = this.prepare(`PRAGMA table_info(${quotedTableName})`).all() as unknown as SQLiteTableInfo[];
+      const rows = this.queryAll<SQLiteTableInfo>(`PRAGMA table_info(${quotedTableName})`);
 
       // Convert SQLite schema format to our standard TableColumn format
       // SQLite does not support column comments, so description is always null

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -7,12 +7,8 @@
  * To use this connector: Set DSN=sqlite:///path/to/database.db in your .env file
  */
 
-// Install the experimental-warning hook before `node:sqlite` is ever loaded.
-// Node emits the warning at module-load time, and `node:sqlite` is loaded
-// lazily via dynamic import() inside connect() (a static import would be
-// hoisted above this side-effect import after bundling, defeating the hook).
-import "./suppress-experimental-warning.js";
 import type { DatabaseSync as SqliteDatabase, StatementSync } from "node:sqlite";
+import { suppressSqliteExperimentalWarning } from "./suppress-experimental-warning.js";
 import {
   Connector,
   ConnectorType,
@@ -178,8 +174,11 @@ export class SQLiteConnector implements Connector {
     this.dbPath = parsedConfig.dbPath;
 
     try {
-      // Load node:sqlite lazily so the experimental-warning hook (installed via
-      // the side-effect import above) is in place before the module is loaded.
+      // Install the experimental-warning hook before node:sqlite is loaded, then
+      // import it lazily. Doing both here keeps the global process.emitWarning
+      // patch scoped to processes that actually use SQLite (node:sqlite emits the
+      // warning at module-load time, so the hook must precede the import).
+      suppressSqliteExperimentalWarning();
       const { DatabaseSync } = await import("node:sqlite");
 
       // SDK-level readonly enforcement: Pass readOnly option to node:sqlite

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -1,10 +1,18 @@
 /**
  * SQLite Connector Implementation
  *
- * Implements SQLite database connectivity for DBHub using better-sqlite3
+ * Implements SQLite database connectivity for DBHub using the built-in
+ * `node:sqlite` module. This requires Node.js >= 22.5.0 and needs no native
+ * compilation (no node-gyp / better-sqlite3 prebuilds).
  * To use this connector: Set DSN=sqlite:///path/to/database.db in your .env file
  */
 
+// Install the experimental-warning hook before `node:sqlite` is ever loaded.
+// Node emits the warning at module-load time, and `node:sqlite` is loaded
+// lazily via dynamic import() inside connect() (a static import would be
+// hoisted above this side-effect import after bundling, defeating the hook).
+import "./suppress-experimental-warning.js";
+import type { DatabaseSync as SqliteDatabase, StatementSync } from "node:sqlite";
 import {
   Connector,
   ConnectorType,
@@ -17,7 +25,6 @@ import {
   ExecuteOptions,
   ConnectorConfig,
 } from "../interface.js";
-import Database from "better-sqlite3";
 import { quoteIdentifier } from "../../utils/identifier-quoter.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
@@ -108,7 +115,7 @@ export class SQLiteConnector implements Connector {
   name = "SQLite";
   dsnParser = new SQLiteDSNParser();
 
-  private db: Database.Database | null = null;
+  private db: SqliteDatabase | null = null;
   private dbPath: string = ":memory:"; // Default to in-memory database
 
   // Source ID is set by ConnectorManager after cloning
@@ -123,6 +130,23 @@ export class SQLiteConnector implements Connector {
   }
 
   /**
+   * Prepare a statement with BigInt reads enabled.
+   *
+   * better-sqlite3 exposed a connection-level `defaultSafeIntegers(true)` to
+   * return all integers as BigInt (preserving precision for large values).
+   * `node:sqlite` only offers this per-statement via `setReadBigInts`, so we
+   * centralize it here to keep behavior identical across the connector.
+   */
+  private prepare(sql: string): StatementSync {
+    if (!this.db) {
+      throw new Error("Not connected to SQLite database");
+    }
+    const statement = this.db.prepare(sql);
+    statement.setReadBigInts(true);
+    return statement;
+  }
+
+  /**
    * Connect to SQLite database
    * Note: SQLite does not support connection timeouts as it's a local file-based database.
    * The config parameter is accepted for interface compliance but ignored.
@@ -132,17 +156,23 @@ export class SQLiteConnector implements Connector {
     this.dbPath = parsedConfig.dbPath;
 
     try {
-      // SDK-level readonly enforcement: Pass readonly option to better-sqlite3
+      // Load node:sqlite lazily so the experimental-warning hook (installed via
+      // the side-effect import above) is in place before the module is loaded.
+      const { DatabaseSync } = await import("node:sqlite");
+
+      // SDK-level readonly enforcement: Pass readOnly option to node:sqlite
       // Note: In-memory databases (:memory:) cannot be opened in readonly mode
-      const dbOptions: any = {};
+      const dbOptions: ConstructorParameters<typeof DatabaseSync>[1] = {
+        // node:sqlite enables foreign key constraints by default, whereas
+        // better-sqlite3 (and SQLite's own default) leaves them off. Preserve
+        // the historical behavior; callers can opt in via `PRAGMA foreign_keys = ON`.
+        enableForeignKeyConstraints: false,
+      };
       if (config?.readonly && this.dbPath !== ':memory:') {
-        dbOptions.readonly = true;
+        dbOptions.readOnly = true;
       }
 
-      this.db = new Database(this.dbPath, dbOptions);
-
-      // Return all integers as BigInt to preserve precision for large values
-      this.db.defaultSafeIntegers(true);
+      this.db = new DatabaseSync(this.dbPath, dbOptions);
 
       // If an initialization script is provided, run it
       if (initScript) {
@@ -157,8 +187,12 @@ export class SQLiteConnector implements Connector {
   async disconnect(): Promise<void> {
     if (this.db) {
       try {
-        // Check if the database is still open before attempting to close
-        if (!this.db.inTransaction) {
+        // Check if the database is still open before attempting to close.
+        // `isTransaction` exists at runtime (Node >= 22.5) but isn't yet in the
+        // installed @types/node, so we read it through a narrow cast.
+        const inTransaction = (this.db as SqliteDatabase & { isTransaction: boolean })
+          .isTransaction;
+        if (!inTransaction) {
           this.db.close();
         } else {
           // If in transaction, try to rollback first
@@ -209,7 +243,7 @@ export class SQLiteConnector implements Connector {
         ORDER BY name
       `
         )
-        .all() as SQLiteTableNameRow[];
+        .all() as unknown as SQLiteTableNameRow[];
 
       return rows.map((row) => row.name);
     } catch (error) {
@@ -232,7 +266,7 @@ export class SQLiteConnector implements Connector {
         ORDER BY name
       `
         )
-        .all() as SQLiteTableNameRow[];
+        .all() as unknown as SQLiteTableNameRow[];
 
       return rows.map((row) => row.name);
     } catch (error) {
@@ -255,7 +289,7 @@ export class SQLiteConnector implements Connector {
         WHERE type='table' AND name = ?
       `
         )
-        .get(tableName) as SQLiteTableNameRow | undefined;
+        .get(tableName) as unknown as SQLiteTableNameRow | undefined;
 
       return !!row;
     } catch (error) {
@@ -282,14 +316,14 @@ export class SQLiteConnector implements Connector {
         AND tbl_name = ?
       `
         )
-        .all(tableName) as { index_name: string; is_unique: number }[];
+        .all(tableName) as unknown as { index_name: string; is_unique: number }[];
 
       // Get unique info from PRAGMA index_list which provides the unique flag
       // Note: PRAGMA commands require proper identifier quoting for special characters
       const quotedTableName = quoteIdentifier(tableName, "sqlite");
       const indexListRows = this.db
         .prepare(`PRAGMA index_list(${quotedTableName})`)
-        .all() as { name: string; unique: number }[];
+        .all() as unknown as { name: string; unique: number }[];
       
       // Create a map of index names to unique status
       const indexUniqueMap = new Map<string, boolean>();
@@ -300,7 +334,7 @@ export class SQLiteConnector implements Connector {
       // Get the primary key info
       const tableInfo = this.db
         .prepare(`PRAGMA table_info(${quotedTableName})`)
-        .all() as SQLiteTableInfo[];
+        .all() as unknown as SQLiteTableInfo[];
 
       // Find primary key columns
       const pkColumns = tableInfo.filter((col) => col.pk > 0).map((col) => col.name);
@@ -313,7 +347,7 @@ export class SQLiteConnector implements Connector {
         const quotedIndexName = quoteIdentifier(indexInfo.index_name, "sqlite");
         const indexDetailRows = this.db
           .prepare(`PRAGMA index_info(${quotedIndexName})`)
-          .all() as {
+          .all() as unknown as {
           name: string;
         }[];
         const columnNames = indexDetailRows.map((row) => row.name);
@@ -353,7 +387,7 @@ export class SQLiteConnector implements Connector {
     // 3. The PRAGMA commands operate on the current database connection
     try {
       const quotedTableName = quoteIdentifier(tableName, "sqlite");
-      const rows = this.db.prepare(`PRAGMA table_info(${quotedTableName})`).all() as SQLiteTableInfo[];
+      const rows = this.prepare(`PRAGMA table_info(${quotedTableName})`).all() as unknown as SQLiteTableInfo[];
 
       // Convert SQLite schema format to our standard TableColumn format
       // SQLite does not support column comments, so description is always null
@@ -439,7 +473,7 @@ export class SQLiteConnector implements Connector {
           // Pass parameters if provided
           if (parameters && parameters.length > 0) {
             try {
-              const rows = this.db.prepare(processedStatement).all(...parameters);
+              const rows = this.prepare(processedStatement).all(...parameters);
               return { rows, rowCount: rows.length };
             } catch (error) {
               console.error(`[SQLite executeSQL] ERROR: ${(error as Error).message}`);
@@ -448,7 +482,7 @@ export class SQLiteConnector implements Connector {
               throw error;
             }
           } else {
-            const rows = this.db.prepare(processedStatement).all();
+            const rows = this.prepare(processedStatement).all();
             return { rows, rowCount: rows.length };
           }
         } else {
@@ -456,7 +490,7 @@ export class SQLiteConnector implements Connector {
           let result;
           if (parameters && parameters.length > 0) {
             try {
-              result = this.db.prepare(processedStatement).run(...parameters);
+              result = this.prepare(processedStatement).run(...parameters);
             } catch (error) {
               console.error(`[SQLite executeSQL] ERROR: ${(error as Error).message}`);
               console.error(`[SQLite executeSQL] SQL: ${processedStatement}`);
@@ -464,9 +498,11 @@ export class SQLiteConnector implements Connector {
               throw error;
             }
           } else {
-            result = this.db.prepare(processedStatement).run();
+            result = this.prepare(processedStatement).run();
           }
-          return { rows: [], rowCount: result.changes };
+          // node:sqlite returns `changes` as BigInt when BigInt reads are
+          // enabled; normalize to a number to match the SQLResult contract.
+          return { rows: [], rowCount: Number(result.changes) };
         }
       } else {
         // Multiple statements - parameters not supported for multi-statement queries
@@ -500,8 +536,8 @@ export class SQLiteConnector implements Connector {
         // Execute write statements individually to track changes
         let totalChanges = 0;
         for (const statement of writeStatements) {
-          const result = this.db.prepare(statement).run();
-          totalChanges += result.changes;
+          const result = this.prepare(statement).run();
+          totalChanges += Number(result.changes);
         }
 
         // Execute read statements individually to collect results
@@ -509,7 +545,7 @@ export class SQLiteConnector implements Connector {
         for (let statement of readStatements) {
           // Apply maxRows limit to SELECT queries if specified
           statement = SQLRowLimiter.applyMaxRows(statement, options.maxRows);
-          const result = this.db.prepare(statement).all();
+          const result = this.prepare(statement).all();
           allRows.push(...result);
         }
 

--- a/src/connectors/sqlite/suppress-experimental-warning.ts
+++ b/src/connectors/sqlite/suppress-experimental-warning.ts
@@ -2,18 +2,30 @@
  * Suppress the one-time `ExperimentalWarning` that Node.js emits the first time
  * the built-in `node:sqlite` module is loaded.
  *
- * Node emits this warning at module-load time, so this hook MUST be installed
- * before `node:sqlite` is imported anywhere in the process. Import this module
- * *before* the `node:sqlite` import (ESM evaluates imports in source order).
+ * Node emits this warning at module-load time, so the hook MUST be installed
+ * before `node:sqlite` is loaded. The SQLite connector loads `node:sqlite`
+ * lazily (dynamic import inside connect()), so call this immediately before
+ * that import — that keeps the global `process.emitWarning` patch scoped to
+ * processes that actually use SQLite, rather than installing it at startup for
+ * every DBHub instance.
  *
  * Only this specific warning is filtered; all other process warnings pass
- * through unchanged.
+ * through unchanged. Idempotent — safe to call on every connect().
  */
-const originalEmitWarning = process.emitWarning.bind(process);
-process.emitWarning = ((warning: string | Error, ...args: any[]) => {
-  const message = typeof warning === "string" ? warning : warning?.message;
-  if (message && message.includes("SQLite is an experimental feature")) {
+let installed = false;
+
+export function suppressSqliteExperimentalWarning(): void {
+  if (installed) {
     return;
   }
-  return (originalEmitWarning as any)(warning, ...args);
-}) as typeof process.emitWarning;
+  installed = true;
+
+  const originalEmitWarning = process.emitWarning.bind(process);
+  process.emitWarning = ((warning: string | Error, ...args: any[]) => {
+    const message = typeof warning === "string" ? warning : warning?.message;
+    if (message && message.includes("SQLite is an experimental feature")) {
+      return;
+    }
+    return (originalEmitWarning as any)(warning, ...args);
+  }) as typeof process.emitWarning;
+}

--- a/src/connectors/sqlite/suppress-experimental-warning.ts
+++ b/src/connectors/sqlite/suppress-experimental-warning.ts
@@ -1,0 +1,19 @@
+/**
+ * Suppress the one-time `ExperimentalWarning` that Node.js emits the first time
+ * the built-in `node:sqlite` module is loaded.
+ *
+ * Node emits this warning at module-load time, so this hook MUST be installed
+ * before `node:sqlite` is imported anywhere in the process. Import this module
+ * *before* the `node:sqlite` import (ESM evaluates imports in source order).
+ *
+ * Only this specific warning is filtered; all other process warnings pass
+ * through unchanged.
+ */
+const originalEmitWarning = process.emitWarning.bind(process);
+process.emitWarning = ((warning: string | Error, ...args: any[]) => {
+  const message = typeof warning === "string" ? warning : warning?.message;
+  if (message && message.includes("SQLite is an experimental feature")) {
+    return;
+  }
+  return (originalEmitWarning as any)(warning, ...args);
+}) as typeof process.emitWarning;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { loadConnectors } from "./utils/module-loader.js";
 const connectorModules = [
   { load: () => import("./connectors/postgres/index.js"), name: "PostgreSQL", driver: "pg" },
   { load: () => import("./connectors/sqlserver/index.js"), name: "SQL Server", driver: "mssql" },
-  { load: () => import("./connectors/sqlite/index.js"), name: "SQLite", driver: "better-sqlite3" },
+  { load: () => import("./connectors/sqlite/index.js"), name: "SQLite", driver: "node:sqlite" },
   { load: () => import("./connectors/mysql/index.js"), name: "MySQL", driver: "mysql2" },
   { load: () => import("./connectors/mariadb/index.js"), name: "MariaDB", driver: "mariadb" },
 ];

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,13 +8,18 @@ export default defineConfig({
   dts: true,
   clean: true,
   outDir: 'dist',
+  // Keep the `node:` protocol on builtin imports. tsup strips it by default
+  // (removeNodeProtocol), which rewrites `node:sqlite` to `sqlite` — and the
+  // bare `sqlite` specifier is not a resolvable Node builtin, so the SQLite
+  // connector would fail to load at runtime.
+  removeNodeProtocol: false,
   // Optional runtime-loaded dependencies (database drivers and cloud auth
   // packages) are declared as optionalDependencies and loaded via dynamic
   // import(). Database drivers must be external so tsup does not bundle their
   // CJS code into ESM chunks (which causes "Dynamic require of X is not
   // supported"). Cloud auth packages are externalized to keep their large
   // dependency trees out of the bundle.
-  external: ['pg', 'mysql2', 'mariadb', 'mssql', 'better-sqlite3', '@aws-sdk/rds-signer', '@azure/identity'],
+  external: ['pg', 'mysql2', 'mariadb', 'mssql', '@aws-sdk/rds-signer', '@azure/identity'],
   // Copy the employee-sqlite demo data to dist
   async onSuccess() {
     // Create target directory


### PR DESCRIPTION
Closes #317.

## What
Replaces `better-sqlite3` with Node's built-in **`node:sqlite`** module for the SQLite connector. This eliminates native C++ compilation (node-gyp) and prebuild-binary friction — the pain points raised in #317 (Alpine/musl Docker, newer Node majors, locked-down environments). SQLite now needs no driver package and is **always available**.

## API mapping
| better-sqlite3 | node:sqlite |
|---|---|
| `new Database(path, {readonly})` | `new DatabaseSync(path, {readOnly})` |
| `db.defaultSafeIntegers(true)` (connection-level) | `stmt.setReadBigInts(true)` per statement, centralized in a private `prepare()` helper |
| `db.inTransaction` | `db.isTransaction` |

## Behavior preserved
- `run()` returns `changes` as BigInt once `setReadBigInts` is on; better-sqlite3 returned a plain number, so the row-count arithmetic is normalized via `Number()`.
- Foreign keys default **off** (`enableForeignKeyConstraints: false`) — node:sqlite defaults them on, better-sqlite3 (and SQLite itself) does not.

## Build/runtime gotchas fixed
1. **tsup stripped the `node:` prefix.** tsup 8.5 defaults `removeNodeProtocol: true`, rewriting `node:sqlite` → `sqlite` (unresolvable builtin) so the connector silently failed to load in the *built* binary. Fixed with `removeNodeProtocol: false`.
2. **`ExperimentalWarning`.** node:sqlite emits it at *module-load* time, and a static import is hoisted above suppression code after bundling. Fixed by a targeted warning filter (`suppress-experimental-warning.ts`) imported first, plus loading `node:sqlite` via a non-hoisted lazy `await import()` inside `connect()`.

## Other changes
- Drop `better-sqlite3` + `@types/better-sqlite3`; remove its native-build approvals from `pnpm-workspace.yaml`.
- Bump `engines.node` to `>=22.5.0`; CI `run-tests` Node 20 → 22.
- Update install/quickstart docs.

## ⚠️ Breaking change
Requires **Node.js >= 22.5.0** (node:sqlite availability). Node 20 is EOL as of April 2026, so the floor bump is reasonable, but it should be flagged in release notes / a suitable version bump.

> Note: `node:sqlite` is still marked *experimental* upstream; the warning is suppressed but the underlying module is stable enough for our usage and fully covered by the existing integration suite.

## Verification
- ✅ 48 SQLite tests pass (connector + multi-source), 708 unit tests pass
- ✅ Built binary runs in `--demo` mode, returns correct data, **no** ExperimentalWarning
- ✅ Positional `?` parameter binding verified at runtime
- ✅ `tsc` clean for all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)