### PR TITLE
add ypipe MCP integration blueprints for DBHub database servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ Connect to multiple databases simultaneously using TOML configuration files. Per
 
 See [Multi-Database Configuration](https://dbhub.ai/config/toml) for complete setup instructions.
 
+### Quick Install with ypipe
+
+Install and run **ypipe** with a single command using JBang:
+```bash
+jbang ypipe@iunera/ypipe
+```
+Or download the desktop app from [ypipe.com](https://ypipe.com). Once opened, simply import any of the pre-configured database blueprints to install and register the MCP server with one click:
+* **SQLite (Demo):** [sqlite-demo.ypipe](./sqlite-demo.ypipe)
+* **SQLite:** [sqlite.ypipe](./sqlite.ypipe)
+* **PostgreSQL:** [postgres.ypipe](./postgres.ypipe)
+* **MySQL:** [mysql.ypipe](./mysql.ypipe)
+* **MariaDB:** [mariadb.ypipe](./mariadb.ypipe)
+* **SQL Server:** [sqlserver.ypipe](./sqlserver.ypipe)
+
 ## Development
 
 Requires Node.js >= 22.5.0 (DBHub uses the built-in `node:sqlite` module).

--- a/mariadb.ypipe
+++ b/mariadb.ypipe
@@ -1,0 +1,132 @@
+---
+apiVersion: "mcp.ypipe.com/v1"
+kind: "McpIntegrationBlueprint"
+metadata:
+  name: "mariadb"
+  namespace: "system"
+spec:
+  displayName: "MariaDB"
+  description: "High-performance MariaDB database access via DBHub. Requires the 'mariadb'\
+    \ driver package."
+  source: "https://github.com/bytebase/dbhub"
+  configurationSchema:
+    DB_HOST:
+      type: "string"
+      required: true
+      default: "localhost"
+      description: "MariaDB server hostname"
+      sensitive: null
+      pattern: null
+    DB_PORT:
+      type: "string"
+      required: true
+      default: "3306"
+      description: "MariaDB server port"
+      sensitive: null
+      pattern: null
+    DB_USER:
+      type: "string"
+      required: true
+      default: null
+      description: "MariaDB username"
+      sensitive: null
+      pattern: null
+    DB_PASSWORD:
+      type: "string"
+      required: true
+      default: null
+      description: "MariaDB password"
+      sensitive: true
+      pattern: null
+    DB_NAME:
+      type: "string"
+      required: true
+      default: null
+      description: "MariaDB database name"
+      sensitive: null
+      pattern: null
+  mcpConfig:
+    type: "stdio"
+    command: "npx"
+    args:
+    - "-y"
+    - "@bytebase/dbhub@latest"
+    - "--transport"
+    - "stdio"
+    env:
+      DB_TYPE: "mariadb"
+      DB_HOST: "${DB_HOST}"
+      DB_PORT: "${DB_PORT}"
+      DB_USER: "${DB_USER}"
+      DB_PASSWORD: "${DB_PASSWORD}"
+      DB_NAME: "${DB_NAME}"
+    url: null
+    headers: null
+  disabledTools: null
+  suggestions: []
+  tools:
+    execute_sql:
+      description: "Execute MariaDB SQL queries with transaction support and safety\
+        \ controls."
+      usageIntent: null
+      discoveryHint: "Execute high-performance MariaDB queries against your server\
+        \ instance to perform critical analytical operations, data manipulation, and\
+        \ schema management. MariaDB is a prominent community-developed fork of MySQL,\
+        \ known for its enhanced performance features and commitment to open-source\
+        \ values. This tool enables full data lifecycle management, allowing for the\
+        \ execution of complex SELECT statements, efficient data modification (INSERT/UPDATE/DELETE),\
+        \ and sophisticated DDL (Data Definition Language) commands using MariaDB's\
+        \ highly compatible but extended SQL dialect. It is specifically optimized\
+        \ to take advantage of MariaDB's unique storage engines and performance enhancements.\
+        \ The tool includes robust safety guardrails provided by the DBHub integration\
+        \ layer, such as strict row limiting and query execution timeouts to prevent\
+        \ runaway processes from consuming excessive server resources or crashing\
+        \ the client. It supports full transaction management, ensuring that multi-stage\
+        \ operations are handled with ACID (Atomicity, Consistency, Isolation, Durability)\
+        \ compliance, which is absolutely vital for maintaining data integrity in\
+        \ professional and high-concurrency environments. By leveraging the DBHub\
+        \ bridge, the agent can interact with MariaDB with exceptional efficiency,\
+        \ minimizing token usage while maximizing the depth and quality of extracted\
+        \ data. Synonyms include running MariaDB queries, executing relational SQL,\
+        \ database manipulation, and data fetching. Common use cases include performing\
+        \ real-time analytics on complex datasets, managing transactional records\
+        \ in a multi-user application, and performing rapid schema exploration for\
+        \ data engineering tasks. Keywords: MariaDB, relational database, MySQL fork,\
+        \ transaction support, query execution, data analysis, SQL dialect, database\
+        \ administration, relational mapping, ACID compliance, data engineering, performance\
+        \ optimization."
+      properties: null
+      required: null
+    search_objects:
+      description: "Search and explore MariaDB databases, tables, columns, indexes,\
+        \ and procedures."
+      usageIntent: null
+      discoveryHint: "Systematically search and explore MariaDB structural components,\
+        \ providing a comprehensive and detailed overview of databases, tables, columns,\
+        \ and indexes. This tool is a critical reconnaissance utility that allows\
+        \ the AI to discover and accurately map the internal organizational structure\
+        \ of a MariaDB environment without any prior knowledge of the underlying schema.\
+        \ It utilizes a progressive disclosure methodology, enabling the agent to\
+        \ efficiently navigate from a high-level list of available databases down\
+        \ to the granular details of individual table structures, data types, primary\
+        \ and foreign keys, and complex index configurations. This structural awareness\
+        \ is an absolute requirement for writing syntactically correct SQL and for\
+        \ performing accurate data analysis where precise table and column identifiers\
+        \ are paramount for success. By identifying the exact shape and relationships\
+        \ of the data, the agent can formulate highly targeted and computationally\
+        \ efficient queries. The tool provides a clean, role-based view of the database\
+        \ metadata, filtering out internal system schemas to focus exclusively on\
+        \ user-defined content that is directly relevant to the current task. It is\
+        \ particularly valuable for identifying key business entities, finding join\
+        \ keys for relational analysis, and auditing the database for consistency\
+        \ and compliance with naming standards. Synonyms include schema discovery,\
+        \ database exploration, metadata inspection, structural mapping, and object\
+        \ searching. Common use cases include performing initial discovery on a new\
+        \ MariaDB cluster, verifying the existence of specific tables after an ETL\
+        \ process, and mapping out complex relationships in a data warehouse. Keywords:\
+        \ MariaDB schema, table discovery, metadata management, column mapping, index\
+        \ search, database reconnaissance, structural inspection, relational mapping,\
+        \ schema audit, database inventory."
+      properties: null
+      required: null
+  modelSemantics: null

--- a/mysql.ypipe
+++ b/mysql.ypipe
@@ -1,0 +1,142 @@
+---
+apiVersion: "mcp.ypipe.com/v1"
+kind: "McpIntegrationBlueprint"
+metadata:
+  name: "mysql"
+  namespace: "system"
+spec:
+  displayName: "MySQL"
+  description: "High-performance MySQL database access via DBHub. Requires the 'mysql2'\
+    \ driver package."
+  source: "https://github.com/bytebase/dbhub"
+  configurationSchema:
+    DB_HOST:
+      type: "string"
+      required: true
+      default: "localhost"
+      description: "MySQL server hostname"
+      sensitive: null
+      pattern: null
+    DB_PORT:
+      type: "string"
+      required: true
+      default: "3306"
+      description: "MySQL server port"
+      sensitive: null
+      pattern: null
+    DB_USER:
+      type: "string"
+      required: true
+      default: null
+      description: "MySQL username"
+      sensitive: null
+      pattern: null
+    DB_PASSWORD:
+      type: "string"
+      required: true
+      default: null
+      description: "MySQL password"
+      sensitive: true
+      pattern: null
+    DB_NAME:
+      type: "string"
+      required: true
+      default: null
+      description: "MySQL database name"
+      sensitive: null
+      pattern: null
+  mcpConfig:
+    type: "stdio"
+    command: "npx"
+    args:
+    - "-y"
+    - "@bytebase/dbhub@latest"
+    - "--transport"
+    - "stdio"
+    env:
+      DB_TYPE: "mysql"
+      DB_HOST: "${DB_HOST}"
+      DB_PORT: "${DB_PORT}"
+      DB_USER: "${DB_USER}"
+      DB_PASSWORD: "${DB_PASSWORD}"
+      DB_NAME: "${DB_NAME}"
+    url: null
+    headers: null
+  disabledTools: null
+  suggestions:
+  - id: "mysql-mysql-show-databases"
+    title: "MySQL: Show Databases"
+    label: "List all databases"
+    action: "Connect to MySQL and list all databases I have access to."
+    actionType: null
+    target: null
+  - id: "mysql-mysql-table-structure"
+    title: "MySQL: Table Structure"
+    label: "Describe a specific table"
+    action: "Connect to my MySQL database and show me the structure of the 'users'\
+      \ table."
+    actionType: null
+    target: null
+  tools:
+    execute_sql:
+      description: "Execute MySQL SQL queries with transaction support and safety\
+        \ controls."
+      usageIntent: null
+      discoveryHint: "Execute high-performance MySQL queries against your server instance\
+        \ to perform critical analytical operations, data manipulation, and schema\
+        \ management. MySQL is globally recognized as one of the most popular open-source\
+        \ relational databases, serving as the foundational storage layer for countless\
+        \ web applications and enterprise systems. This tool enables full data lifecycle\
+        \ management, allowing for the execution of complex SELECT statements, efficient\
+        \ INSERT/UPDATE/DELETE operations, and sophisticated DDL commands using MySQL's\
+        \ proven SQL dialect. It is specifically designed to leverage MySQL-specific\
+        \ optimizations and features, such as specialized join algorithms and storage\
+        \ engine-specific behaviors (like InnoDB transactions). The tool includes\
+        \ robust safety guardrails provided by the DBHub layer, including strict row\
+        \ limiting and query timeouts to prevent runaway processes from impacting\
+        \ server health or exceeding client memory limits. It supports full transaction\
+        \ management, ensuring that multi-step operations are handled with ACID (Atomicity,\
+        \ Consistency, Isolation, Durability) compliance. This is essential for maintaining\
+        \ data integrity in high-concurrency environments. By using the DBHub bridge,\
+        \ the agent can interact with MySQL with high efficiency, minimizing token\
+        \ usage while maximizing the quality of data extraction. Synonyms include\
+        \ running MySQL queries, executing relational SQL, database manipulation,\
+        \ and data fetching. Common use cases include performing real-time analytics\
+        \ on user behavioral data, updating inventory records in an e-commerce platform,\
+        \ and managing schema migrations for evolving applications. Keywords: MySQL,\
+        \ relational database, InnoDB, web storage, transaction support, query execution,\
+        \ data analysis, SQL dialect, database administration, relational mapping,\
+        \ ACID compliance, data engineering."
+      properties: null
+      required: null
+    search_objects:
+      description: "Search and explore MySQL databases, tables, columns, indexes,\
+        \ and procedures."
+      usageIntent: null
+      discoveryHint: "Systematically search and explore MySQL structural components,\
+        \ providing a comprehensive overview of databases, tables, columns, and indexes.\
+        \ This tool is a critical reconnaissance utility that allows the AI to discover\
+        \ and map the internal organizational structure of a MySQL environment without\
+        \ any prior knowledge of the schema. It utilizes a progressive disclosure\
+        \ methodology, enabling the agent to efficiently navigate from a list of available\
+        \ databases down to the granular details of individual table schemas, data\
+        \ types, primary keys, and index configurations. This structural awareness\
+        \ is an absolute requirement for writing syntactically correct SQL and for\
+        \ performing accurate data analysis where precise table and column names are\
+        \ paramount. By identifying the exact shape of the data, the agent can formulate\
+        \ highly targeted and performant queries. The tool provides a clean, role-based\
+        \ view of the database metadata, filtering out internal system schemas (like\
+        \ information_schema) to focus on user-defined content that is directly relevant\
+        \ to the current task. It is particularly valuable for identifying key entities\
+        \ in a large database, finding join keys for relational analysis, and auditing\
+        \ the database for consistency and naming convention compliance. Synonyms\
+        \ include schema discovery, database exploration, metadata inspection, structural\
+        \ mapping, and object searching. Common use cases include performing initial\
+        \ discovery on a legacy database, verifying the existence of specific tables\
+        \ after an ingestion process, and mapping out relationships between raw data\
+        \ and summarized views. Keywords: MySQL schema, table discovery, metadata\
+        \ management, column mapping, index search, database reconnaissance, structural\
+        \ inspection, relational mapping, schema audit, database inventory."
+      properties: null
+      required: null
+  modelSemantics: null

--- a/postgres.ypipe
+++ b/postgres.ypipe
@@ -1,0 +1,147 @@
+---
+apiVersion: "mcp.ypipe.com/v1"
+kind: "McpIntegrationBlueprint"
+metadata:
+  name: "postgres"
+  namespace: "system"
+spec:
+  displayName: "PostgreSQL"
+  description: "High-performance PostgreSQL database access via DBHub. Requires the\
+    \ 'pg' driver package."
+  source: "https://github.com/bytebase/dbhub"
+  configurationSchema:
+    DB_HOST:
+      type: "string"
+      required: true
+      default: "localhost"
+      description: "PostgreSQL server hostname"
+      sensitive: null
+      pattern: null
+    DB_PORT:
+      type: "string"
+      required: true
+      default: "5432"
+      description: "PostgreSQL server port"
+      sensitive: null
+      pattern: null
+    DB_USER:
+      type: "string"
+      required: true
+      default: null
+      description: "PostgreSQL username"
+      sensitive: null
+      pattern: null
+    DB_PASSWORD:
+      type: "string"
+      required: true
+      default: null
+      description: "PostgreSQL password"
+      sensitive: true
+      pattern: null
+    DB_NAME:
+      type: "string"
+      required: true
+      default: null
+      description: "PostgreSQL database name"
+      sensitive: null
+      pattern: null
+  mcpConfig:
+    type: "stdio"
+    command: "npx"
+    args:
+    - "-y"
+    - "@bytebase/dbhub@latest"
+    - "--transport"
+    - "stdio"
+    env:
+      DB_TYPE: "postgres"
+      DB_HOST: "${DB_HOST}"
+      DB_PORT: "${DB_PORT}"
+      DB_USER: "${DB_USER}"
+      DB_PASSWORD: "${DB_PASSWORD}"
+      DB_NAME: "${DB_NAME}"
+    url: null
+    headers: null
+  disabledTools: null
+  suggestions:
+  - id: "postgres-postgres-table-list"
+    title: "Postgres: Table List"
+    label: "List all tables in the database"
+    action: "Connect to my Postgres database and list all available tables."
+    actionType: null
+    target: null
+  - id: "postgres-postgres-sample-data"
+    title: "Postgres: Sample Data"
+    label: "Show first 10 rows of a table"
+    action: "Select the first 10 rows from the most important table in my Postgres\
+      \ database."
+    actionType: null
+    target: null
+  tools:
+    execute_sql:
+      description: "Execute PostgreSQL SQL queries with transaction support and safety\
+        \ controls."
+      usageIntent: null
+      discoveryHint: "Execute high-performance PostgreSQL queries against your database\
+        \ cluster to perform analytical operations, data manipulation, and schema\
+        \ management. PostgreSQL is a powerful, open-source object-relational database\
+        \ system known for its reliability, feature robustness, and performance. This\
+        \ tool allows for complex analytical operations using PostgreSQL-specific\
+        \ syntax and features like JSONB support for semi-structured data, advanced\
+        \ window functions for time-series analysis, and rich data types including\
+        \ geometric and network address types. It is the primary interface for professional\
+        \ database interaction, supporting both DDL (Data Definition Language) for\
+        \ creating tables and DML (Data Manipulation Language) for inserting or updating\
+        \ records. It includes built-in safety controls like row limiting (enforced\
+        \ by DBHub) and query timeouts to prevent runaway operations and ensure system\
+        \ stability even under heavy load. The tool supports transaction management,\
+        \ allowing for atomic operations where multiple steps succeed or fail as a\
+        \ single unit, which is critical for maintaining data integrity in production\
+        \ environments. By leveraging the DBHub engine, the agent can efficiently\
+        \ retrieve results and handle large result sets with minimal token overhead.\
+        \ This is essential for a wide variety of tasks, including real-time research,\
+        \ competitive analysis, data scraping, and automated UI testing. Synonyms\
+        \ include running SQL, executing PGSQL queries, database manipulation, and\
+        \ data fetching. Common use cases involve calculating complex aggregations\
+        \ over billions of rows, filtering events by highly granular time ranges,\
+        \ and performing multi-dimensional grouping on both streaming and batch-ingested\
+        \ data. The tool correctly handles standard protocols and ensures compatibility\
+        \ with modern PostgreSQL features. Keywords: PostgreSQL, PGSQL, object-relational,\
+        \ transaction support, query execution, data analysis, JSONB, window functions,\
+        \ ACID compliance, database administration, SQL optimization, data engineering,\
+        \ relational mapping."
+      properties: null
+      required: null
+    search_objects:
+      description: "Search and explore PostgreSQL schemas, tables, columns, indexes,\
+        \ and procedures."
+      usageIntent: null
+      discoveryHint: "Systematically search and explore PostgreSQL structural components\
+        \ across all schemas, including the default public schema and any custom organizational\
+        \ namespaces. This tool provides a powerful mechanism for database reconnaissance\
+        \ and discovery, allowing the AI to understand the internal organizational\
+        \ structure and metadata of a database without prior knowledge of its schema.\
+        \ It utilizes a progressive disclosure approach, enabling the agent to drill\
+        \ down from high-level schema overviews to granular table definitions, column\
+        \ types, primary and foreign keys, indexes, and stored procedures. This is\
+        \ an absolute requirement for any task involving database exploration, schema\
+        \ mapping, or preparing for complex SQL generation where accurate table and\
+        \ column names are paramount. By identifying the exact names and types of\
+        \ database objects, the agent ensures that subsequent queries are syntactically\
+        \ correct and computationally efficient. The tool provides a structural overview\
+        \ of the page as perceived by database administrators, filtering out internal\
+        \ system catalogs to focus exclusively on user-defined content that is meaningful\
+        \ for interaction. It is particularly useful for identifying the main entities\
+        \ in a complex microservices architecture, locating primary keys for join\
+        \ operations, and finding key relationships in a deeply nested data model.\
+        \ Synonyms include schema discovery, database exploration, metadata inspection,\
+        \ structural mapping, and object searching. Common use cases include performing\
+        \ initial reconnaissance on a new PostgreSQL instance, verifying the availability\
+        \ of specific tables mentioned in documentation, and identifying which schemas\
+        \ contain the most relevant information for a given analytical task. Keywords:\
+        \ PostgreSQL schema, metadata discovery, table exploration, column mapping,\
+        \ index search, database reconnaissance, structural inspection, relational\
+        \ mapping, schema audit, database inventory."
+      properties: null
+      required: null
+  modelSemantics: null

--- a/sqlite-demo.ypipe
+++ b/sqlite-demo.ypipe
@@ -1,0 +1,96 @@
+---
+apiVersion: "mcp.ypipe.com/v1"
+kind: "McpIntegrationBlueprint"
+metadata:
+  name: "sqlite-demo"
+  namespace: "system"
+spec:
+  displayName: "SQLite (Demo)"
+  description: "Zero-dependency, token-efficient database MCP server in demo mode.\
+    \ Includes a sample 'employee' SQLite database for rapid testing and experimentation."
+  source: "https://github.com/bytebase/dbhub"
+  configurationSchema: {}
+  mcpConfig:
+    type: "stdio"
+    command: "npx"
+    args:
+    - "-y"
+    - "-p"
+    - "@bytebase/dbhub@latest"
+    - "-p"
+    - "better-sqlite3"
+    - "dbhub"
+    - "--transport"
+    - "stdio"
+    - "--demo"
+    env: null
+    url: null
+    headers: null
+  disabledTools: null
+  suggestions:
+  - id: "sqlite-demo-sqlite-show-all-tables"
+    title: "SQLite: Show All Tables"
+    label: "List tables in the demo database"
+    action: "Show all available tables in the demo database with ${metadata.name}_search_objects"
+    actionType: null
+    target: null
+  - id: "sqlite-demo-sqlite-query-employees"
+    title: "SQLite: Query Employees"
+    label: "Show sample employee data"
+    action: "Query the first 10 rows from the 'employee' table in the  SQLite demo\
+      \ database ${metadata.name}_execute_sql"
+    actionType: null
+    target: null
+  tools:
+    execute_sql:
+      description: "Execute SQL queries with transaction support and safety controls."
+      usageIntent: null
+      discoveryHint: "Execute high-performance SQL queries against a built-in sample\
+        \ 'employee' database using the DBHub engine. This tool is specifically designed\
+        \ for testing the core capabilities of the database MCP server in a completely\
+        \ zero-risk, sandbox environment. It supports standard SQL operations, allowing\
+        \ you to experiment with data retrieval, complex grouping, and analytical\
+        \ functions on a pre-populated dataset. The sample database provides a rich\
+        \ playground for exploring SQL-based workflows, verifying query logic, and\
+        \ training AI agents in a safe, controlled environment. By running queries\
+        \ through this tool, the agent can practice data manipulation and analysis\
+        \ without the need for an external database setup. It includes safety guardrails\
+        \ like row limiting and execution timeouts to maintain system performance.\
+        \ This is an excellent way to demonstrate the power of MCP-based database\
+        \ interaction to new users or to perform quick validation of an AI's SQL-generating\
+        \ abilities. Synonyms include running SQL queries, database testing, SQL experimentation,\
+        \ sample data exploration, and sandbox querying. Common use cases include\
+        \ testing complex join logic on known data, benchmarking query performance\
+        \ for different SQL patterns, and providing interactive tutorials for SQL\
+        \ analysis. Keywords: SQL testing, SQLite, demo mode, database sandbox, query\
+        \ experimentation, sample data, DBHub, SQL simulation, developer experience,\
+        \ educational sandbox."
+      properties: null
+      required: null
+    search_objects:
+      description: "Search and explore database schemas, tables, columns, indexes,\
+        \ and procedures."
+      usageIntent: null
+      discoveryHint: "Systematically search and discover the structural components\
+        \ of the built-in sample database, including schemas, tables, columns, and\
+        \ indexes. This tool is the foundational starting point for database reconnaissance\
+        \ in the demo environment, enabling the AI to identify available tables like\
+        \ 'employees', 'departments', and 'salaries' without any prior information.\
+        \ By exploring the schema, the agent builds an accurate mental map of the\
+        \ database, which is absolutely essential for writing precise and syntactically\
+        \ correct SQL queries during testing and experimentation. It utilizes a progressive\
+        \ disclosure methodology, allowing the agent to drill down from high-level\
+        \ table lists to granular column definitions and data types. This structural\
+        \ awareness ensures that the AI can act as a truly expert data analyst within\
+        \ the demo sandbox. The tool provides a clean and focused view of the metadata,\
+        \ filtering out system overhead to highlight the data structures relevant\
+        \ for user-facing analysis. Synonyms include schema discovery, database exploration,\
+        \ metadata mapping, structural inspection, and object searching. Common use\
+        \ cases include performing initial discovery on the demo environment, teaching\
+        \ users how to map out relational data, and verifying the schema coverage\
+        \ of the sample dataset. Keywords: schema discovery, database exploration,\
+        \ sample metadata, table mapping, index search, structural audit, DBHub demo,\
+        \ reconnaissance, educational tool."
+      properties: null
+      required: null
+  modelSemantics: null

--- a/sqlite.ypipe
+++ b/sqlite.ypipe
@@ -1,0 +1,92 @@
+---
+apiVersion: "mcp.ypipe.com/v1"
+kind: "McpIntegrationBlueprint"
+metadata:
+  name: "sqlite"
+  namespace: "system"
+spec:
+  displayName: "SQLite"
+  description: "Local SQLite database access via DBHub. Requires the 'better-sqlite3'\
+    \ driver package."
+  source: "https://github.com/bytebase/dbhub"
+  configurationSchema:
+    DB_NAME:
+      type: "string"
+      required: true
+      default: null
+      description: "Path to the SQLite database file (e.g., /path/to/database.sqlite)"
+      sensitive: null
+      pattern: null
+  mcpConfig:
+    type: "stdio"
+    command: "npx"
+    args:
+    - "-y"
+    - "@bytebase/dbhub@latest"
+    - "--transport"
+    - "stdio"
+    env:
+      DB_TYPE: "sqlite"
+      DB_NAME: "${DB_NAME}"
+    url: null
+    headers: null
+  disabledTools: null
+  suggestions: []
+  tools:
+    execute_sql:
+      description: "Execute SQLite SQL queries with transaction support and safety\
+        \ controls."
+      usageIntent: null
+      discoveryHint: "Execute SQL queries against a local, file-based SQLite database\
+        \ to perform efficient data analysis, manipulation, and local storage management.\
+        \ SQLite is a lightweight, C-language library that implements a small, fast,\
+        \ self-contained, high-reliability, full-featured, SQL database engine. It\
+        \ is the most used database engine in the world, found in everything from\
+        \ mobile apps to web browsers and embedded systems. This tool allows for the\
+        \ execution of standard SQL commands, including complex joins, aggregations,\
+        \ and subqueries, directly against a local database file. It is ideal for\
+        \ local data science tasks, development workflows, and managing persistent\
+        \ state for small-scale applications. The tool includes built-in safety guardrails\
+        \ provided by the DBHub integration, such as row limiting and query execution\
+        \ timeouts to ensure that accidental long-running queries do not impact system\
+        \ performance. It supports full transaction management, allowing for atomic\
+        \ operations that maintain data consistency during multi-step updates. By\
+        \ leveraging the DBHub bridge, the agent can interact with SQLite with high\
+        \ efficiency, providing a powerful way to query local data with minimal setup.\
+        \ Synonyms include running SQLite queries, executing local SQL, file-based\
+        \ database manipulation, and local data fetching. Common use cases include\
+        \ analyzing local application logs, managing personal knowledge bases, and\
+        \ performing rapid prototyping for larger database systems. Keywords: SQLite,\
+        \ embedded database, local SQL, file-based storage, query execution, data\
+        \ analysis, SQL dialect, serverless database, data engineering, rapid prototyping."
+      properties: null
+      required: null
+    search_objects:
+      description: "Search and explore SQLite tables, columns, and indexes."
+      usageIntent: null
+      discoveryHint: "Systematically search and explore the structural components of\
+        \ a local SQLite database, providing a clear and comprehensive overview of\
+        \ tables, columns, and indexes. This tool is a vital reconnaissance utility\
+        \ that allows the AI to discover and map the internal structure of a SQLite\
+        \ file without any prior knowledge of its schema. It utilizes a progressive\
+        \ disclosure methodology, enabling the agent to navigate from a list of available\
+        \ tables down to the granular details of individual column definitions, data\
+        \ types, and index configurations. This structural awareness is an absolute\
+        \ requirement for writing syntactically correct SQL and for performing accurate\
+        \ data analysis where precise table and column names are paramount. By identifying\
+        \ the exact shape of the local data, the agent can formulate highly targeted\
+        \ and efficient queries. The tool provides a clean view of the database metadata,\
+        \ focusing exclusively on user-defined content that is directly relevant to\
+        \ the current task. It is particularly valuable for identifying key data structures\
+        \ in a local file, verifying the success of data import operations, and auditing\
+        \ the database for structural consistency. Synonyms include schema discovery,\
+        \ local database exploration, metadata inspection, structural mapping, and\
+        \ object searching. Common use cases include performing initial discovery\
+        \ on a newly received SQLite file, verifying the structure of a local development\
+        \ database, and mapping out relationships in an embedded data store. Keywords:\
+        \ SQLite schema, table discovery, metadata management, column mapping, index\
+        \ search, local database reconnaissance, structural inspection, file-based\
+        \ schema, database inventory."
+      properties: null
+      required: null
+  modelSemantics: null

--- a/sqlserver.ypipe
+++ b/sqlserver.ypipe
@@ -1,0 +1,130 @@
+---
+apiVersion: "mcp.ypipe.com/v1"
+kind: "McpIntegrationBlueprint"
+metadata:
+  name: "sqlserver"
+  namespace: "system"
+spec:
+  displayName: "SQL Server"
+  description: "High-performance Microsoft SQL Server database access via DBHub. Requires\
+    \ the 'mssql' driver package."
+  source: "https://github.com/bytebase/dbhub"
+  configurationSchema:
+    DB_HOST:
+      type: "string"
+      required: true
+      default: "localhost"
+      description: "SQL Server hostname"
+      sensitive: null
+      pattern: null
+    DB_PORT:
+      type: "string"
+      required: true
+      default: "1433"
+      description: "SQL Server port"
+      sensitive: null
+      pattern: null
+    DB_USER:
+      type: "string"
+      required: true
+      default: null
+      description: "SQL Server username"
+      sensitive: null
+      pattern: null
+    DB_PASSWORD:
+      type: "string"
+      required: true
+      default: null
+      description: "SQL Server password"
+      sensitive: true
+      pattern: null
+    DB_NAME:
+      type: "string"
+      required: true
+      default: null
+      description: "SQL Server database name"
+      sensitive: null
+      pattern: null
+  mcpConfig:
+    type: "stdio"
+    command: "npx"
+    args:
+    - "-y"
+    - "@bytebase/dbhub@latest"
+    - "--transport"
+    - "stdio"
+    env:
+      DB_TYPE: "sqlserver"
+      DB_HOST: "${DB_HOST}"
+      DB_PORT: "${DB_PORT}"
+      DB_USER: "${DB_USER}"
+      DB_PASSWORD: "${DB_PASSWORD}"
+      DB_NAME: "${DB_NAME}"
+    url: null
+    headers: null
+  disabledTools: null
+  suggestions: []
+  tools:
+    execute_sql:
+      description: "Execute MS SQL Server T-SQL queries with transaction support and\
+        \ safety controls."
+      usageIntent: null
+      discoveryHint: "Execute high-performance T-SQL queries against your Microsoft\
+        \ SQL Server instance to perform critical analytical operations, data manipulation,\
+        \ and complex schema management. Microsoft SQL Server is a comprehensive,\
+        \ enterprise-level database platform designed to handle massive workloads\
+        \ and provide robust data management for business-critical applications. This\
+        \ tool allows for the execution of advanced Transact-SQL (T-SQL) commands,\
+        \ including specialized window functions, common table expressions (CTEs),\
+        \ and complex multi-table joins. It is specifically designed to work with\
+        \ SQL Server's unique features, such as stored procedure execution and schema-qualified\
+        \ table access. The tool includes built-in safety guardrails provided by the\
+        \ DBHub layer, such as strict row limiting and query execution timeouts to\
+        \ prevent accidental resource exhaustion or long-running queries from blocking\
+        \ other database processes. It supports full transaction management, ensuring\
+        \ that complex data modifications are handled with full ACID compliance, which\
+        \ is critical for maintaining data integrity in professional enterprise environments.\
+        \ By leveraging the DBHub bridge, the agent can interact with SQL Server with\
+        \ high precision and efficiency, minimizing token overhead while ensuring\
+        \ the accuracy of data extraction. Synonyms include running T-SQL queries,\
+        \ executing MSSQL commands, database manipulation, and data fetching. Common\
+        \ use cases include generating complex business reports from multiple related\
+        \ tables, performing data cleaning and transformation tasks, and auditing\
+        \ database activity for compliance. Keywords: SQL Server, MSSQL, T-SQL, enterprise\
+        \ database, transaction support, query execution, data analysis, Transact-SQL,\
+        \ database administration, relational mapping, ACID compliance, data engineering."
+      properties: null
+      required: null
+    search_objects:
+      description: "Search and explore MS SQL Server schemas, tables, columns, indexes,\
+        \ and procedures."
+      usageIntent: null
+      discoveryHint: "Systematically search and explore Microsoft SQL Server structural\
+        \ components, providing a detailed and hierarchical overview of schemas, tables,\
+        \ views, and columns. This tool is an essential reconnaissance utility that\
+        \ allows the AI to discover and map the internal organizational structure\
+        \ of a SQL Server environment without prior knowledge of the database schema.\
+        \ It utilizes a progressive disclosure methodology, enabling the agent to\
+        \ navigate from a list of available schemas (such as 'dbo' or custom business\
+        \ schemas) down to the granular details of individual table structures, data\
+        \ types, primary and foreign keys, and index configurations. This structural\
+        \ awareness is an absolute requirement for writing syntactically correct T-SQL\
+        \ and for performing accurate data analysis where precise schema-qualified\
+        \ table and column names are paramount. By identifying the exact shape of\
+        \ the data and its relational constraints, the agent can formulate highly\
+        \ targeted and performant queries. The tool provides a clean, role-based view\
+        \ of the database metadata, filtering out internal system catalogs to focus\
+        \ on user-defined content that is directly relevant to the current analytical\
+        \ task. It is particularly valuable for identifying key entities in an enterprise\
+        \ data warehouse, finding relationship keys for complex joins, and auditing\
+        \ the database for consistency across different environments. Synonyms include\
+        \ schema discovery, database exploration, metadata inspection, structural\
+        \ mapping, and object searching. Common use cases include performing initial\
+        \ discovery on a legacy SQL Server instance, verifying table availability\
+        \ after a data migration, and mapping out relationships in a multi-schema\
+        \ database. Keywords: SQL Server schema, T-SQL metadata, table discovery,\
+        \ column mapping, index search, database reconnaissance, structural inspection,\
+        \ relational mapping, schema audit, database inventory."
+      properties: null
+      required: null
+  modelSemantics: null


### PR DESCRIPTION
First of all, a huge thank you to the Bytebase team for your fantastic work on DBHub! Having a zero-dependency, token-efficient MCP server that supports multiple SQL databases out-of-the-box is incredibly powerful and well-engineered.

This Pull Request introduces a set of **ypipe** MCP integration blueprint configurations for DBHub-powered database servers, covering MySQL, PostgreSQL, MariaDB, SQL Server, and SQLite.

### What is ypipe?
[ypipe](https://github.com/iunera/ypipe) is an AI agent orchestration and workflow automation platform. It supports declarative, one-click installations of MCP servers via Kubernetes-conforming YAML files called **MCP Integration Blueprints**.

### How it works
These blueprints define schema templates for database connections powered by `@bytebase/dbhub`:
* **`sqlite-demo.ypipe`:** Boots a zero-dependency demo environment loaded with a sample `employee` database for testing.
* **`sqlite.ypipe`, `mysql.ypipe`, `postgres.ypipe`, `mariadb.ypipe`, `sqlserver.ypipe`:** Declaratively ask users for host, port, user credentials, and database name configurations. These sensitive variables are dynamically resolved via environments during runtime.

Adding these blueprints allows users to bind standard relational databases to their AI agents running in ypipe with a unified, template-driven experience. We love your work on DBHub!

<img width="1578" height="1175" alt="Bildschirmfoto 2026-06-17 um 10 25 15" src="https://github.com/user-attachments/assets/a92cb2ff-2c15-4a91-9b31-627151cdbb03" />
