### PR TITLE
chore: upgrade from 0.22.5 to 0.22.6

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dbhub/frontend",
   "private": true,
-  "version": "0.22.5",
+  "version": "0.22.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbhub",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "mcpName": "io.github.bytebase/dbhub",
   "description": "Minimal, token-efficient Database MCP Server for PostgreSQL, MySQL, SQL Server, SQLite, MariaDB",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/bytebase/dbhub",
     "source": "github"
   },
-  "version": "0.22.5",
+  "version": "0.22.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@bytebase/dbhub",
-      "version": "0.22.5",
+      "version": "0.22.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Release **0.22.6**.

Contains the read-only enforcement hardening from #342:
- Engine-level read-only backstops: Postgres `BEGIN READ ONLY`, SQLite `PRAGMA query_only=ON` (re-asserted per statement), MySQL/MariaDB `START TRANSACTION READ ONLY`.
- Classifier hardening (no SQL parser): SQLite write-pragma detection incl. the parenthesized setter form; MySQL/MariaDB dialect-correct `--` comment parsing.

Addresses GHSA-mwwr-p57h-56pf and GHSA-j656-3hf2-fvjc (and the duplicates GHSA-7rgf-cwgq-c2qc, GHSA-m689-287g-5xpc).

Merging this to main triggers the npm trusted-publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)