### PR TITLE
perf: trim redundant prose from built-in tool schemas

### DIFF
--- a/src/tools/search-objects.ts
+++ b/src/tools/search-objects.ts
@@ -30,7 +30,7 @@ export const searchDatabaseObjectsSchema = {
     .string()
     .optional()
     .default("%")
-    .describe("LIKE pattern (% = any chars, _ = one char). Default: %"),
+    .describe("LIKE pattern (% = any chars, _ = one char)"),
   schema: z
     .string()
     .optional()
@@ -49,7 +49,7 @@ export const searchDatabaseObjectsSchema = {
     .positive()
     .max(1000)
     .default(100)
-    .describe("Max results (default: 100, max: 1000)"),
+    .describe("Max results"),
 };
 
 /**

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -246,13 +246,13 @@ function buildSearchObjectsTool(sourceId: string): Tool {
         name: "object_type",
         type: "string",
         required: true,
-        description: "Object type to search",
+        description: "Object type to search: schema, table, view, column, procedure, function, index",
       },
       {
         name: "pattern",
         type: "string",
         required: false,
-        description: "LIKE pattern (% = any chars, _ = one char)",
+        description: "LIKE pattern (% = any chars, _ = one char). Default: %",
       },
       {
         name: "schema",
@@ -276,7 +276,7 @@ function buildSearchObjectsTool(sourceId: string): Tool {
         name: "limit",
         type: "integer",
         required: false,
-        description: "Max results",
+        description: "Max results (default: 100, max: 1000)",
       },
     ],
     readonly: true, // search_objects is always readonly

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -183,8 +183,8 @@ export function getSearchObjectsMetadata(sourceId: string): { name: string; desc
   // so AI clients reading the MCP tool list see the source's purpose first.
   const userDescPrefix = buildSourceDescriptionPrefix(sourceConfig.description);
   const description = isSingleSource
-    ? `${userDescPrefix}Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the ${dbType} database`
-    : `${userDescPrefix}Search and list database objects (schemas, tables, columns, procedures, functions, indexes) on the '${sourceId}' ${dbType} database`;
+    ? `${userDescPrefix}Search and list database objects on the ${dbType} database`
+    : `${userDescPrefix}Search and list database objects on the '${sourceId}' ${dbType} database`;
 
   return {
     name: toolName,
@@ -252,7 +252,7 @@ function buildSearchObjectsTool(sourceId: string): Tool {
         name: "pattern",
         type: "string",
         required: false,
-        description: "LIKE pattern (% = any chars, _ = one char). Default: %",
+        description: "LIKE pattern (% = any chars, _ = one char)",
       },
       {
         name: "schema",
@@ -276,7 +276,7 @@ function buildSearchObjectsTool(sourceId: string): Tool {
         name: "limit",
         type: "integer",
         required: false,
-        description: "Max results (default: 100, max: 1000)",
+        description: "Max results",
       },
     ],
     readonly: true, // search_objects is always readonly


### PR DESCRIPTION
## Summary

In multi-source mode, `execute_sql` and `search_objects` are registered **per source** (`execute_sql_prod`, `execute_sql_staging`, …), so every byte of their description and parameter docs is replicated `O(n)` across sources in the MCP `tools/list`. This trims prose from the **MCP** schema that merely restates what the structured JSON Schema already encodes — lossless context savings on the MCP path.

Trimmed in the MCP path (`search-objects.ts` Zod schema + the shared tool description):
- `search_objects` description: the `(schemas, tables, columns, procedures, functions, indexes)` list — duplicates the `object_type` enum
- `pattern` param: `". Default: %"` — already in `.default("%")`
- `limit` param: `" (default: 100, max: 1000)"` — already in `.default(100).max(1000)`

On the MCP path the model still receives every fact via the schema's `enum`/`default`/`maximum`, so there is **no information loss there**.

### REST API / web UI (`/api/sources`)

The REST tool metadata uses `ToolParameter`, which has **no** enum/default/maximum fields — so prose is the only place that info lives. The API copies therefore keep the descriptive text (`Default: %`, `default: 100, max: 1000`), and the `object_type` param description spells out its allowed values, since the shared tool description no longer lists them. The REST API is not in the model context, so keeping it verbose costs no tokens. (Thanks @copilot for catching this.)

## Context

This came out of #266. The originally-proposed fix there was to collapse the per-source tools into a single `execute_sql(sql, source_id)` + a `list_sources` discovery tool (`O(1)` context). That collapse was rejected because it removes per-source **tool identity** in the MCP client — users would lose the ability to select/enable/permission a specific source's tool (e.g. always-deny writes to prod), since that only works while `source_id` is part of the tool name. Under MCP's flat tool list, per-source selectability and an `O(1)` tool count are mutually exclusive.

This PR is the alternative: keep per-source tools (selectability preserved), reduce the per-tool MCP token cost instead. It's the lossless floor — stays `O(n)` in count, but removes the duplicated prose from the MCP schema with no downside.

## Test plan

- [x] `pnpm test` for `search-objects`, `tool-metadata`, `execute-sql` suites — 72 passing
- [x] Verified the leading phrases (`"Execute SQL queries"`, `"Search and list database objects"`) pinned by `startsWith`/`indexOf` assertions are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
