### PR TITLE
chore: upgrade from 0.22.4 to 0.22.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dbhub/frontend",
   "private": true,
-  "version": "0.22.4",
+  "version": "0.22.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbhub",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "mcpName": "io.github.bytebase/dbhub",
   "description": "Minimal, token-efficient Database MCP Server for PostgreSQL, MySQL, SQL Server, SQLite, MariaDB",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/bytebase/dbhub",
     "source": "github"
   },
-  "version": "0.22.4",
+  "version": "0.22.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@bytebase/dbhub",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump **0.22.4 → 0.22.5**.

This release contains the HTTP-transport **DNS-rebinding fix** from #340 (Host allow-list, closing GHSA-fm8p-53ww-hf6w and two duplicates).

Merging this to `main` changes `package.json`, which triggers `npm-publish.yml` (OIDC trusted publish) to push `@bytebase/dbhub@0.22.5` to npm.

### After this merges + publishes
- Set `patched_versions = 0.22.5` on `GHSA-fm8p-53ww-hf6w` and publish it (requests a CVE, credits all three reporters).

Files: `package.json`, `frontend/package.json`, `server.json` — matches the prior bump's footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)