### PR TITLE
fix: scope search_objects to configured database on MySQL/MariaDB

### DIFF
--- a/src/connectors/__tests__/mariadb.integration.test.ts
+++ b/src/connectors/__tests__/mariadb.integration.test.ts
@@ -19,7 +19,7 @@ class MariaDBTestContainer implements TestContainer {
 class MariaDBIntegrationTest extends IntegrationTestBase<MariaDBTestContainer> {
   constructor() {
     const config: DatabaseTestConfig = {
-      expectedSchemas: ['testdb', 'information_schema'],
+      expectedSchemas: ['testdb'],
       expectedTables: ['users', 'orders', 'products'],
       supportsStoredProcedures: false, // Disabled due to container privilege restrictions
       supportsComments: true,
@@ -182,6 +182,19 @@ describe('MariaDB Connector Integration Tests', () => {
   mariadbTest.createSSLTests();
 
   describe('MariaDB-specific Features', () => {
+    it('should exclude server-level system databases from getSchemas()', async () => {
+      const schemas = await mariadbTest.connector.getSchemas();
+      expect(schemas).toContain('testdb');
+      expect(schemas).not.toContain('information_schema');
+      expect(schemas).not.toContain('performance_schema');
+      expect(schemas).not.toContain('mysql');
+      expect(schemas).not.toContain('sys');
+    });
+
+    it('should report the DSN-configured database as the default schema', async () => {
+      expect(await mariadbTest.connector.getDefaultSchema!()).toBe('testdb');
+    });
+
     it('should execute multiple statements with native support', async () => {
       // First insert the test data
       await mariadbTest.connector.executeSQL(`

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -19,7 +19,7 @@ class MySQLTestContainer implements TestContainer {
 class MySQLIntegrationTest extends IntegrationTestBase<MySQLTestContainer> {
   constructor() {
     const config: DatabaseTestConfig = {
-      expectedSchemas: ['testdb', 'information_schema'],
+      expectedSchemas: ['testdb'],
       expectedTables: ['users', 'orders', 'products'],
       supportsStoredProcedures: false, // Disabled due to container privilege restrictions
       supportsComments: true,
@@ -176,6 +176,19 @@ describe('MySQL Connector Integration Tests', () => {
   mysqlTest.createSSLTests();
 
   describe('MySQL-specific Features', () => {
+    it('should exclude server-level system databases from getSchemas()', async () => {
+      const schemas = await mysqlTest.connector.getSchemas();
+      expect(schemas).toContain('testdb');
+      expect(schemas).not.toContain('information_schema');
+      expect(schemas).not.toContain('performance_schema');
+      expect(schemas).not.toContain('mysql');
+      expect(schemas).not.toContain('sys');
+    });
+
+    it('should report the DSN-configured database as the default schema', async () => {
+      expect(await mysqlTest.connector.getDefaultSchema!()).toBe('testdb');
+    });
+
     it('should execute multiple statements with native support', async () => {
       // First insert the test data
       await mysqlTest.connector.executeSQL(`

--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -298,6 +298,41 @@ describe('SQL Server Connector Integration Tests', () => {
       expect(Number(after.rows[0].count)).toBe(0);
     });
 
+    it('should translate EXPLAIN even when preceded by a comment', async () => {
+      const result = await sqlServerTest.connector.executeSQL(
+        '/* inspect plan */ EXPLAIN SELECT * FROM users',
+        {}
+      );
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].plan as string).toContain('ShowPlanXML');
+    });
+
+    it('should reject SET SHOWPLAN smuggled into an EXPLAIN query', async () => {
+      const before = await sqlServerTest.connector.executeSQL(
+        'SELECT COUNT(*) as count FROM users',
+        {}
+      );
+
+      await expect(
+        sqlServerTest.connector.executeSQL(
+          'EXPLAIN SET SHOWPLAN_XML OFF DELETE FROM users',
+          {}
+        )
+      ).rejects.toThrow(/SET SHOWPLAN/i);
+
+      const after = await sqlServerTest.connector.executeSQL(
+        'SELECT COUNT(*) as count FROM users',
+        {}
+      );
+      expect(Number(after.rows[0].count)).toBe(Number(before.rows[0].count));
+    });
+
+    it('should reject an empty EXPLAIN', async () => {
+      await expect(
+        sqlServerTest.connector.executeSQL('EXPLAIN   ', {})
+      ).rejects.toThrow(/requires a statement/i);
+    });
+
     it('should handle SQL Server IDENTITY columns', async () => {
       await sqlServerTest.connector.executeSQL(`
         CREATE TABLE identity_test (

--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -264,6 +264,40 @@ describe('SQL Server Connector Integration Tests', () => {
   });
 
   describe('SQL Server-specific Features', () => {
+    it('should return an execution plan for EXPLAIN <query> (SHOWPLAN_XML)', async () => {
+      const result = await sqlServerTest.connector.executeSQL(
+        'EXPLAIN SELECT * FROM users WHERE age > 30',
+        {}
+      );
+
+      expect(result.rows).toHaveLength(1);
+      const planXml = result.rows[0].plan as string;
+      expect(typeof planXml).toBe('string');
+      // SHOWPLAN_XML output is a ShowPlanXML document referencing the query.
+      expect(planXml).toContain('ShowPlanXML');
+      expect(planXml).toContain('users');
+    });
+
+    it('should not execute the statement under EXPLAIN', async () => {
+      const before = await sqlServerTest.connector.executeSQL(
+        "SELECT COUNT(*) as count FROM users WHERE email = 'explain-noexec@example.com'",
+        {}
+      );
+      expect(Number(before.rows[0].count)).toBe(0);
+
+      // SHOWPLAN_XML compiles without executing, so this INSERT must not run.
+      await sqlServerTest.connector.executeSQL(
+        "EXPLAIN INSERT INTO users (name, email, age) VALUES ('NoExec', 'explain-noexec@example.com', 99)",
+        {}
+      );
+
+      const after = await sqlServerTest.connector.executeSQL(
+        "SELECT COUNT(*) as count FROM users WHERE email = 'explain-noexec@example.com'",
+        {}
+      );
+      expect(Number(after.rows[0].count)).toBe(0);
+    });
+
     it('should handle SQL Server IDENTITY columns', async () => {
       await sqlServerTest.connector.executeSQL(`
         CREATE TABLE identity_test (

--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -333,6 +333,12 @@ describe('SQL Server Connector Integration Tests', () => {
       ).rejects.toThrow(/requires a statement/i);
     });
 
+    it('should reject a comment-only EXPLAIN', async () => {
+      await expect(
+        sqlServerTest.connector.executeSQL('EXPLAIN /* just a comment */', {})
+      ).rejects.toThrow(/requires a statement/i);
+    });
+
     it('should handle SQL Server IDENTITY columns', async () => {
       await sqlServerTest.connector.executeSQL(`
         CREATE TABLE identity_test (

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -132,6 +132,19 @@ export interface Connector {
   getSchemas(): Promise<string[]>;
 
   /**
+   * Get the schema that searches should default to when no schema is specified.
+   *
+   * Returns a single schema name when the connection is scoped to one (e.g. the
+   * database named in a MySQL/MariaDB DSN), or null when there is no configured
+   * scope and callers should fall back to getSchemas() (the full list).
+   *
+   * Connectors whose getSchemas() is already scoped to the connected database
+   * (PostgreSQL, SQL Server, SQLite) may omit this or return null.
+   * @returns Promise with the default schema name, or null for the full list
+   */
+  getDefaultSchema?(): Promise<string | null>;
+
+  /**
    * Get all tables in the database or in a specific schema
    * @param schema Optional schema name. If not provided, implementation should use the default schema:
    *   - PostgreSQL: 'public' schema

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -152,10 +152,13 @@ export class MariaDBConnector implements Connector {
     }
 
     try {
-      // In MariaDB, schemas are equivalent to databases
+      // In MariaDB, schemas are equivalent to databases. Exclude server-level
+      // system databases so the list matches the user-facing schemas only
+      // (parity with the PostgreSQL connector, which hides pg_catalog et al.).
       const rows = await this.pool.query(`
-        SELECT SCHEMA_NAME 
+        SELECT SCHEMA_NAME
         FROM INFORMATION_SCHEMA.SCHEMATA
+        WHERE SCHEMA_NAME NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys')
         ORDER BY SCHEMA_NAME
       `) as any[];
 
@@ -540,6 +543,19 @@ export class MariaDBConnector implements Connector {
   private async getCurrentSchema(): Promise<string> {
     const rows = await this.pool!.query("SELECT DATABASE() AS DB") as any[];
     return rows[0].DB;
+  }
+
+  /**
+   * Default search scope = the database named in the DSN. DATABASE() returns
+   * null when the connection was opened without a database, in which case
+   * callers fall back to the full server-wide schema list.
+   */
+  async getDefaultSchema(): Promise<string | null> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+    const rows = await this.pool.query("SELECT DATABASE() AS DB") as any[];
+    return rows[0]?.DB ?? null;
   }
 
   async executeSQL(sql: string, options: ExecuteOptions, parameters?: any[]): Promise<SQLResult> {

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -160,10 +160,13 @@ export class MySQLConnector implements Connector {
     }
 
     try {
-      // In MySQL, schemas are equivalent to databases
+      // In MySQL, schemas are equivalent to databases. Exclude server-level
+      // system databases so the list matches the user-facing schemas only
+      // (parity with the PostgreSQL connector, which hides pg_catalog et al.).
       const [rows] = (await this.pool.query(`
-        SELECT SCHEMA_NAME 
+        SELECT SCHEMA_NAME
         FROM INFORMATION_SCHEMA.SCHEMATA
+        WHERE SCHEMA_NAME NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys')
         ORDER BY SCHEMA_NAME
       `)) as [any[], any];
 
@@ -548,6 +551,19 @@ export class MySQLConnector implements Connector {
   private async getCurrentSchema(): Promise<string> {
     const [rows] = (await this.pool!.query("SELECT DATABASE() AS DB")) as [any[], any];
     return rows[0].DB;
+  }
+
+  /**
+   * Default search scope = the database named in the DSN. DATABASE() returns
+   * null when the connection was opened without a database, in which case
+   * callers fall back to the full server-wide schema list.
+   */
+  async getDefaultSchema(): Promise<string | null> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+    const [rows] = (await this.pool.query("SELECT DATABASE() AS DB")) as [any[], any];
+    return rows[0]?.DB ?? null;
   }
 
   async executeSQL(sql: string, options: ExecuteOptions, parameters?: any[]): Promise<SQLResult> {

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -15,6 +15,7 @@ import { isDriverNotInstalled } from "../../utils/module-loader.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
+import { stripCommentsAndStrings } from "../../utils/sql-parser.js";
 
 /**
  * SQL Server DSN parser
@@ -171,8 +172,13 @@ export class SQLServerConnector implements Connector {
   // Source ID is set by ConnectorManager after cloning
   private sourceId: string = "default";
 
-  /** Leading `EXPLAIN ` keyword, translated to a SHOWPLAN_XML request. */
-  private static readonly EXPLAIN_PREFIX = /^\s*explain\s+/i;
+  /**
+   * Leading whitespace and SQL comments to skip before looking for a keyword.
+   * The read-only validator strips comments before checking the first keyword,
+   * so the connector must skip them too; otherwise an EXPLAIN preceded by a
+   * comment passes validation but reaches the server untranslated.
+   */
+  private static readonly LEADING_NOISE = /^(?:\s+|--[^\n]*(?:\n|$)|\/\*[\s\S]*?\*\/)*/;
 
   getId(): string {
     return this.sourceId;
@@ -580,10 +586,12 @@ export class SQLServerConnector implements Connector {
     // SQL Server has no native EXPLAIN statement. Translate a leading `EXPLAIN`
     // into a SHOWPLAN_XML request so callers get a Postgres/MySQL-like
     // experience. SHOWPLAN_XML compiles the statement without executing it, so
-    // this is always read-only safe.
-    const explainMatch = sqlQuery.match(SQLServerConnector.EXPLAIN_PREFIX);
-    if (explainMatch) {
-      return this.explainQuery(sqlQuery.slice(explainMatch[0].length));
+    // this is read-only safe (further enforced in explainQuery).
+    const afterNoise = sqlQuery.slice(
+      sqlQuery.match(SQLServerConnector.LEADING_NOISE)![0].length
+    );
+    if (/^explain\b/i.test(afterNoise)) {
+      return this.explainQuery(afterNoise.slice("explain".length).trim());
     }
 
     try {
@@ -658,6 +666,18 @@ export class SQLServerConnector implements Connector {
    * with SHOWPLAN enabled (which would return a plan instead of its results).
    */
   private async explainQuery(innerQuery: string): Promise<SQLResult> {
+    if (!innerQuery) {
+      throw new Error("EXPLAIN requires a statement to analyze");
+    }
+
+    // Defense in depth: the SET SHOWPLAN session toggle is what makes EXPLAIN
+    // non-executing, so the explained statement must not disable it. SQL Server
+    // already rejects `SET SHOWPLAN_* OFF` alongside other statements in a
+    // batch, but enforcing it here keeps the read-only guarantee self-contained.
+    if (/\bset\s+showplan/i.test(stripCommentsAndStrings(innerQuery, "sqlserver"))) {
+      throw new Error("EXPLAIN does not support SET SHOWPLAN statements");
+    }
+
     if (!this.config) {
       throw new Error("Not connected to SQL Server database");
     }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -171,6 +171,9 @@ export class SQLServerConnector implements Connector {
   // Source ID is set by ConnectorManager after cloning
   private sourceId: string = "default";
 
+  /** Leading `EXPLAIN ` keyword, translated to a SHOWPLAN_XML request. */
+  private static readonly EXPLAIN_PREFIX = /^\s*explain\s+/i;
+
   getId(): string {
     return this.sourceId;
   }
@@ -574,6 +577,15 @@ export class SQLServerConnector implements Connector {
       throw new Error("Not connected to SQL Server database");
     }
 
+    // SQL Server has no native EXPLAIN statement. Translate a leading `EXPLAIN`
+    // into a SHOWPLAN_XML request so callers get a Postgres/MySQL-like
+    // experience. SHOWPLAN_XML compiles the statement without executing it, so
+    // this is always read-only safe.
+    const explainMatch = sqlQuery.match(SQLServerConnector.EXPLAIN_PREFIX);
+    if (explainMatch) {
+      return this.explainQuery(sqlQuery.slice(explainMatch[0].length));
+    }
+
     try {
       // Apply maxRows limit to SELECT queries if specified
       let processedSQL = sqlQuery;
@@ -628,6 +640,50 @@ export class SQLServerConnector implements Connector {
       };
     } catch (error) {
       throw new Error(`Failed to execute query: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Return the estimated execution plan for a query using SHOWPLAN_XML.
+   *
+   * SHOWPLAN_XML compiles the statement and returns its plan without executing
+   * it, but it has two constraints: `SET SHOWPLAN_XML ON` must be the only
+   * statement in its batch, and the setting is session scoped. The shared pool
+   * hands out a fresh connection per request() and an open transaction
+   * suppresses SHOWPLAN, so neither can carry the setting to a follow-up query.
+   *
+   * We therefore run the SET / query pair on a short-lived, single-connection
+   * pool built from the same config. The dedicated session keeps SHOWPLAN state
+   * off the shared pool, so a concurrent query can never land on a connection
+   * with SHOWPLAN enabled (which would return a plan instead of its results).
+   */
+  private async explainQuery(innerQuery: string): Promise<SQLResult> {
+    if (!this.config) {
+      throw new Error("Not connected to SQL Server database");
+    }
+
+    const explainPool = new sql.ConnectionPool({
+      ...this.config,
+      pool: { ...this.config.pool, max: 1, min: 1 },
+    });
+
+    try {
+      await explainPool.connect();
+      // max:1 + sequential awaits guarantee both batches hit the same session.
+      await explainPool.request().batch("SET SHOWPLAN_XML ON");
+      const planResult = await explainPool.request().batch(innerQuery);
+
+      // The plan is returned as the single column of the first row.
+      const planRow = planResult.recordset?.[0];
+      const planXml = planRow ? Object.values(planRow)[0] : null;
+      return {
+        rows: planXml != null ? [{ plan: planXml }] : [],
+        rowCount: planXml != null ? 1 : 0,
+      };
+    } catch (error) {
+      throw new Error(`Failed to explain query: ${(error as Error).message}`);
+    } finally {
+      await explainPool.close();
     }
   }
 }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -666,7 +666,10 @@ export class SQLServerConnector implements Connector {
    * with SHOWPLAN enabled (which would return a plan instead of its results).
    */
   private async explainQuery(innerQuery: string): Promise<SQLResult> {
-    if (!innerQuery) {
+    // Validate against comment/string-stripped SQL so comment-only input counts
+    // as empty and a SET SHOWPLAN can't hide behind comments.
+    const cleaned = stripCommentsAndStrings(innerQuery, "sqlserver").trim();
+    if (!cleaned) {
       throw new Error("EXPLAIN requires a statement to analyze");
     }
 
@@ -674,7 +677,7 @@ export class SQLServerConnector implements Connector {
     // non-executing, so the explained statement must not disable it. SQL Server
     // already rejects `SET SHOWPLAN_* OFF` alongside other statements in a
     // batch, but enforcing it here keeps the read-only guarantee self-contained.
-    if (/\bset\s+showplan/i.test(stripCommentsAndStrings(innerQuery, "sqlserver"))) {
+    if (/\bset\s+showplan/i.test(cleaned)) {
       throw new Error("EXPLAIN does not support SET SHOWPLAN statements");
     }
 

--- a/src/tools/__tests__/search-objects.test.ts
+++ b/src/tools/__tests__/search-objects.test.ts
@@ -1106,4 +1106,88 @@ describe('search_database_objects tool', () => {
       expect(asteriskParsed.data.results.map((r: any) => r.name)).toEqual(['user*data']);
     });
   });
+
+  describe('default schema scoping', () => {
+    // Simulates a MySQL/MariaDB connector whose getSchemas() lists every
+    // database on the server, but getDefaultSchema() reports the DSN-configured
+    // database. Searches without an explicit schema must stay within the default.
+    beforeEach(() => {
+      mockConnector = createMockConnector('mysql');
+      (mockConnector as any).getDefaultSchema = vi.fn();
+      mockGetCurrentConnector.mockReturnValue(mockConnector);
+      vi.mocked(mockConnector.getSchemas).mockResolvedValue([
+        'configured_db',
+        'other_db',
+        'third_db',
+      ]);
+      vi.mocked(mockConnector.getTables).mockImplementation(async (schema?: string) => {
+        if (schema === 'configured_db') return ['orders'];
+        if (schema === 'other_db') return ['secrets'];
+        return ['misc'];
+      });
+    });
+
+    it('scopes table search to the default schema and never fans out to other databases', async () => {
+      vi.mocked((mockConnector as any).getDefaultSchema).mockResolvedValue('configured_db');
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        { object_type: 'table', pattern: '%', detail_level: 'names' },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results.map((r: any) => r.schema)).toEqual(['configured_db']);
+      expect(parsed.data.results.map((r: any) => r.name)).toEqual(['orders']);
+      // Only the configured database should have been inspected.
+      expect(mockConnector.getTables).toHaveBeenCalledTimes(1);
+      expect(mockConnector.getTables).toHaveBeenCalledWith('configured_db');
+    });
+
+    it('scopes schema listing to the default schema', async () => {
+      vi.mocked((mockConnector as any).getDefaultSchema).mockResolvedValue('configured_db');
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        { object_type: 'schema', pattern: '%', detail_level: 'names' },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results.map((r: any) => r.name)).toEqual(['configured_db']);
+    });
+
+    it('falls back to the full schema list when no default is configured (null)', async () => {
+      vi.mocked((mockConnector as any).getDefaultSchema).mockResolvedValue(null);
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        { object_type: 'table', pattern: '%', detail_level: 'names' },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results.map((r: any) => r.schema)).toEqual([
+        'configured_db',
+        'other_db',
+        'third_db',
+      ]);
+    });
+
+    it('honors an explicit schema filter targeting a non-default database', async () => {
+      vi.mocked((mockConnector as any).getDefaultSchema).mockResolvedValue('configured_db');
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        { object_type: 'table', pattern: '%', schema: 'other_db', detail_level: 'names' },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results.map((r: any) => r.schema)).toEqual(['other_db']);
+      expect(parsed.data.results.map((r: any) => r.name)).toEqual(['secrets']);
+      // getDefaultSchema must not override an explicit caller-provided schema.
+      expect((mockConnector as any).getDefaultSchema).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/tools/search-objects.ts
+++ b/src/tools/search-objects.ts
@@ -67,6 +67,26 @@ function likePatternToRegex(pattern: string): RegExp {
 }
 
 /**
+ * Resolve the set of schemas a search should scope to when the caller did not
+ * pass an explicit `schema` filter.
+ *
+ * Prefers the connector's default schema (e.g. the database named in a
+ * MySQL/MariaDB DSN) so searches don't leak across every database on the
+ * server. When the connector reports no default (null) — or doesn't implement
+ * getDefaultSchema at all — it falls back to the full getSchemas() list, which
+ * for PostgreSQL/SQL Server/SQLite is already scoped to the connected database.
+ */
+async function resolveDefaultSchemas(connector: Connector): Promise<string[]> {
+  if (connector.getDefaultSchema) {
+    const defaultSchema = await connector.getDefaultSchema();
+    if (defaultSchema) {
+      return [defaultSchema];
+    }
+  }
+  return connector.getSchemas();
+}
+
+/**
  * Get row count estimate for a table.
  * Prefers the connector's native statistics-based method (e.g. pg_class.reltuples)
  * when available, falling back to COUNT(*) for connectors that don't implement it.
@@ -123,7 +143,7 @@ async function searchSchemas(
   detailLevel: DetailLevel,
   limit: number
 ): Promise<any[]> {
-  const schemas = await connector.getSchemas();
+  const schemas = await resolveDefaultSchemas(connector);
   const regex = likePatternToRegex(pattern);
   const matched = schemas.filter((schema: string) => regex.test(schema)).slice(0, limit);
 
@@ -170,7 +190,7 @@ async function searchTables(
   if (schemaFilter) {
     schemasToSearch = [schemaFilter];
   } else {
-    schemasToSearch = await connector.getSchemas();
+    schemasToSearch = await resolveDefaultSchemas(connector);
   }
 
   // Search tables in each schema
@@ -276,7 +296,7 @@ async function searchColumns(
   if (schemaFilter) {
     schemasToSearch = [schemaFilter];
   } else {
-    schemasToSearch = await connector.getSchemas();
+    schemasToSearch = await resolveDefaultSchemas(connector);
   }
 
   // Search columns in tables across schemas
@@ -358,7 +378,7 @@ async function searchProcedures(
   if (schemaFilter) {
     schemasToSearch = [schemaFilter];
   } else {
-    schemasToSearch = await connector.getSchemas();
+    schemasToSearch = await resolveDefaultSchemas(connector);
   }
 
   // Search procedures/functions in each schema
@@ -427,7 +447,7 @@ async function searchIndexes(
   if (schemaFilter) {
     schemasToSearch = [schemaFilter];
   } else {
-    schemasToSearch = await connector.getSchemas();
+    schemasToSearch = await resolveDefaultSchemas(connector);
   }
 
   // Search indexes in tables across schemas

--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -220,6 +220,20 @@ describe("isReadOnlySQL", () => {
     });
   });
 
+  describe("SQL Server keywords", () => {
+    it("should allow EXPLAIN (translated to SHOWPLAN_XML by the connector)", () => {
+      expect(isReadOnlySQL("EXPLAIN SELECT * FROM users", "sqlserver")).toBe(true);
+    });
+
+    it("should reject SHOWPLAN (not a real T-SQL statement)", () => {
+      expect(isReadOnlySQL("SHOWPLAN SELECT * FROM users", "sqlserver")).toBe(false);
+    });
+
+    it("should reject bare SET SHOWPLAN_XML (session-scoped, handled via EXPLAIN)", () => {
+      expect(isReadOnlySQL("SET SHOWPLAN_XML ON", "sqlserver")).toBe(false);
+    });
+  });
+
   describe("edge cases", () => {
     it("should treat empty SQL after comment stripping as not read-only", () => {
       expect(isReadOnlySQL("-- just a comment", "postgres")).toBe(false);

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -11,7 +11,9 @@ export const allowedKeywords: Record<ConnectorType, string[]> = {
   mysql: ["select", "with", "explain", "show", "describe", "desc"],
   mariadb: ["select", "with", "explain", "show", "describe", "desc"],
   sqlite: ["select", "with", "explain", "pragma"],
-  sqlserver: ["select", "with", "explain", "showplan"],
+  // SQL Server has no native EXPLAIN statement; the connector translates a
+  // leading `EXPLAIN` into a SET SHOWPLAN_XML request (see SQLServerConnector).
+  sqlserver: ["select", "with", "explain"],
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes #323. `search_objects` without an explicit `schema` leaked tables/views/columns/procedures/indexes from **every database on the MySQL/MariaDB server**, and `object_type="schema"` listed the whole instance. MCP clients can't see the DSN, so the AI had no way to know it was straying outside the configured database.

Root cause: when no `schema` is given, the tool layer fans out over `connector.getSchemas()`, which on MySQL/MariaDB queries `INFORMATION_SCHEMA.SCHEMATA` — all databases on the server. (PostgreSQL/SQL Server/SQLite are unaffected; their `getSchemas()` is already scoped to the connected database.)

## Approach

The right semantics: **default scope = the database the user configured; explicit `schema` is the escape hatch for deliberate cross-database access.**

- New optional `Connector.getDefaultSchema()` — returns the schema a search should default to, or `null` to mean "use the full `getSchemas()` list." Keeps the tool layer engine-agnostic.
- MySQL/MariaDB implement it via `DATABASE()` — the DSN database, or `null` when the DSN specifies no database (a genuine server-wide connection, where listing all databases is the *correct* behavior, not a leak).
- Tool layer resolves scope as: **explicit `schema` → connector default → full `getSchemas()`**, applied across all five searches (schemas, tables, columns, procedures, indexes).
- Explicit-schema **validation** still uses the full `getSchemas()` list, so targeting another database deliberately keeps working.
- `getSchemas()` on MySQL/MariaDB now excludes system databases (`information_schema`, `performance_schema`, `mysql`, `sys`), matching the PostgreSQL connector which already hides `pg_catalog` et al.

### Behavior

| Config | Default scope when no `schema` given |
|--------|--------------------------------------|
| MySQL/MariaDB, db in DSN | just that database *(leak fixed)* |
| MySQL/MariaDB, no db in DSN | all user databases, system DBs hidden |
| PostgreSQL / SQL Server / SQLite | all schemas in connected db *(unchanged)* |
| explicit `schema=otherdb` | that database *(cross-db preserved)* |

## Behavior change to note

On MySQL/MariaDB, `search_objects(object_type="schema")` no longer lists every database on the server (and hides system DBs). This is the intended outcome of the issue, but it's user-visible if anyone relied on it as a "list all databases" feature — the escape hatch is an explicit `schema=`.

## Testing

- 4 new unit tests in `search-objects.test.ts` (scoping, schema listing, null fallback, explicit-schema bypass) — 39/39 pass.
- 2 new integration tests each for MySQL and MariaDB (system-schema exclusion, default-schema reporting) against real Testcontainers — 66/66 pass. Updated the `expectedSchemas` fixtures that previously asserted the leaky behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)