### PR TITLE
fix: enforce read-only mode at the database engine, not just the keyword classifier

### DIFF
--- a/src/connectors/__tests__/mariadb.integration.test.ts
+++ b/src/connectors/__tests__/mariadb.integration.test.ts
@@ -474,4 +474,51 @@ describe('MariaDB Connector Integration Tests', () => {
       expect(result.rows.length).toBeGreaterThanOrEqual(3);
     });
   });
+
+  describe('Per-tool readonly engine backstop (options.readonly)', () => {
+    // The READ ONLY transaction reliably blocks DML. (DDL like DROP performs an
+    // implicit commit and escapes the transaction; stacked-DDL payloads such as
+    // `SELECT 1--1;DROP TABLE t` are instead rejected upstream by the read-only
+    // classifier — see the unit tests in allowed-keywords.test.ts.)
+    it('should block a stacked UPDATE hidden after -- via the READ ONLY transaction', async () => {
+      const connector = new MariaDBConnector();
+      try {
+        await connector.connect(mariadbTest.connectionString);
+
+        await expect(
+          connector.executeSQL("SELECT 1--1;UPDATE users SET name='hacked'", { readonly: true })
+        ).rejects.toThrow(/read only|read-only/i);
+
+        const check = await connector.executeSQL(
+          "SELECT COUNT(*) AS c FROM users WHERE name='hacked'",
+          {}
+        );
+        expect(Number(check.rows[0].c)).toBe(0);
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should block INSERT and keep the connection writable afterward', async () => {
+      const connector = new MariaDBConnector();
+      try {
+        await connector.connect(mariadbTest.connectionString);
+
+        await expect(
+          connector.executeSQL("INSERT INTO users (name, email) VALUES ('ro', 'ro@ro.com')", {
+            readonly: true,
+          })
+        ).rejects.toThrow(/read only|read-only/i);
+
+        const insert = await connector.executeSQL(
+          "INSERT INTO users (name, email) VALUES ('rw', 'rw@rw.com')",
+          {}
+        );
+        expect(insert.rowCount).toBe(1);
+        await connector.executeSQL("DELETE FROM users WHERE email = 'rw@rw.com'", {});
+      } finally {
+        await connector.disconnect();
+      }
+    });
+  });
 });

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -459,4 +459,55 @@ describe('MySQL Connector Integration Tests', () => {
       }
     });
   });
+
+  describe('Per-tool readonly engine backstop (options.readonly)', () => {
+    // The READ ONLY transaction reliably blocks DML. (DDL like DROP performs an
+    // implicit commit and escapes the transaction; stacked-DDL payloads such as
+    // `SELECT 1--1;DROP TABLE t` are instead rejected upstream by the read-only
+    // classifier — see the unit tests in allowed-keywords.test.ts.)
+    it('should block a stacked UPDATE hidden after -- via the READ ONLY transaction', async () => {
+      const connector = new MySQLConnector();
+      try {
+        await connector.connect(mysqlTest.connectionString);
+
+        // multipleStatements is on, so MySQL sees this as SELECT then UPDATE. The
+        // READ ONLY transaction must reject the UPDATE (DML) at the engine.
+        await expect(
+          connector.executeSQL("SELECT 1--1;UPDATE users SET name='hacked'", { readonly: true })
+        ).rejects.toThrow(/read only|read-only/i);
+
+        // No row should have been renamed.
+        const check = await connector.executeSQL(
+          "SELECT COUNT(*) AS c FROM users WHERE name='hacked'",
+          {}
+        );
+        expect(Number(check.rows[0].c)).toBe(0);
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should block INSERT and keep the connection writable afterward', async () => {
+      const connector = new MySQLConnector();
+      try {
+        await connector.connect(mysqlTest.connectionString);
+
+        await expect(
+          connector.executeSQL("INSERT INTO users (name, email) VALUES ('ro', 'ro@ro.com')", {
+            readonly: true,
+          })
+        ).rejects.toThrow(/read only|read-only/i);
+
+        // Non-read-only call on the same pooled connection still works.
+        const insert = await connector.executeSQL(
+          "INSERT INTO users (name, email) VALUES ('rw', 'rw@rw.com')",
+          {}
+        );
+        expect(insert.rowCount).toBe(1);
+        await connector.executeSQL("DELETE FROM users WHERE email = 'rw@rw.com'", {});
+      } finally {
+        await connector.disconnect();
+      }
+    });
+  });
 });

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -596,6 +596,69 @@ describe('PostgreSQL Connector Integration Tests', () => {
     });
   });
 
+  describe('Per-tool readonly engine backstop (options.readonly)', () => {
+    // These mirror the realistic config: the connection is writable (no
+    // connection-level readonly), and read-only is enforced per execution by
+    // running inside a READ ONLY transaction. This catches function-based writes
+    // that the leading-keyword classifier passes (e.g. SELECT setval()).
+    it('should block a sequence write via SELECT setval() when options.readonly is set', async () => {
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(postgresTest.connectionString);
+
+        // SELECT setval(...) passes the read-only keyword classifier but writes a
+        // sequence; the READ ONLY transaction must reject it at the engine.
+        await expect(
+          connector.executeSQL(
+            "SELECT setval(pg_get_serial_sequence('users','id'), 1, true)",
+            { readonly: true }
+          )
+        ).rejects.toThrow(/read-only transaction/i);
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should block INSERT when options.readonly is set', async () => {
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(postgresTest.connectionString);
+        await expect(
+          connector.executeSQL(
+            "INSERT INTO users (name, email) VALUES ('ro', 'ro@ro.com')",
+            { readonly: true }
+          )
+        ).rejects.toThrow(/read-only transaction/i);
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should keep the connection writable for non-read-only calls', async () => {
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(postgresTest.connectionString);
+
+        // A read-only call (rolled back) must not leave the session read-only.
+        await expect(
+          connector.executeSQL("INSERT INTO users (name, email) VALUES ('x', 'x@x.com')", {
+            readonly: true,
+          })
+        ).rejects.toThrow();
+
+        const insert = await connector.executeSQL(
+          "INSERT INTO users (name, email) VALUES ('rw', 'rw@rw.com') RETURNING id",
+          {}
+        );
+        expect(insert.rows).toHaveLength(1);
+
+        await connector.executeSQL("DELETE FROM users WHERE email = 'rw@rw.com'", {});
+      } finally {
+        await connector.disconnect();
+      }
+    });
+  });
+
   describe('Search Path Configuration Tests', () => {
     it('should use first schema in search_path as default for discovery', async () => {
       const connector = new PostgresConnector();

--- a/src/connectors/__tests__/sqlite.integration.test.ts
+++ b/src/connectors/__tests__/sqlite.integration.test.ts
@@ -608,5 +608,22 @@ describe('SQLite Connector Integration Tests', () => {
       const pragma = await sqliteTest.connector.executeSQL('PRAGMA table_info(users)', { readonly: true });
       expect(pragma.rows.length).toBeGreaterThan(0);
     });
+
+    it('should not let an in-batch query_only toggle disable the backstop', async () => {
+      // Even if the classifier were skipped, the engine re-asserts query_only=ON
+      // before each statement, so a mid-batch toggle cannot enable the later INSERT.
+      await expect(
+        sqliteTest.connector.executeSQL(
+          "PRAGMA query_only = OFF; INSERT INTO users (name, email) VALUES ('bypass', 'bypass@test.com')",
+          { readonly: true }
+        )
+      ).rejects.toThrow(/readonly|query_only/i);
+
+      const check = await sqliteTest.connector.executeSQL(
+        "SELECT COUNT(*) AS c FROM users WHERE email = 'bypass@test.com'",
+        {}
+      );
+      expect(Number(check.rows[0].c)).toBe(0);
+    });
   });
 });

--- a/src/connectors/__tests__/sqlite.integration.test.ts
+++ b/src/connectors/__tests__/sqlite.integration.test.ts
@@ -563,4 +563,50 @@ describe('SQLite Connector Integration Tests', () => {
       ).rejects.toThrow();
     });
   });
+
+  describe('Per-tool readonly engine backstop (options.readonly)', () => {
+    // The connection itself is writable (shared by read-only and writable tools);
+    // read-only enforcement is applied per execution via PRAGMA query_only.
+    it('should block a write-effecting PRAGMA when options.readonly is set', async () => {
+      // query_only makes the engine reject the header write; the classifier would
+      // also reject the assignment form, so this is defense in depth.
+      await expect(
+        sqliteTest.connector.executeSQL('PRAGMA user_version = 1337', { readonly: true })
+      ).rejects.toThrow(/readonly|query_only/i);
+    });
+
+    it('should block INSERT when options.readonly is set', async () => {
+      await expect(
+        sqliteTest.connector.executeSQL(
+          "INSERT INTO users (name, email) VALUES ('ro', 'ro@test.com')",
+          { readonly: true }
+        )
+      ).rejects.toThrow(/readonly/i);
+    });
+
+    it('should restore writability for non-read-only calls on the same connection', async () => {
+      // A read-only call toggles query_only ON; it must be turned back OFF after.
+      await expect(
+        sqliteTest.connector.executeSQL('PRAGMA user_version = 1', { readonly: true })
+      ).rejects.toThrow();
+
+      // Subsequent writable call must succeed.
+      const insert = await sqliteTest.connector.executeSQL(
+        "INSERT INTO users (name, email) VALUES ('rw', 'rw@test.com')",
+        {}
+      );
+      expect(insert.rowCount).toBe(1);
+
+      // Cleanup
+      await sqliteTest.connector.executeSQL("DELETE FROM users WHERE email = 'rw@test.com'", {});
+    });
+
+    it('should allow read-only PRAGMA and SELECT when options.readonly is set', async () => {
+      const select = await sqliteTest.connector.executeSQL('SELECT 1 AS one', { readonly: true });
+      expect(Number(select.rows[0].one)).toBe(1);
+
+      const pragma = await sqliteTest.connector.executeSQL('PRAGMA table_info(users)', { readonly: true });
+      expect(pragma.rows.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -243,8 +243,8 @@ export class ConnectorManager {
       config.queryTimeoutSeconds = source.query_timeout;
     }
     // Note: read-only enforcement is per-tool, not per-source. It is applied at
-    // execution time via ExecuteOptions.readonly (see each connector's executeSQL,
-    // which runs read-only tool calls inside a READ ONLY transaction / query_only),
+    // execution time via ExecuteOptions.readonly. Some connectors also add an
+    // engine-level backstop in executeSQL (e.g. READ ONLY transactions or SQLite PRAGMA query_only),
     // because a single source connection may be shared by both read-only and
     // writable tools. ConnectorConfig.readonly (connection-level) remains supported
     // for direct connector use but is intentionally not wired from source config.

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -242,10 +242,12 @@ export class ConnectorManager {
     if (source.query_timeout !== undefined && connector.id !== 'sqlite') {
       config.queryTimeoutSeconds = source.query_timeout;
     }
-    // Pass readonly flag for SDK-level enforcement (PostgreSQL, SQLite)
-    if (source.readonly !== undefined) {
-      config.readonly = source.readonly;
-    }
+    // Note: read-only enforcement is per-tool, not per-source. It is applied at
+    // execution time via ExecuteOptions.readonly (see each connector's executeSQL,
+    // which runs read-only tool calls inside a READ ONLY transaction / query_only),
+    // because a single source connection may be shared by both read-only and
+    // writable tools. ConnectorConfig.readonly (connection-level) remains supported
+    // for direct connector use but is intentionally not wired from source config.
     // Pass search_path for PostgreSQL
     if (source.search_path) {
       config.searchPath = source.search_path;

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -599,6 +599,18 @@ export class MariaDBConnector implements Connector {
     // This is critical for session-specific features like LAST_INSERT_ID()
     const conn = await this.pool.getConnection();
     try {
+      // Engine-level read-only backstop: run the batch inside a READ ONLY
+      // transaction so MariaDB rejects DML writes (INSERT/UPDATE/DELETE/REPLACE)
+      // that the keyword classifier missed (e.g. function-based writes). Note this
+      // does NOT stop DDL: statements like DROP/CREATE perform an implicit COMMIT
+      // that ends the read-only transaction first, so DDL escapes. Stacked-DDL
+      // payloads (e.g. `SELECT 1--1;DROP TABLE t`) are instead rejected upstream by
+      // the read-only classifier, which now splits `--`-hidden statements (see
+      // scanSingleLineCommentMySQL in sql-parser.ts).
+      if (options.readonly) {
+        await conn.query("START TRANSACTION READ ONLY");
+      }
+
       // Apply maxRows limit to SELECT queries if specified
       let processedSQL = sql;
       if (options.maxRows) {
@@ -634,8 +646,20 @@ export class MariaDBConnector implements Connector {
       // Parse results using shared utility that handles both single and multi-statement queries
       const rows = parseQueryResults(results);
       const rowCount = extractAffectedRows(results);
+
+      if (options.readonly) {
+        await conn.query("COMMIT");
+      }
       return { rows, rowCount };
     } catch (error) {
+      if (options.readonly) {
+        // Best-effort rollback so the connection returns to the pool clean.
+        try {
+          await conn.query("ROLLBACK");
+        } catch {
+          // ignore rollback failure; the original error is more useful
+        }
+      }
       console.error("Error executing query:", error);
       throw error;
     } finally {

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -612,6 +612,18 @@ export class MySQLConnector implements Connector {
     // This is critical for session-specific features like LAST_INSERT_ID()
     const conn = await this.pool.getConnection();
     try {
+      // Engine-level read-only backstop: run the batch inside a READ ONLY
+      // transaction so MySQL rejects DML writes (INSERT/UPDATE/DELETE/REPLACE)
+      // that the keyword classifier missed (e.g. function-based writes). Note this
+      // does NOT stop DDL: statements like DROP/CREATE perform an implicit COMMIT
+      // that ends the read-only transaction first, so DDL escapes. Stacked-DDL
+      // payloads (e.g. `SELECT 1--1;DROP TABLE t`) are instead rejected upstream by
+      // the read-only classifier, which now splits `--`-hidden statements (see
+      // scanSingleLineCommentMySQL in sql-parser.ts).
+      if (options.readonly) {
+        await conn.query("START TRANSACTION READ ONLY");
+      }
+
       // Apply maxRows limit to SELECT queries if specified
       let processedSQL = sql;
       if (options.maxRows) {
@@ -651,8 +663,20 @@ export class MySQLConnector implements Connector {
       // Parse results using shared utility that handles both single and multi-statement queries
       const rows = parseQueryResults(firstResult);
       const rowCount = extractAffectedRows(firstResult);
+
+      if (options.readonly) {
+        await conn.query("COMMIT");
+      }
       return { rows, rowCount };
     } catch (error) {
+      if (options.readonly) {
+        // Best-effort rollback so the connection returns to the pool clean.
+        try {
+          await conn.query("ROLLBACK");
+        } catch {
+          // ignore rollback failure; the original error is more useful
+        }
+      }
       console.error("Error executing query:", error);
       throw error;
     } finally {

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -684,7 +684,13 @@ export class PostgresConnector implements Connector {
           }
           await client.query('COMMIT');
         } catch (error) {
-          await client.query('ROLLBACK');
+          // Best-effort rollback so a failed ROLLBACK can't mask the original
+          // error (read-only violations mid-batch are expected under BEGIN READ ONLY).
+          try {
+            await client.query('ROLLBACK');
+          } catch {
+            // ignore; the original error is more useful
+          }
           throw error;
         }
 

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -609,6 +609,25 @@ export class PostgresConnector implements Connector {
         // Single statement - apply maxRows if applicable
         const processedStatement = SQLRowLimiter.applyMaxRows(statements[0], options.maxRows);
 
+        // Engine-level read-only enforcement: when the tool is read-only, run the
+        // statement inside a READ ONLY transaction so the database itself rejects any
+        // write, even one the keyword classifier failed to catch (e.g. SELECT setval()).
+        if (options.readonly) {
+          await client.query('BEGIN READ ONLY');
+          try {
+            const result = parameters && parameters.length > 0
+              ? await client.query(processedStatement, parameters)
+              : await client.query(processedStatement);
+            await client.query('COMMIT');
+            return { rows: result.rows, rowCount: result.rowCount ?? result.rows.length };
+          } catch (error) {
+            await client.query('ROLLBACK');
+            console.error(`[PostgreSQL executeSQL] ERROR: ${(error as Error).message}`);
+            console.error(`[PostgreSQL executeSQL] SQL: ${processedStatement}`);
+            throw error;
+          }
+        }
+
         // Use parameters if provided
         let result;
         if (parameters && parameters.length > 0) {
@@ -635,8 +654,10 @@ export class PostgresConnector implements Connector {
         let allRows: any[] = [];
         let totalRowCount = 0;
 
-        // Execute within a transaction to ensure session consistency
-        await client.query('BEGIN');
+        // Execute within a transaction to ensure session consistency.
+        // In read-only mode, open it READ ONLY so the engine rejects any write the
+        // keyword classifier missed (defense in depth, not a parser).
+        await client.query(options.readonly ? 'BEGIN READ ONLY' : 'BEGIN');
         try {
           for (let statement of statements) {
             // Apply maxRows limit to SELECT queries if specified

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -621,9 +621,18 @@ export class PostgresConnector implements Connector {
             await client.query('COMMIT');
             return { rows: result.rows, rowCount: result.rowCount ?? result.rows.length };
           } catch (error) {
-            await client.query('ROLLBACK');
+            // Best-effort rollback so a failed ROLLBACK (e.g. dropped connection)
+            // can't mask the original query error.
+            try {
+              await client.query('ROLLBACK');
+            } catch {
+              // ignore; the original error is more useful
+            }
             console.error(`[PostgreSQL executeSQL] ERROR: ${(error as Error).message}`);
             console.error(`[PostgreSQL executeSQL] SQL: ${processedStatement}`);
+            if (parameters && parameters.length > 0) {
+              console.error(`[PostgreSQL executeSQL] Parameters: ${JSON.stringify(parameters)}`);
+            }
             throw error;
           }
         }

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -570,9 +570,14 @@ export class SQLiteConnector implements Connector {
       }
     } finally {
       // Restore the connection to writable so non-read-only tools on the same
-      // shared connection are unaffected.
+      // shared connection are unaffected. Best-effort: if this throws it must not
+      // mask the primary execution error (the expected read-only rejection).
       if (options.readonly) {
-        this.db.exec("PRAGMA query_only = OFF");
+        try {
+          this.db.exec("PRAGMA query_only = OFF");
+        } catch {
+          // ignore; preserve the original error
+        }
       }
     }
   }

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -552,6 +552,12 @@ export class SQLiteConnector implements Connector {
         // Execute write statements individually to track changes
         let totalChanges = 0;
         for (const statement of writeStatements) {
+          // Re-assert the read-only backstop before each statement so an earlier
+          // statement in the batch (e.g. `PRAGMA query_only = OFF` / `query_only(0)`)
+          // cannot disable it for the ones that follow.
+          if (options.readonly) {
+            this.db.exec("PRAGMA query_only = ON");
+          }
           const result = this.prepare(statement).run();
           totalChanges += Number(result.changes);
         }
@@ -559,6 +565,9 @@ export class SQLiteConnector implements Connector {
         // Execute read statements individually to collect results
         let allRows: any[] = [];
         for (let statement of readStatements) {
+          if (options.readonly) {
+            this.db.exec("PRAGMA query_only = ON");
+          }
           // Apply maxRows limit to SELECT queries if specified
           statement = SQLRowLimiter.applyMaxRows(statement, options.maxRows);
           const result = this.prepare(statement).all();

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -453,6 +453,15 @@ export class SQLiteConnector implements Connector {
       throw new Error("Not connected to SQLite database");
     }
 
+    // Engine-level read-only backstop: PRAGMA query_only=ON makes SQLite reject any
+    // write (including header-writing pragmas like `PRAGMA user_version=N` and
+    // `wal_checkpoint(...)`) regardless of what the keyword classifier allowed. The
+    // body below runs synchronously (node:sqlite is sync), so no other executeSQL
+    // call can interleave between toggling the flag on and restoring it.
+    if (options.readonly) {
+      this.db.exec("PRAGMA query_only = ON");
+    }
+
     try {
       // Check if this is a multi-statement query
       const statements = splitSQLStatements(sql, "sqlite");
@@ -559,8 +568,12 @@ export class SQLiteConnector implements Connector {
         // rowCount is total changes for writes, plus rows returned for reads
         return { rows: allRows, rowCount: totalChanges + allRows.length };
       }
-    } catch (error) {
-      throw error;
+    } finally {
+      // Restore the connection to writable so non-read-only tools on the same
+      // shared connection are unaffected.
+      if (options.readonly) {
+        this.db.exec("PRAGMA query_only = OFF");
+      }
     }
   }
 }

--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -315,6 +315,24 @@ describe("isReadOnlySQL", () => {
     it("should reject assignment-form pragma without surrounding spaces", () => {
       expect(isReadOnlySQL("PRAGMA user_version=1", "sqlite")).toBe(false);
     });
+
+    it("should reject the parenthesized setter form (equivalent to '= value')", () => {
+      // SQLite accepts `PRAGMA name(value)` as an alias for `PRAGMA name = value`.
+      expect(isReadOnlySQL("PRAGMA user_version(1337)", "sqlite")).toBe(false);
+      expect(isReadOnlySQL("PRAGMA journal_mode(wal)", "sqlite")).toBe(false);
+      expect(isReadOnlySQL("PRAGMA writable_schema(1)", "sqlite")).toBe(false);
+    });
+
+    it("should reject disabling the backstop via the parenthesized form", () => {
+      expect(isReadOnlySQL("PRAGMA query_only(0)", "sqlite")).toBe(false);
+      expect(isReadOnlySQL("PRAGMA query_only(OFF)", "sqlite")).toBe(false);
+    });
+
+    it("should still allow introspection pragmas that take a name argument", () => {
+      expect(isReadOnlySQL("PRAGMA table_info(users)", "sqlite")).toBe(true);
+      expect(isReadOnlySQL("PRAGMA index_list(users)", "sqlite")).toBe(true);
+      expect(isReadOnlySQL("PRAGMA foreign_key_list(orders)", "sqlite")).toBe(true);
+    });
   });
 
   describe("MySQL/MariaDB -- comment bypass prevention", () => {

--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { isReadOnlySQL } from "../allowed-keywords.js";
+import { splitSQLStatements } from "../sql-parser.js";
+import type { ConnectorType } from "../../connectors/interface.js";
+
+// Mirrors areAllStatementsReadOnly in src/tools/execute-sql.ts: the real
+// enforcement splits a batch into statements first, then checks each one.
+function areAllStatementsReadOnly(sql: string, connectorType: ConnectorType): boolean {
+  return splitSQLStatements(sql, connectorType).every(s => isReadOnlySQL(s, connectorType));
+}
 
 describe("isReadOnlySQL", () => {
   describe("basic read-only detection", () => {
@@ -278,6 +286,58 @@ describe("isReadOnlySQL", () => {
 
     it("should reject MariaDB M-bang executable comment on MySQL dialect", () => {
       expect(isReadOnlySQL("/*M! DROP TABLE users */", "mysql")).toBe(false);
+    });
+  });
+
+  describe("SQLite PRAGMA write bypass prevention", () => {
+    it("should allow query-form introspection pragmas", () => {
+      expect(isReadOnlySQL("PRAGMA table_info(users)", "sqlite")).toBe(true);
+      expect(isReadOnlySQL("PRAGMA user_version", "sqlite")).toBe(true);
+      expect(isReadOnlySQL("PRAGMA journal_mode", "sqlite")).toBe(true);
+    });
+
+    it("should reject assignment-form pragma writing the database header", () => {
+      expect(isReadOnlySQL("PRAGMA user_version = 1337", "sqlite")).toBe(false);
+      expect(isReadOnlySQL("PRAGMA application_id = 1", "sqlite")).toBe(false);
+    });
+
+    it("should reject assignment-form pragma changing durable state", () => {
+      expect(isReadOnlySQL("PRAGMA journal_mode = WAL", "sqlite")).toBe(false);
+      expect(isReadOnlySQL("PRAGMA foreign_keys = OFF", "sqlite")).toBe(false);
+      expect(isReadOnlySQL("PRAGMA secure_delete = ON", "sqlite")).toBe(false);
+    });
+
+    it("should reject assignment-form pragma disabling the read-only backstop", () => {
+      expect(isReadOnlySQL("PRAGMA query_only = OFF", "sqlite")).toBe(false);
+      expect(isReadOnlySQL("PRAGMA writable_schema = ON", "sqlite")).toBe(false);
+    });
+
+    it("should reject assignment-form pragma without surrounding spaces", () => {
+      expect(isReadOnlySQL("PRAGMA user_version=1", "sqlite")).toBe(false);
+    });
+  });
+
+  describe("MySQL/MariaDB -- comment bypass prevention", () => {
+    // MySQL/MariaDB only treat "--" as a comment when followed by whitespace.
+    // "SELECT 1--1;DROP TABLE t" is one statement to a naive parser but two to
+    // the engine, so after splitting the hidden DROP must be checked and rejected.
+    it("should split and reject a DROP hidden after -- without whitespace (mysql)", () => {
+      expect(splitSQLStatements("SELECT 1--1;DROP TABLE victim", "mysql")).toHaveLength(2);
+      expect(areAllStatementsReadOnly("SELECT 1--1;DROP TABLE victim", "mysql")).toBe(false);
+    });
+
+    it("should split and reject a DROP hidden after -- without whitespace (mariadb)", () => {
+      expect(areAllStatementsReadOnly("SELECT 1--1;DROP TABLE victim", "mariadb")).toBe(false);
+    });
+
+    it("should still treat '-- ' followed by whitespace as a comment (mysql)", () => {
+      expect(splitSQLStatements("SELECT 1 -- a comment;DROP TABLE t", "mysql")).toHaveLength(1);
+      expect(areAllStatementsReadOnly("SELECT 1 -- a comment", "mysql")).toBe(true);
+    });
+
+    it("should still treat the DML-in-comment as inert for postgres (-- is always a comment)", () => {
+      expect(splitSQLStatements("SELECT 1--1;DROP TABLE victim", "postgres")).toHaveLength(1);
+      expect(areAllStatementsReadOnly("SELECT 1--1;DROP TABLE victim", "postgres")).toBe(true);
     });
   });
 });

--- a/src/utils/__tests__/sql-parser.test.ts
+++ b/src/utils/__tests__/sql-parser.test.ts
@@ -598,4 +598,25 @@ describe("splitSQLStatements", () => {
     });
   });
 
+  describe("MySQL/MariaDB dialect-aware -- comments", () => {
+    it("does not treat -- as a comment unless followed by whitespace/control/EOL", () => {
+      // `--1;DROP...` is not a comment in MySQL, so the ; still splits.
+      expect(splitSQLStatements("SELECT 1--1;DROP TABLE t", "mysql")).toHaveLength(2);
+      expect(splitSQLStatements("SELECT 1--1;DROP TABLE t", "mariadb")).toHaveLength(2);
+    });
+
+    it("treats '-- ' (whitespace) as a comment, swallowing the rest of the line", () => {
+      expect(splitSQLStatements("SELECT 1 -- c;DROP TABLE t", "mysql")).toHaveLength(1);
+    });
+
+    it("treats '--' followed by a control char (ASCII DEL 0x7F) as a comment", () => {
+      // MySQL's lexer uses my_isspace() || my_iscntrl(); DEL is a control char.
+      expect(splitSQLStatements("SELECT 1 --\x7Fc;DROP TABLE t", "mysql")).toHaveLength(1);
+    });
+
+    it("keeps -- as an always-comment for postgres (dialect difference)", () => {
+      expect(splitSQLStatements("SELECT 1--1;DROP TABLE t", "postgres")).toHaveLength(1);
+    });
+  });
+
 });

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -61,6 +61,22 @@ const mutatingPatterns: Record<ConnectorType, RegExp> = {
 
 const selectIntoPattern = /\bselect\b[\s\S]+\binto\b/i;
 
+/**
+ * SQLite read-only introspection pragmas that legitimately take a parenthesized
+ * argument (a table/index name) and return rows without mutating state. Any other
+ * pragma using the parenthesized form is a setter (e.g. `PRAGMA user_version(1)`,
+ * `PRAGMA query_only(0)`), which SQLite treats identically to the `= value` form.
+ */
+const sqliteReadOnlyArgPragmas = new Set([
+  "table_info",
+  "index_info",
+  "index_list",
+  "foreign_key_list",
+]);
+
+/** Matches `PRAGMA [schema.]name(` to extract the pragma name of the parenthesized form. */
+const sqlitePragmaParenPattern = /^pragma\s+(?:[a-z0-9_]+\.)?([a-z0-9_]+)\s*\(/;
+
 /** Matches EXPLAIN ANALYZE (or parenthesized form), excluding disabled forms (false/off/0) */
 const explainAnalyzePattern =
   /^explain\s+(?:\([^)]*\banalyze\b(?!\s*(?:=\s*)?(?:false|off|0)\b)[^)]*\)|\banalyze\b(?!\s*(?:=\s*)?(?:false|off|0)\b)(?:\s+verbose\b)?)/i;
@@ -103,14 +119,21 @@ function checkReadOnly(cleanedSQL: string, connectorType: ConnectorType | string
     }
   }
 
-  // SQLite PRAGMA: the assignment form (e.g. `PRAGMA user_version = 1`,
-  // `PRAGMA journal_mode = WAL`, `PRAGMA query_only = OFF`) mutates durable or
-  // session state and must not classify as read-only. Only the query form
-  // (`PRAGMA user_version`, `PRAGMA table_info(t)`) is allowed here. Function-form
-  // write pragmas (e.g. `wal_checkpoint(...)`) are caught by the engine-level
-  // query_only backstop in SQLiteConnector.executeSQL.
-  if (firstWord === "pragma" && connectorType === "sqlite" && cleanedSQL.includes("=")) {
-    return false;
+  // SQLite PRAGMA: a pragma that sets a value mutates durable or session state and
+  // must not classify as read-only. SQLite accepts a setter in two equivalent
+  // forms — `PRAGMA name = value` and `PRAGMA name(value)` — so checking for `=`
+  // alone is not enough. Reject the assignment form, and reject the parenthesized
+  // form unless the pragma is a known introspection pragma (e.g. `table_info(t)`)
+  // that takes an argument purely to return rows. The bare query form
+  // (`PRAGMA user_version`) returns the value and is allowed.
+  if (firstWord === "pragma" && connectorType === "sqlite") {
+    if (cleanedSQL.includes("=")) {
+      return false;
+    }
+    const parenMatch = cleanedSQL.match(sqlitePragmaParenPattern);
+    if (parenMatch && !sqliteReadOnlyArgPragmas.has(parenMatch[1])) {
+      return false;
+    }
   }
 
   // SELECT/WITH ... INTO writes data (creates tables or writes to files)

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -103,6 +103,16 @@ function checkReadOnly(cleanedSQL: string, connectorType: ConnectorType | string
     }
   }
 
+  // SQLite PRAGMA: the assignment form (e.g. `PRAGMA user_version = 1`,
+  // `PRAGMA journal_mode = WAL`, `PRAGMA query_only = OFF`) mutates durable or
+  // session state and must not classify as read-only. Only the query form
+  // (`PRAGMA user_version`, `PRAGMA table_info(t)`) is allowed here. Function-form
+  // write pragmas (e.g. `wal_checkpoint(...)`) are caught by the engine-level
+  // query_only backstop in SQLiteConnector.executeSQL.
+  if (firstWord === "pragma" && connectorType === "sqlite" && cleanedSQL.includes("=")) {
+    return false;
+  }
+
   // SELECT/WITH ... INTO writes data (creates tables or writes to files)
   if ((firstWord === "select" || firstWord === "with") && selectIntoPattern.test(cleanedSQL)) {
     return false;

--- a/src/utils/sql-parser.ts
+++ b/src/utils/sql-parser.ts
@@ -19,6 +19,24 @@ function scanSingleLineComment(sql: string, i: number): SQLToken | null {
   return { type: TokenType.Comment, end: j };
 }
 
+/**
+ * MySQL/MariaDB single-line comment scanner. Unlike ANSI SQL, MySQL and MariaDB
+ * only begin a `--` comment when the two dashes are followed by whitespace, a
+ * control character, or end of input. Otherwise the dashes are two minus
+ * operators and the rest of the line is ordinary SQL (e.g. `SELECT 1--1` is
+ * `SELECT 1 - (-1)`). Treating `--x` as a comment here would let a statement
+ * hidden after it (`SELECT 1--1;DROP TABLE t`) pass the read-only classifier
+ * while the engine still executes the DROP.
+ */
+function scanSingleLineCommentMySQL(sql: string, i: number): SQLToken | null {
+  if (sql[i] !== "-" || sql[i + 1] !== "-") { return null; }
+  const next = sql[i + 2];
+  if (next !== undefined && next.charCodeAt(0) > 0x20) { return null; }
+  let j = i;
+  while (j < sql.length && sql[j] !== "\n") { j++; }
+  return { type: TokenType.Comment, end: j };
+}
+
 function scanMultiLineComment(sql: string, i: number): SQLToken | null {
   if (sql[i] !== "/" || sql[i + 1] !== "*") { return null; }
   let j = i + 2;
@@ -133,7 +151,7 @@ function scanTokenPostgres(sql: string, i: number): SQLToken {
 }
 
 function scanTokenMySQL(sql: string, i: number): SQLToken {
-  return scanSingleLineComment(sql, i)
+  return scanSingleLineCommentMySQL(sql, i)
     ?? scanMultiLineCommentMySQL(sql, i)
     ?? scanSingleQuotedString(sql, i)
     ?? scanDoubleQuotedString(sql, i)

--- a/src/utils/sql-parser.ts
+++ b/src/utils/sql-parser.ts
@@ -31,7 +31,12 @@ function scanSingleLineComment(sql: string, i: number): SQLToken | null {
 function scanSingleLineCommentMySQL(sql: string, i: number): SQLToken | null {
   if (sql[i] !== "-" || sql[i + 1] !== "-") { return null; }
   const next = sql[i + 2];
-  if (next !== undefined && next.charCodeAt(0) > 0x20) { return null; }
+  // Comment trigger = whitespace, control char, or EOL. MySQL's lexer uses
+  // my_isspace() || my_iscntrl(), so besides bytes <= 0x20 this also includes
+  // ASCII DEL (0x7F). Anything else means the dashes are minus operators.
+  if (next !== undefined && next.charCodeAt(0) > 0x20 && next.charCodeAt(0) !== 0x7f) {
+    return null;
+  }
   let j = i;
   while (j < sql.length && sql[j] !== "\n") { j++; }
   return { type: TokenType.Comment, end: j };


### PR DESCRIPTION
## Summary

Read-only mode was enforced only by a leading-keyword classifier. A real database parses SQL differently than our string checks, so several writes slipped through in read-only mode. The connection-level `config.readonly` backstop existed but was never wired up — `manager.ts` read a `source.readonly` field that doesn't exist on `SourceConfig` and is rejected by the TOML loader — so the classifier was the *only* live layer.

This PR adds **engine-level read-only enforcement**, scoped per-tool via `options.readonly` (already plumbed into every `executeSQL`), so the database itself rejects writes the classifier missed. The classifier stays as a best-effort first layer and gets two parser-free hardening fixes.

## Changes

**Engine-level enforcement (per tool, respects mixed read-only/writable tools on a shared connection):**

| Connector | Mechanism | Blocks |
|---|---|---|
| Postgres | `BEGIN READ ONLY` (single + multi path) | `SELECT setval()`, INSERT/UPDATE/DELETE, data-modifying CTEs |
| SQLite | `PRAGMA query_only=ON` around the call | header-writing pragmas, `wal_checkpoint`, all writes |
| MySQL / MariaDB | `START TRANSACTION READ ONLY` | DML writes (INSERT/UPDATE/DELETE/REPLACE) |

**Classifier hardening (no SQL parser introduced):**
- SQLite: assignment-form `PRAGMA x = ...` now classified as a write.
- MySQL/MariaDB: `--` only begins a comment when followed by whitespace/control/EOL, matching the engine — so `SELECT 1--1;DROP TABLE t` splits into two statements and the hidden DROP is rejected before execution.

**Cleanup:** removed the dead `source.readonly` wiring; documented that read-only is enforced per-tool at execution time.

## Known limitation (documented in code)

On MySQL/MariaDB, DDL (`DROP`/`CREATE`) performs an implicit commit that ends the read-only transaction, so DDL escapes the engine backstop. Stacked-DDL payloads are instead caught upstream by the classifier comment-scanner fix. The engine transaction reliably blocks DML.

The privileged-role Postgres vectors (`lo_export`, `dblink`, `COPY ... TO PROGRAM`) are not closeable by a read-only transaction and remain a least-privilege / documentation concern.

## Testing

- Unit: new coverage for the PRAGMA-write and `--`-comment classifier fixes; full unit suite green (pre-existing env-specific ssh-config/env failures unrelated).
- Integration (Docker): Postgres 48/48, MySQL + MariaDB 74/74, SQLite 43/43. New tests confirm `setval()`, stacked `--` UPDATE, INSERT, and PRAGMA writes are rejected, and the shared connection stays writable for non-read-only tools.
- `pnpm run build:backend`: success.

Addresses GHSA-mwwr-p57h-56pf, GHSA-j656-3hf2-fvjc, GHSA-m689-287g-5xpc, GHSA-7rgf-cwgq-c2qc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)