### PR TITLE
feat: delegate SSH config aliases to native OpenSSH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,10 +172,13 @@ DBHub supports SSH tunnels for secure database connections through bastion hosts
 - Configuration via command-line options: `--ssh-host`, `--ssh-port`, `--ssh-user`, `--ssh-password`, `--ssh-key`, `--ssh-passphrase`
 - Configuration via environment variables: `SSH_HOST`, `SSH_PORT`, `SSH_USER`, `SSH_PASSWORD`, `SSH_KEY`, `SSH_PASSPHRASE`
 - SSH config file support: Automatically reads from `~/.ssh/config` when using host aliases
-- Implementation in `src/utils/ssh-tunnel.ts` using the `ssh2` library
+- **Native SSH mode** (auto): When `ssh_host` matches a Host alias in `~/.ssh/config` (and no `ssh_password` / `ssh_proxy_jump`), DBHub spawns the system `ssh` client (`src/utils/native-ssh-tunnel.ts`) so ProxyJump and per-hop auth are handled by OpenSSH
+- **ssh2 fallback**: Direct IP/hostname, password auth, and explicit `ssh_proxy_jump` use `src/utils/ssh-tunnel.ts` with the `ssh2` library
+- Troubleshooting env: `DBHUB_SSH_BIN`, `DBHUB_SSH_CONFIG`, `DBHUB_SSH_FORCE_SSH2`
 - SSH config parsing in `src/utils/ssh-config-parser.ts` using the `ssh-config` library
+- Tunnel mode resolution in `src/utils/ssh-tunnel-resolver.ts`
 - Automatic tunnel establishment when SSH config is detected
-- Support for both password and key-based authentication
+- Support for both password and key-based authentication (ssh2 mode)
 - Default SSH key detection (tries `~/.ssh/id_rsa`, `~/.ssh/id_ed25519`, etc.)
 - Tunnel lifecycle managed by `ConnectorManager`
 

--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -68,13 +68,19 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # sslmode = "verify-ca"
 # sslrootcert = "~/.ssl/rds-combined-ca-bundle.pem"
 
+# SSH tunnel via ~/.ssh/config alias (native OpenSSH — ProxyJump handled automatically)
+# [[sources]]
+# id = "prod_pg"
+# dsn = "postgres://app_user:secure_password@10.0.1.100:5432/myapp_prod?sslmode=require"
+# ssh_host = "target-with-jump"   # Host alias from ~/.ssh/config (e.g. ProxyJump mybastion)
+
 # Production PostgreSQL (behind SSH bastion, lazy connection)
 # [[sources]]
 # id = "prod_pg"
 # dsn = "postgres://app_user:secure_password@10.0.1.100:5432/myapp_prod?sslmode=require"
 # lazy = true  # Defer connection until first query (avoids startup overhead for remote DBs)
 # connection_timeout = 30
-# # SSH tunnel configuration
+# # SSH tunnel configuration (direct host — uses built-in ssh2)
 # ssh_host = "bastion.company.com"
 # ssh_port = 22
 # ssh_user = "deploy"

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -334,8 +334,9 @@ npx @bytebase/dbhub@latest --dsn "..." \
 
 <Note>
 - `--ssh-key` / `SSH_KEY` accepts either a file path or a base64-encoded private key. DBHub automatically detects the format: it first tries to read the value as a file path, and if that fails, decodes it as base64.
-- When `--ssh-host` is a plain alias (no dots, not an IP address), DBHub automatically resolves it from `~/.ssh/config`, reading the `Hostname`, `User`, `IdentityFile`, and `ProxyJump` directives. Explicit flags always override values from the config file.
-- ProxyCommand is not supported (requires shell execution). Use ProxyJump instead.
+- When `--ssh-host` is a plain alias (no dots, not an IP address) that matches a `Host` entry in `~/.ssh/config`, DBHub spawns the system `ssh` client and passes the alias through unchanged. OpenSSH handles `ProxyJump`, nested aliases, and per-host credentials. This applies when neither `ssh_password` nor `ssh_proxy_jump` is set.
+- For direct hostnames, password authentication, or explicit `ssh_proxy_jump`, DBHub uses the built-in `ssh2` tunnel and resolves `Hostname`, `User`, `IdentityFile`, and `ProxyJump` from `~/.ssh/config` when applicable. Explicit flags always override values from the config file.
+- ProxyCommand is not supported by the `ssh2` tunnel (requires shell execution). Use ProxyJump instead, or use a `~/.ssh/config` alias so native OpenSSH handles ProxyCommand.
 - Path expansion for `~/` is supported in file paths.
 </Note>
 

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -460,6 +460,9 @@ Sources define database connections. Each source represents a database that DBHu
   ssh_key = "~/.ssh/id_rsa"  # File path or base64-encoded key
   ssh_passphrase = "my_key_passphrase"  # Optional
   ssh_proxy_jump = "jump1.example.com,admin@jump2.internal:2222"
+
+  # Or use a ~/.ssh/config Host alias (native OpenSSH when no ssh_password / ssh_proxy_jump):
+  # ssh_host = "target-with-jump"
   ```
 
   `ssh_key` accepts either a file path or a base64-encoded private key. DBHub automatically detects the format.

--- a/docs/design/native-ssh-tunnel.md
+++ b/docs/design/native-ssh-tunnel.md
@@ -1,0 +1,66 @@
+# Native SSH Tunnel Design
+
+> Status: implemented (Phase 1)
+
+When `ssh_host` matches a `Host` alias in `~/.ssh/config`, DBHub automatically delegates tunnel setup to the system `ssh` client instead of re-implementing ProxyJump chains in `ssh2`.
+
+## Mode selection (automatic, no `ssh_mode` flag)
+
+```
+ssh_host set?
+  └─ DBHUB_SSH_FORCE_SSH2=1? ──yes──► ssh2
+  └─ looksLikeSSHAlias + parseSSHConfig match
+     and no ssh_password and no ssh_proxy_jump?
+        ├─ yes → native OpenSSH
+        └─ no  → ssh2 (existing implementation)
+```
+
+| ssh_host | ~/.ssh/config | ssh_password | ssh_proxy_jump | Result |
+|----------|---------------|--------------|----------------|--------|
+| `mybastion` | match | no | no | **native** |
+| `target-with-jump` | match | no | no | **native** |
+| `mybastion` | match | yes | no | ssh2 |
+| `mybastion` | no match | - | - | ssh2 |
+| `bastion.example.com` | - | - | - | ssh2 |
+| `target-with-jump` | match | no | yes | ssh2 |
+
+Troubleshooting environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `DBHUB_SSH_BIN` | Path to `ssh` executable |
+| `DBHUB_SSH_CONFIG` | Path to SSH config file |
+| `DBHUB_SSH_FORCE_SSH2` | Force ssh2 mode |
+
+## Example `~/.ssh/config`
+
+```sshconfig
+Host mybastion
+    HostName bastion.example.com
+    User ubuntu
+    IdentityFile ~/.ssh/id_rsa
+
+Host target-with-jump
+    HostName 10.0.0.5
+    User admin
+    ProxyJump mybastion
+```
+
+## Example `dbhub.toml`
+
+```toml
+[[sources]]
+id = "prod_pg"
+dsn = "postgres://app_user:secure_password@10.0.1.100:5432/myapp_prod?sslmode=require"
+ssh_host = "target-with-jump"
+```
+
+Equivalent to: `ssh -N -L 127.0.0.1:<port>:10.0.1.100:5432 target-with-jump`
+
+OpenSSH resolves `ProxyJump mybastion` (including nested alias → `bastion.example.com`) and per-hop credentials.
+
+## Limitations
+
+- Native mode does not support `ssh_password` (BatchMode)
+- Encrypted private keys require `ssh-agent` or `ssh-add`
+- Requires the system OpenSSH client

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -736,12 +736,16 @@ export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[];
     // Add SSH config if available
     const sshResult = resolveSSHConfig();
     if (sshResult) {
-      source.ssh_host = sshResult.config.host;
+      const args = parseCommandLineArgs();
+      const sshHostArg = args["ssh-host"] || process.env.SSH_HOST;
+      // Preserve the original alias so native SSH auto-detection can use it
+      source.ssh_host = sshHostArg || sshResult.config.host;
       source.ssh_port = sshResult.config.port;
       source.ssh_user = sshResult.config.username;
       source.ssh_password = sshResult.config.password;
       source.ssh_key = sshResult.config.privateKey;
       source.ssh_passphrase = sshResult.config.passphrase;
+      source.ssh_proxy_jump = sshResult.config.proxyJump;
       source.ssh_keepalive_interval = sshResult.config.keepaliveInterval;
       source.ssh_keepalive_count_max = sshResult.config.keepaliveCountMax;
     }

--- a/src/connectors/__tests__/manager.test.ts
+++ b/src/connectors/__tests__/manager.test.ts
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   parseSSHConfig: vi.fn(),
   looksLikeSSHAlias: vi.fn(),
   getDefaultSSHConfigPath: vi.fn(() => join(homedir(), '.ssh', 'config')),
+  nativeEstablish: vi.fn(),
+  ssh2Establish: vi.fn(),
 }));
 
 vi.mock("../../utils/aws-rds-signer.js", () => ({
@@ -19,14 +21,47 @@ vi.mock("../../utils/ssh-config-parser.js", () => ({
   parseSSHConfig: mocks.parseSSHConfig,
   looksLikeSSHAlias: mocks.looksLikeSSHAlias,
   getDefaultSSHConfigPath: mocks.getDefaultSSHConfigPath,
+  resolveSymlink: vi.fn((p: string) => p),
+  parseJumpHosts: vi.fn(),
+  parseJumpHost: vi.fn(),
 }));
 
-describe("ConnectorManager SSH config resolution", () => {
+vi.mock("../../utils/native-ssh-tunnel.js", () => ({
+  NativeSSHTunnel: class MockNativeSSHTunnel {
+    establish(...args: unknown[]) {
+      return mocks.nativeEstablish(...args);
+    }
+    close = vi.fn();
+    getMode() {
+      return "native" as const;
+    }
+    getTunnelInfo = vi.fn();
+    getIsConnected = vi.fn();
+  },
+}));
+
+vi.mock("../../utils/ssh-tunnel.js", () => ({
+  SSHTunnel: class MockSSHTunnel {
+    establish(...args: unknown[]) {
+      return mocks.ssh2Establish(...args);
+    }
+    close = vi.fn();
+    getMode() {
+      return "ssh2" as const;
+    }
+    getTunnelInfo = vi.fn();
+    getIsConnected = vi.fn();
+  },
+}));
+
+describe("ConnectorManager SSH tunnel routing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.nativeEstablish.mockRejectedValue(new Error('native tunnel failed (expected in test)'));
+    mocks.ssh2Establish.mockRejectedValue(new Error('ssh2 tunnel failed (expected in test)'));
   });
 
-  it("should resolve SSH config from ~/.ssh/config for alias hosts", async () => {
+  it("should use native SSH when alias is found in SSH config", async () => {
     mocks.looksLikeSSHAlias.mockReturnValue(true);
     mocks.parseSSHConfig.mockReturnValue({
       host: "bastion.example.com",
@@ -43,16 +78,20 @@ describe("ConnectorManager SSH config resolution", () => {
       ssh_host: "mybastion",
     };
 
-    // connectSource is private; connectWithSources calls it.
-    // It will fail when trying to establish the actual SSH tunnel,
-    // but only after the config resolution succeeds.
-    await expect(manager.connectWithSources([source])).rejects.toThrow();
+    await expect(manager.connectWithSources([source])).rejects.toThrow('native tunnel failed');
 
-    expect(mocks.looksLikeSSHAlias).toHaveBeenCalledWith("mybastion");
-    expect(mocks.parseSSHConfig).toHaveBeenCalledWith("mybastion", expect.stringContaining(".ssh/config"));
+    expect(mocks.nativeEstablish).toHaveBeenCalledTimes(1);
+    expect(mocks.ssh2Establish).not.toHaveBeenCalled();
+    expect(mocks.nativeEstablish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostAlias: "mybastion",
+        targetHost: "db.internal",
+        targetPort: 5432,
+      })
+    );
   });
 
-  it("should let explicit TOML fields override SSH config values", async () => {
+  it("should use ssh2 when ssh_password is set", async () => {
     mocks.looksLikeSSHAlias.mockReturnValue(true);
     mocks.parseSSHConfig.mockReturnValue({
       host: "bastion.example.com",
@@ -67,15 +106,14 @@ describe("ConnectorManager SSH config resolution", () => {
       type: "postgres",
       dsn: "postgres://user:pass@db.internal:5432/mydb",
       ssh_host: "mybastion",
-      ssh_user: "override-user",
-      ssh_port: 3333,
-      ssh_key: "/custom/key",
+      ssh_password: "secret",
+      ssh_user: "ubuntu",
     };
 
-    await expect(manager.connectWithSources([source])).rejects.toThrow();
+    await expect(manager.connectWithSources([source])).rejects.toThrow('ssh2 tunnel failed');
 
-    // Verify parseSSHConfig was still called (alias was resolved)
-    expect(mocks.parseSSHConfig).toHaveBeenCalled();
+    expect(mocks.ssh2Establish).toHaveBeenCalledTimes(1);
+    expect(mocks.nativeEstablish).not.toHaveBeenCalled();
   });
 
   it("should throw when SSH alias not found and no ssh_user provided", async () => {
@@ -93,30 +131,12 @@ describe("ConnectorManager SSH config resolution", () => {
     await expect(manager.connectWithSources([source])).rejects.toThrow(
       "SSH tunnel requires ssh_user (or a matching Host entry in ~/.ssh/config with User)"
     );
+
+    expect(mocks.ssh2Establish).not.toHaveBeenCalled();
+    expect(mocks.nativeEstablish).not.toHaveBeenCalled();
   });
 
-  it("should throw when no auth method available after SSH config resolution", async () => {
-    mocks.looksLikeSSHAlias.mockReturnValue(true);
-    mocks.parseSSHConfig.mockReturnValue({
-      host: "bastion.example.com",
-      username: "ubuntu",
-      // No privateKey, no password
-    });
-
-    const manager = new ConnectorManager();
-    const source: SourceConfig = {
-      id: "test",
-      type: "postgres",
-      dsn: "postgres://user:pass@db.internal:5432/mydb",
-      ssh_host: "mybastion",
-    };
-
-    await expect(manager.connectWithSources([source])).rejects.toThrow(
-      "SSH tunnel requires either ssh_password or ssh_key (or a matching Host entry in ~/.ssh/config with IdentityFile)"
-    );
-  });
-
-  it("should skip SSH config resolution for direct hostnames", async () => {
+  it("should use ssh2 for direct hostnames", async () => {
     mocks.looksLikeSSHAlias.mockReturnValue(false);
 
     const manager = new ConnectorManager();
@@ -129,11 +149,12 @@ describe("ConnectorManager SSH config resolution", () => {
       ssh_key: "/home/user/.ssh/id_rsa",
     };
 
-    // Will fail at tunnel establishment, not at config resolution
-    await expect(manager.connectWithSources([source])).rejects.toThrow();
+    await expect(manager.connectWithSources([source])).rejects.toThrow('ssh2 tunnel failed');
 
     expect(mocks.looksLikeSSHAlias).toHaveBeenCalledWith("bastion.example.com");
     expect(mocks.parseSSHConfig).not.toHaveBeenCalled();
+    expect(mocks.ssh2Establish).toHaveBeenCalledTimes(1);
+    expect(mocks.nativeEstablish).not.toHaveBeenCalled();
   });
 });
 

--- a/src/connectors/__tests__/postgres-ssh.integration.test.ts
+++ b/src/connectors/__tests__/postgres-ssh.integration.test.ts
@@ -135,11 +135,10 @@ describe('PostgreSQL SSH Tunnel Simple Integration Tests', () => {
 
         // Verify that SSH tunnel was attempted with the correct config values
         expect(mockSSHTunnelEstablish).toHaveBeenCalledTimes(1);
-        const sshTunnelCall = mockSSHTunnelEstablish.mock.calls[0];
-        const [sshConfig, tunnelOptions] = sshTunnelCall;
+        const [request] = mockSSHTunnelEstablish.mock.calls[0];
 
         // Verify SSH config values were properly set from source config
-        expect(sshConfig).toMatchObject({
+        expect(request.sshConfig).toMatchObject({
           host: 'bastion.example.com',
           username: 'sshuser',
           port: 2222,
@@ -148,8 +147,8 @@ describe('PostgreSQL SSH Tunnel Simple Integration Tests', () => {
 
         // Verify tunnel options are correctly set up for the database connection
         const originalDsnUrl = new URL(dsn);
-        expect(tunnelOptions.targetHost).toBe(originalDsnUrl.hostname);
-        expect(tunnelOptions.targetPort).toBe(parseInt(originalDsnUrl.port));
+        expect(request.targetHost).toBe(originalDsnUrl.hostname);
+        expect(request.targetPort).toBe(parseInt(originalDsnUrl.port));
 
       } finally {
         mockSSHTunnelEstablish.mockRestore();
@@ -179,8 +178,8 @@ describe('PostgreSQL SSH Tunnel Simple Integration Tests', () => {
 
         // Verify SSH tunnel was attempted with password auth
         expect(mockSSHTunnelEstablish).toHaveBeenCalledTimes(1);
-        const [sshConfig] = mockSSHTunnelEstablish.mock.calls[0];
-        expect(sshConfig.password).toBe('sshpass');
+        const [request] = mockSSHTunnelEstablish.mock.calls[0];
+        expect(request.sshConfig?.password).toBe('sshpass');
 
       } finally {
         mockSSHTunnelEstablish.mockRestore();

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -1,13 +1,14 @@
 import { Connector, ConnectorType, ConnectorRegistry, ExecuteOptions, ConnectorConfig } from "./interface.js";
 import { SSHTunnel } from "../utils/ssh-tunnel.js";
-import type { SSHTunnelConfig, SSHTunnelInfo } from "../types/ssh.js";
+import { NativeSSHTunnel } from "../utils/native-ssh-tunnel.js";
+import type { SSHTunnelBackend, SSHTunnelInfo } from "../types/ssh.js";
 import type { SourceConfig } from "../types/config.js";
 import { buildDSNFromSource } from "../config/toml-loader.js";
 import { getDatabaseTypeFromDSN, getDefaultPortForType } from "../utils/dsn-obfuscate.js";
 import { redactDSN } from "../config/env.js";
 import { SafeURL } from "../utils/safe-url.js";
 import { generateRdsAuthToken } from "../utils/aws-rds-signer.js";
-import { parseSSHConfig, looksLikeSSHAlias, getDefaultSSHConfigPath } from "../utils/ssh-config-parser.js";
+import { resolveTunnelPlan } from "../utils/ssh-tunnel-resolver.js";
 import { TUNNEL_ERROR_MARKER } from "../utils/error-classifier.js";
 
 // Singleton instance for global access
@@ -21,7 +22,7 @@ const AWS_IAM_TOKEN_REFRESH_MS = 14 * 60 * 1000; // refresh before 15-minute tok
 export class ConnectorManager {
   // Maps for multi-source support
   private connectors: Map<string, Connector> = new Map();
-  private sshTunnels: Map<string, SSHTunnel> = new Map();
+  private sshTunnels: Map<string, SSHTunnelBackend> = new Map();
   private sourceConfigs: Map<string, SourceConfig> = new Map(); // Store original source configs
   private sourceIds: string[] = []; // Ordered list of source IDs (first is default)
   private iamRefreshTimers: Map<string, NodeJS.Timeout> = new Map();
@@ -149,52 +150,38 @@ export class ConnectorManager {
     // Setup SSH tunnel if needed
     let actualDSN = dsn;
     if (source.ssh_host) {
-      // If ssh_host looks like an SSH config alias, resolve from ~/.ssh/config
-      let resolvedSSHConfig: SSHTunnelConfig | null = null;
-      if (looksLikeSSHAlias(source.ssh_host)) {
-        const sshConfigPath = getDefaultSSHConfigPath();
-        console.error(`  Resolving SSH config for host '${source.ssh_host}' from: ${sshConfigPath}`);
-        resolvedSSHConfig = parseSSHConfig(source.ssh_host, sshConfigPath);
-      }
+      const plan = resolveTunnelPlan(source);
 
-      // Build SSH config: explicit TOML fields override SSH config values
-      const username = source.ssh_user || resolvedSSHConfig?.username;
-      const sshConfig: SSHTunnelConfig = {
-        host: resolvedSSHConfig?.host || source.ssh_host,
-        port: source.ssh_port || resolvedSSHConfig?.port || 22,
-        username: username || '',
-        password: source.ssh_password,
-        privateKey: source.ssh_key || resolvedSSHConfig?.privateKey,
-        passphrase: source.ssh_passphrase,
-        proxyJump: source.ssh_proxy_jump || resolvedSSHConfig?.proxyJump,
-        keepaliveInterval: source.ssh_keepalive_interval,
-        keepaliveCountMax: source.ssh_keepalive_count_max,
-      };
-
-      // Validate required SSH fields
-      if (!username) {
-        throw new Error(
-          `Source '${sourceId}': SSH tunnel requires ssh_user (or a matching Host entry in ~/.ssh/config with User)`
-        );
-      }
-
-      // Validate SSH auth
-      if (!sshConfig.password && !sshConfig.privateKey) {
-        throw new Error(
-          `Source '${sourceId}': SSH tunnel requires either ssh_password or ssh_key (or a matching Host entry in ~/.ssh/config with IdentityFile)`
-        );
-      }
-
-      // Parse DSN to get target host and port
       const url = new URL(dsn);
       const targetHost = url.hostname;
       const targetPort = parseInt(url.port) || this.getDefaultPort(dsn);
 
-      // Create and establish SSH tunnel
-      const tunnel = new SSHTunnel();
+      if (plan.mode === "ssh2") {
+        const sshConfig = plan.sshConfig!;
+        if (!sshConfig.username) {
+          throw new Error(
+            `Source '${sourceId}': SSH tunnel requires ssh_user (or a matching Host entry in ~/.ssh/config with User)`
+          );
+        }
+        if (!sshConfig.password && !sshConfig.privateKey) {
+          throw new Error(
+            `Source '${sourceId}': SSH tunnel requires either ssh_password or ssh_key (or a matching Host entry in ~/.ssh/config with IdentityFile)`
+          );
+        }
+      }
+
+      const tunnel: SSHTunnelBackend =
+        plan.mode === "native" ? new NativeSSHTunnel() : new SSHTunnel();
+
+      console.error(`  SSH tunnel mode: ${plan.mode} (${plan.reason})`);
+
       let tunnelInfo: SSHTunnelInfo;
       try {
-        tunnelInfo = await tunnel.establish(sshConfig, {
+        tunnelInfo = await tunnel.establish({
+          hostAlias: plan.hostAlias,
+          sshConfigPath: plan.sshConfigPath,
+          sshConfig: plan.sshConfig,
+          overrides: plan.overrides,
           targetHost,
           targetPort,
         });
@@ -205,12 +192,10 @@ export class ConnectorManager {
         throw error;
       }
 
-      // Update DSN to use local tunnel endpoint
       url.hostname = "127.0.0.1";
       url.port = tunnelInfo.localPort.toString();
       actualDSN = url.toString();
 
-      // Store tunnel for later cleanup
       this.sshTunnels.set(sourceId, tunnel);
 
       console.error(

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -71,3 +71,43 @@ export interface SSHTunnelInfo {
   /** Original target port */
   targetPort: number;
 }
+
+/** Optional overrides passed to the native ssh CLI */
+export interface NativeSSHOverrides {
+  user?: string;
+  port?: number;
+  privateKey?: string;
+  keepaliveInterval?: number;
+  keepaliveCountMax?: number;
+}
+
+/** Request to establish an SSH tunnel (native or ssh2) */
+export interface SSHTunnelEstablishRequest {
+  hostAlias?: string;
+  sshConfigPath?: string;
+  sshConfig?: SSHTunnelConfig;
+  targetHost: string;
+  targetPort: number;
+  localPort?: number;
+  overrides?: NativeSSHOverrides;
+}
+
+/** Common interface for native and ssh2 tunnel backends */
+export interface SSHTunnelBackend {
+  establish(request: SSHTunnelEstablishRequest): Promise<SSHTunnelInfo>;
+  close(): Promise<void>;
+  getTunnelInfo(): SSHTunnelInfo | null;
+  getIsConnected(): boolean;
+  getMode(): 'native' | 'ssh2';
+}
+
+export type SSHTunnelBackendMode = 'native' | 'ssh2';
+
+export interface ResolvedTunnelPlan {
+  mode: SSHTunnelBackendMode;
+  hostAlias?: string;
+  sshConfigPath: string;
+  sshConfig?: SSHTunnelConfig;
+  overrides?: NativeSSHOverrides;
+  reason: string;
+}

--- a/src/utils/__tests__/native-ssh-tunnel.test.ts
+++ b/src/utils/__tests__/native-ssh-tunnel.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { buildNativeSshArgs } from '../native-ssh-tunnel.js';
+import type { SSHTunnelEstablishRequest } from '../../types/ssh.js';
+
+describe('buildNativeSshArgs', () => {
+  const baseRequest: SSHTunnelEstablishRequest = {
+    hostAlias: 'mybastion',
+    sshConfigPath: '/home/user/.ssh/config',
+    targetHost: 'db.internal',
+    targetPort: 5432,
+  };
+
+  it('should include port forward and host alias', () => {
+    const args = buildNativeSshArgs(baseRequest, 15432);
+
+    expect(args).toContain('-N');
+    expect(args).toContain('-F');
+    expect(args).toContain('/home/user/.ssh/config');
+    expect(args).toContain('127.0.0.1:15432:db.internal:5432');
+    expect(args[args.length - 1]).toBe('mybastion');
+  });
+
+  it('should include overrides when provided', () => {
+    const args = buildNativeSshArgs(
+      {
+        ...baseRequest,
+        overrides: {
+          user: 'ubuntu',
+          port: 2222,
+          privateKey: '/home/user/.ssh/id_rsa',
+          keepaliveInterval: 60,
+          keepaliveCountMax: 5,
+        },
+      },
+      15432
+    );
+
+    expect(args).toContain('-l');
+    expect(args).toContain('ubuntu');
+    expect(args).toContain('-p');
+    expect(args).toContain('2222');
+    expect(args).toContain('-i');
+    expect(args).toContain('/home/user/.ssh/id_rsa');
+    expect(args).toContain('ServerAliveInterval=60');
+    expect(args).toContain('ServerAliveCountMax=5');
+  });
+
+  it('should require hostAlias and sshConfigPath', () => {
+    expect(() => buildNativeSshArgs({ ...baseRequest, hostAlias: undefined }, 1)).toThrow(
+      'hostAlias'
+    );
+    expect(() => buildNativeSshArgs({ ...baseRequest, sshConfigPath: undefined }, 1)).toThrow(
+      'sshConfigPath'
+    );
+  });
+});

--- a/src/utils/__tests__/ssh-tunnel-resolver.test.ts
+++ b/src/utils/__tests__/ssh-tunnel-resolver.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveTunnelPlan } from '../ssh-tunnel-resolver.js';
+import type { SourceConfig } from '../../types/config.js';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+function baseSource(overrides: Partial<SourceConfig> = {}): SourceConfig {
+  return {
+    id: 'test',
+    type: 'postgres',
+    dsn: 'postgres://user:pass@10.0.0.5:5432/mydb',
+    ssh_host: 'target-with-jump',
+    ...overrides,
+  };
+}
+
+describe('resolveTunnelPlan', () => {
+  let tempDir: string;
+  let configPath: string;
+  let originalForceSsh2: string | undefined;
+  let originalSshConfig: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'dbhub-tunnel-resolver-'));
+    configPath = join(tempDir, 'config');
+    originalForceSsh2 = process.env.DBHUB_SSH_FORCE_SSH2;
+    originalSshConfig = process.env.DBHUB_SSH_CONFIG;
+    delete process.env.DBHUB_SSH_FORCE_SSH2;
+    process.env.DBHUB_SSH_CONFIG = configPath;
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalForceSsh2 === undefined) {
+      delete process.env.DBHUB_SSH_FORCE_SSH2;
+    } else {
+      process.env.DBHUB_SSH_FORCE_SSH2 = originalForceSsh2;
+    }
+    if (originalSshConfig === undefined) {
+      delete process.env.DBHUB_SSH_CONFIG;
+    } else {
+      process.env.DBHUB_SSH_CONFIG = originalSshConfig;
+    }
+  });
+
+  it('should choose native mode when alias exists in SSH config', () => {
+    writeFileSync(
+      configPath,
+      `
+Host target-with-jump
+    HostName 10.0.0.5
+    User admin
+    ProxyJump mybastion
+`
+    );
+
+    const plan = resolveTunnelPlan(baseSource());
+
+    expect(plan.mode).toBe('native');
+    expect(plan.hostAlias).toBe('target-with-jump');
+    expect(plan.sshConfigPath).toBe(configPath);
+    expect(plan.reason).toContain("alias 'target-with-jump'");
+  });
+
+  it('should choose ssh2 when ssh_password is set', () => {
+    writeFileSync(
+      configPath,
+      `
+Host mybastion
+    HostName bastion.example.com
+    User ubuntu
+`
+    );
+
+    const plan = resolveTunnelPlan(
+      baseSource({
+        ssh_host: 'mybastion',
+        ssh_password: 'secret',
+        ssh_user: 'ubuntu',
+      })
+    );
+
+    expect(plan.mode).toBe('ssh2');
+    expect(plan.sshConfig?.host).toBe('bastion.example.com');
+    expect(plan.reason).toContain('ssh_password');
+  });
+
+  it('should choose ssh2 when ssh_proxy_jump is set', () => {
+    writeFileSync(
+      configPath,
+      `
+Host target-with-jump
+    HostName 10.0.0.5
+    User admin
+    ProxyJump mybastion
+`
+    );
+
+    const plan = resolveTunnelPlan(
+      baseSource({
+        ssh_proxy_jump: 'bastion.example.com',
+        ssh_user: 'admin',
+        ssh_key: '/home/user/.ssh/id_rsa',
+      })
+    );
+
+    expect(plan.mode).toBe('ssh2');
+    expect(plan.sshConfig?.proxyJump).toBe('bastion.example.com');
+    expect(plan.reason).toContain('ssh_proxy_jump');
+  });
+
+  it('should choose ssh2 for direct hostnames', () => {
+    const plan = resolveTunnelPlan(
+      baseSource({
+        ssh_host: 'bastion.example.com',
+        ssh_user: 'ubuntu',
+        ssh_key: '/home/user/.ssh/id_rsa',
+      })
+    );
+
+    expect(plan.mode).toBe('ssh2');
+    expect(plan.sshConfig?.host).toBe('bastion.example.com');
+  });
+
+  it('should choose ssh2 when alias is not found in SSH config', () => {
+    writeFileSync(configPath, '');
+
+    const plan = resolveTunnelPlan(
+      baseSource({
+        ssh_host: 'unknown-alias',
+        ssh_user: 'ubuntu',
+        ssh_key: '/home/user/.ssh/id_rsa',
+      })
+    );
+
+    expect(plan.mode).toBe('ssh2');
+    expect(plan.reason).toContain('not found');
+  });
+
+  it('should force ssh2 when DBHUB_SSH_FORCE_SSH2 is set', () => {
+    writeFileSync(
+      configPath,
+      `
+Host mybastion
+    HostName bastion.example.com
+    User ubuntu
+`
+    );
+    process.env.DBHUB_SSH_FORCE_SSH2 = '1';
+
+    const plan = resolveTunnelPlan(
+      baseSource({
+        ssh_host: 'mybastion',
+        dsn: 'postgres://user:pass@db.internal:5432/mydb',
+      })
+    );
+
+    expect(plan.mode).toBe('ssh2');
+    expect(plan.reason).toContain('DBHUB_SSH_FORCE_SSH2');
+  });
+
+  it('should pass TOML overrides for native mode', () => {
+    writeFileSync(
+      configPath,
+      `
+Host mybastion
+    HostName bastion.example.com
+    User ubuntu
+`
+    );
+
+    const plan = resolveTunnelPlan(
+      baseSource({
+        ssh_host: 'mybastion',
+        dsn: 'postgres://user:pass@db.internal:5432/mydb',
+        ssh_user: 'override-user',
+        ssh_port: 2222,
+        ssh_key: '/custom/key',
+        ssh_keepalive_interval: 60,
+      })
+    );
+
+    expect(plan.mode).toBe('native');
+    expect(plan.overrides).toEqual({
+      user: 'override-user',
+      port: 2222,
+      privateKey: '/custom/key',
+      keepaliveInterval: 60,
+    });
+  });
+});

--- a/src/utils/get-free-port.ts
+++ b/src/utils/get-free-port.ts
@@ -1,0 +1,31 @@
+import { createServer } from 'net';
+
+/**
+ * Find an available TCP port on 127.0.0.1 by binding to port 0.
+ */
+export function getFreePort(host = '127.0.0.1'): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+
+    server.on('error', reject);
+
+    server.listen(0, host, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to allocate a free local port'));
+        return;
+      }
+
+      const { port } = address;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}

--- a/src/utils/native-ssh-tunnel.ts
+++ b/src/utils/native-ssh-tunnel.ts
@@ -1,0 +1,238 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { access } from 'fs/promises';
+import { constants } from 'fs';
+import type {
+  SSHTunnelBackend,
+  SSHTunnelEstablishRequest,
+  SSHTunnelInfo,
+} from '../types/ssh.js';
+import { getFreePort } from './get-free-port.js';
+import { waitForPort } from './wait-for-port.js';
+
+const SSH_CLOSE_TIMEOUT_MS = 5_000;
+const SSH_READY_TIMEOUT_MS = 30_000;
+
+async function fileIsExecutable(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the ssh executable path.
+ * Uses DBHUB_SSH_BIN when set; otherwise assumes `ssh` is on PATH.
+ */
+export async function resolveSshBinary(): Promise<string> {
+  const fromEnv = process.env.DBHUB_SSH_BIN;
+  if (fromEnv) {
+    if (!(await fileIsExecutable(fromEnv))) {
+      throw new Error(
+        `DBHUB_SSH_BIN is set to '${fromEnv}' but the file is not executable`
+      );
+    }
+    return fromEnv;
+  }
+  return 'ssh';
+}
+
+export function buildNativeSshArgs(
+  request: SSHTunnelEstablishRequest,
+  localPort: number
+): string[] {
+  if (!request.hostAlias) {
+    throw new Error('Native SSH tunnel requires hostAlias');
+  }
+
+  const sshConfigPath = request.sshConfigPath;
+  if (!sshConfigPath) {
+    throw new Error('Native SSH tunnel requires sshConfigPath');
+  }
+
+  const args = [
+    '-N',
+    '-F',
+    sshConfigPath,
+    '-L',
+    `127.0.0.1:${localPort}:${request.targetHost}:${request.targetPort}`,
+    '-o',
+    'ExitOnForwardFailure=yes',
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'StrictHostKeyChecking=accept-new',
+  ];
+
+  const overrides = request.overrides;
+  if (overrides?.user) {
+    args.push('-l', overrides.user);
+  }
+  if (overrides?.port !== undefined) {
+    args.push('-p', String(overrides.port));
+  }
+  if (overrides?.privateKey) {
+    args.push('-i', overrides.privateKey);
+  }
+  if (overrides?.keepaliveInterval !== undefined && overrides.keepaliveInterval > 0) {
+    args.push('-o', `ServerAliveInterval=${overrides.keepaliveInterval}`);
+    args.push(
+      '-o',
+      `ServerAliveCountMax=${overrides.keepaliveCountMax ?? 3}`
+    );
+  }
+
+  args.push(request.hostAlias);
+  return args;
+}
+
+/**
+ * SSH tunnel via the system OpenSSH client.
+ * Delegates ProxyJump, ProxyCommand, and per-host auth to ~/.ssh/config.
+ */
+export class NativeSSHTunnel implements SSHTunnelBackend {
+  private child: ChildProcess | null = null;
+  private tunnelInfo: SSHTunnelInfo | null = null;
+  private isConnected = false;
+  private stderrChunks: string[] = [];
+
+  getMode(): 'native' {
+    return 'native';
+  }
+
+  async establish(request: SSHTunnelEstablishRequest): Promise<SSHTunnelInfo> {
+    if (this.isConnected) {
+      throw new Error('SSH tunnel is already established');
+    }
+
+    this.isConnected = true;
+    this.stderrChunks = [];
+
+    const sshBinary = await resolveSshBinary();
+    const localPort = request.localPort ?? (await getFreePort());
+    const args = buildNativeSshArgs(request, localPort);
+    const abortController = new AbortController();
+
+    try {
+      this.child = spawn(sshBinary, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      this.child.stderr?.on('data', (chunk: Buffer) => {
+        const text = chunk.toString('utf8').trim();
+        if (text) {
+          this.stderrChunks.push(text);
+          console.error(`ssh: ${text}`);
+        }
+      });
+
+      const exitPromise = new Promise<never>((_, reject) => {
+        this.child?.once('error', (err) => {
+          abortController.abort();
+          reject(new Error(`Failed to start ssh: ${err.message}`));
+        });
+
+        this.child?.once('exit', (code, signal) => {
+          abortController.abort();
+          const detail = this.formatStderr();
+          if (signal) {
+            reject(
+              new Error(
+                `ssh exited with signal ${signal}${detail ? `: ${detail}` : ''}`
+              )
+            );
+            return;
+          }
+          reject(
+            new Error(
+              `ssh exited with code ${code ?? 'unknown'}${detail ? `: ${detail}` : ''}`
+            )
+          );
+        });
+      });
+
+      await Promise.race([
+        waitForPort(localPort, {
+          timeoutMs: SSH_READY_TIMEOUT_MS,
+          signal: abortController.signal,
+        }),
+        exitPromise,
+      ]);
+
+      this.tunnelInfo = {
+        localPort,
+        targetHost: request.targetHost,
+        targetPort: request.targetPort,
+      };
+
+      console.error(
+        `SSH tunnel established (native): localhost:${localPort} → ${request.targetHost}:${request.targetPort} via ${request.hostAlias}`
+      );
+
+      return this.tunnelInfo;
+    } catch (error) {
+      await this.close();
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.child) {
+      this.isConnected = false;
+      this.tunnelInfo = null;
+      return;
+    }
+
+    const child = this.child;
+    this.child = null;
+    this.tunnelInfo = null;
+    this.isConnected = false;
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+
+      const finish = () => {
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+      };
+
+      const timer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // Ignore errors during forced shutdown
+        }
+        finish();
+      }, SSH_CLOSE_TIMEOUT_MS);
+
+      child.once('exit', () => {
+        clearTimeout(timer);
+        finish();
+      });
+
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        clearTimeout(timer);
+        finish();
+      }
+    });
+
+    console.error('SSH tunnel closed (native)');
+  }
+
+  getTunnelInfo(): SSHTunnelInfo | null {
+    return this.tunnelInfo;
+  }
+
+  getIsConnected(): boolean {
+    return this.isConnected;
+  }
+
+  private formatStderr(): string {
+    return this.stderrChunks.join(' ').trim();
+  }
+}

--- a/src/utils/ssh-tunnel-resolver.ts
+++ b/src/utils/ssh-tunnel-resolver.ts
@@ -1,0 +1,120 @@
+import type { SourceConfig } from '../types/config.js';
+import type { ResolvedTunnelPlan, NativeSSHOverrides, SSHTunnelConfig } from '../types/ssh.js';
+import {
+  parseSSHConfig,
+  looksLikeSSHAlias,
+  getDefaultSSHConfigPath,
+} from './ssh-config-parser.js';
+
+function getSSHConfigPath(): string {
+  return process.env.DBHUB_SSH_CONFIG ?? getDefaultSSHConfigPath();
+}
+
+function isForceSsh2(): boolean {
+  const value = process.env.DBHUB_SSH_FORCE_SSH2;
+  return value === '1' || value?.toLowerCase() === 'true';
+}
+
+function buildOverrides(source: SourceConfig): NativeSSHOverrides | undefined {
+  const overrides: NativeSSHOverrides = {};
+  let hasOverride = false;
+
+  if (source.ssh_user) {
+    overrides.user = source.ssh_user;
+    hasOverride = true;
+  }
+  if (source.ssh_port !== undefined) {
+    overrides.port = source.ssh_port;
+    hasOverride = true;
+  }
+  if (source.ssh_key) {
+    overrides.privateKey = source.ssh_key;
+    hasOverride = true;
+  }
+  if (source.ssh_keepalive_interval !== undefined) {
+    overrides.keepaliveInterval = source.ssh_keepalive_interval;
+    hasOverride = true;
+  }
+  if (source.ssh_keepalive_count_max !== undefined) {
+    overrides.keepaliveCountMax = source.ssh_keepalive_count_max;
+    hasOverride = true;
+  }
+
+  return hasOverride ? overrides : undefined;
+}
+
+function buildSsh2Config(
+  source: SourceConfig,
+  resolvedSSHConfig: SSHTunnelConfig | null
+): SSHTunnelConfig {
+  const username = source.ssh_user || resolvedSSHConfig?.username;
+
+  return {
+    host: resolvedSSHConfig?.host || source.ssh_host!,
+    port: source.ssh_port || resolvedSSHConfig?.port || 22,
+    username: username || '',
+    password: source.ssh_password,
+    privateKey: source.ssh_key || resolvedSSHConfig?.privateKey,
+    passphrase: source.ssh_passphrase,
+    proxyJump: source.ssh_proxy_jump || resolvedSSHConfig?.proxyJump,
+    keepaliveInterval: source.ssh_keepalive_interval,
+    keepaliveCountMax: source.ssh_keepalive_count_max,
+  };
+}
+
+function resolveSSHConfigForHost(host: string, sshConfigPath: string): SSHTunnelConfig | null {
+  if (!looksLikeSSHAlias(host)) {
+    return null;
+  }
+  return parseSSHConfig(host, sshConfigPath);
+}
+
+/**
+ * Decide whether to use native OpenSSH or the built-in ssh2 tunnel.
+ */
+export function resolveTunnelPlan(source: SourceConfig): ResolvedTunnelPlan {
+  const sshConfigPath = getSSHConfigPath();
+  const host = source.ssh_host!;
+
+  if (isForceSsh2()) {
+    const resolvedSSHConfig = resolveSSHConfigForHost(host, sshConfigPath);
+    return {
+      mode: 'ssh2',
+      sshConfigPath,
+      sshConfig: buildSsh2Config(source, resolvedSSHConfig),
+      reason: 'DBHUB_SSH_FORCE_SSH2 is set',
+    };
+  }
+
+  const resolvedSSHConfig = resolveSSHConfigForHost(host, sshConfigPath);
+  const useNative =
+    resolvedSSHConfig !== null &&
+    !source.ssh_password &&
+    !source.ssh_proxy_jump;
+
+  if (useNative) {
+    return {
+      mode: 'native',
+      hostAlias: host,
+      sshConfigPath,
+      overrides: buildOverrides(source),
+      reason: `alias '${host}' found in ${sshConfigPath}`,
+    };
+  }
+
+  let reason = `ssh2 mode for '${host}'`;
+  if (resolvedSSHConfig && source.ssh_password) {
+    reason = 'ssh2 mode: ssh_password is not supported by native SSH';
+  } else if (resolvedSSHConfig && source.ssh_proxy_jump) {
+    reason = 'ssh2 mode: explicit ssh_proxy_jump overrides native SSH';
+  } else if (!resolvedSSHConfig && looksLikeSSHAlias(host)) {
+    reason = `ssh2 mode: alias '${host}' not found in ${sshConfigPath}`;
+  }
+
+  return {
+    mode: 'ssh2',
+    sshConfigPath,
+    sshConfig: buildSsh2Config(source, resolvedSSHConfig),
+    reason,
+  };
+}

--- a/src/utils/ssh-tunnel.ts
+++ b/src/utils/ssh-tunnel.ts
@@ -2,26 +2,52 @@ import { Client, ConnectConfig } from 'ssh2';
 import { readFileSync } from 'fs';
 import { Server, createServer } from 'net';
 import type { Duplex } from 'stream';
-import type { SSHTunnelConfig, SSHTunnelOptions, SSHTunnelInfo, JumpHost } from '../types/ssh.js';
+import type { SSHTunnelConfig, SSHTunnelOptions, SSHTunnelInfo, JumpHost, SSHTunnelBackend, SSHTunnelEstablishRequest } from '../types/ssh.js';
 import { resolveSymlink, parseJumpHosts } from './ssh-config-parser.js';
 
 /**
  * SSH Tunnel implementation for secure database connections.
  * Supports ProxyJump for multi-hop SSH connections through bastion/jump hosts.
  */
-export class SSHTunnel {
+export class SSHTunnel implements SSHTunnelBackend {
   private sshClients: Client[] = []; // All SSH clients in the chain
   private localServer: Server | null = null;
   private tunnelInfo: SSHTunnelInfo | null = null;
   private isConnected: boolean = false;
 
+  getMode(): 'ssh2' {
+    return 'ssh2';
+  }
+
   /**
-   * Establish an SSH tunnel, optionally through jump hosts (ProxyJump).
-   * @param config SSH connection configuration
-   * @param options Tunnel options including target host and port
-   * @returns Promise resolving to tunnel information including local port
+   * Establish an SSH tunnel via ssh2 (supports ProxyJump multi-hop).
    */
   async establish(
+    config: SSHTunnelConfig,
+    options: SSHTunnelOptions
+  ): Promise<SSHTunnelInfo>;
+  async establish(request: SSHTunnelEstablishRequest): Promise<SSHTunnelInfo>;
+  async establish(
+    configOrRequest: SSHTunnelConfig | SSHTunnelEstablishRequest,
+    options?: SSHTunnelOptions
+  ): Promise<SSHTunnelInfo> {
+    if (options !== undefined) {
+      return this.doEstablish(configOrRequest as SSHTunnelConfig, options);
+    }
+
+    const request = configOrRequest as SSHTunnelEstablishRequest;
+    if (!request.sshConfig) {
+      throw new Error('ssh2 tunnel requires sshConfig in establish request');
+    }
+
+    return this.doEstablish(request.sshConfig, {
+      targetHost: request.targetHost,
+      targetPort: request.targetPort,
+      localPort: request.localPort,
+    });
+  }
+
+  private async doEstablish(
     config: SSHTunnelConfig,
     options: SSHTunnelOptions
   ): Promise<SSHTunnelInfo> {

--- a/src/utils/wait-for-port.ts
+++ b/src/utils/wait-for-port.ts
@@ -1,0 +1,70 @@
+import { connect } from 'net';
+
+export interface WaitForPortOptions {
+  host?: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Poll until a TCP port accepts connections or timeout/abort.
+ */
+export function waitForPort(port: number, options: WaitForPortOptions = {}): Promise<void> {
+  const host = options.host ?? '127.0.0.1';
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const intervalMs = options.intervalMs ?? 100;
+  const signal = options.signal;
+  const deadline = Date.now() + timeoutMs;
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      reject(new Error(`Timed out waiting for ${host}:${port} to accept connections`));
+    };
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+
+    const tryConnect = () => {
+      if (signal?.aborted) {
+        return;
+      }
+
+      if (Date.now() >= deadline) {
+        signal?.removeEventListener('abort', onAbort);
+        reject(new Error(`Timed out waiting for ${host}:${port} to accept connections`));
+        return;
+      }
+
+      const socket = connect({ host, port });
+      socket.setTimeout(1_000);
+
+      const cleanup = () => {
+        socket.removeAllListeners();
+        socket.destroy();
+      };
+
+      socket.once('connect', () => {
+        cleanup();
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      });
+
+      socket.once('error', () => {
+        cleanup();
+        setTimeout(tryConnect, intervalMs);
+      });
+
+      socket.once('timeout', () => {
+        cleanup();
+        setTimeout(tryConnect, intervalMs);
+      });
+    };
+
+    tryConnect();
+  });
+}


### PR DESCRIPTION
## Summary

- **Problem**: When `ssh_host` is a `~/.ssh/config` Host alias (e.g. `target-with-jump` with `ProxyJump mybastion`), DBHub parses the config and re-implements the jump chain via the `ssh2` library. This breaks common setups because:
  - `ProxyJump` values that are themselves aliases (e.g. `mybastion`) are treated as literal hostnames
  - All hops share a single username/key, so different credentials per hop cannot work
  - Behavior diverges from the system `ssh` client
- **Solution**: Automatically spawn the system `ssh` client when `ssh_host` is a resolvable SSH config alias (no `ssh_password`, no explicit `ssh_proxy_jump`). OpenSSH handles ProxyJump, nested aliases, and per-host credentials. The existing `ssh2` implementation remains for direct hosts, password auth, and explicit `ssh_proxy_jump`.
- **Also fixes**: Preserve the original `--ssh-host` alias in single-source CLI mode (instead of replacing it with `HostName`), and map `proxyJump` to `ssh_proxy_jump`.

## Example

`~/.ssh/config`:
```sshconfig
Host mybastion
    HostName bastion.example.com
    User ubuntu
    IdentityFile ~/.ssh/id_rsa

Host target-with-jump
    HostName 10.0.0.5
    User admin
    ProxyJump mybastion
```

`dbhub.toml`:
```toml
[[sources]]
id = "prod_pg"
dsn = "postgres://app_user:secure_password@10.0.1.100:5432/myapp_prod?sslmode=require"
ssh_host = "target-with-jump"
```

Equivalent to: `ssh -N -L 127.0.0.1:<port>:10.0.1.100:5432 target-with-jump`

## Test plan

- [x] Unit tests for tunnel mode resolver
- [x] Unit tests for native SSH arg building
- [x] ConnectorManager routing tests (native vs ssh2)
- [x] Existing `ssh-tunnel.test.ts` still passes
- [ ] Manual: `ssh_host = "target-with-jump"` with nested `ProxyJump mybastion` in `~/.ssh/config`
- [ ] Manual: direct hostname / `ssh_password` / `ssh_proxy_jump` still use ssh2


Made with [Cursor](https://cursor.com)