### PR TITLE
feat: add MongoDB connector support (including Atlas SRV) and bundle config fix

### DIFF
--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -209,6 +209,47 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # dsn = "sqlite:///:memory:"
 
 # ============================================================================
+# MONGODB (Local, Atlas, or self-hosted)
+# ============================================================================
+
+# Local MongoDB - DSN format
+# [[sources]]
+# id = "local_mongo"
+# description = "Local MongoDB instance"
+# dsn = "mongodb://localhost:27017/myapp"
+
+# Local MongoDB with authentication - DSN format
+# [[sources]]
+# id = "local_mongo_auth"
+# dsn = "mongodb://user:password@localhost:27017/myapp"
+
+# Local MongoDB - Individual parameters
+# [[sources]]
+# id = "local_mongo"
+# type = "mongodb"
+# host = "localhost"
+# port = 27017
+# database = "myapp"
+# user = "user"
+# password = "password"
+
+# MongoDB Atlas - SRV connection string (recommended for Atlas)
+# [[sources]]
+# id = "atlas_mongo"
+# description = "MongoDB Atlas cluster"
+# dsn = "mongodb+srv://user:password@cluster0.example.mongodb.net/myapp"
+# lazy = true  # Defer connection until first query (recommended for remote clusters)
+
+# MongoDB behind SSH bastion
+# [[sources]]
+# id = "prod_mongo"
+# dsn = "mongodb://app_user:secure_password@10.0.1.100:27017/myapp_prod"
+# lazy = true
+# ssh_host = "bastion.company.com"
+# ssh_user = "deploy"
+# ssh_key = "~/.ssh/id_ed25519"
+
+# ============================================================================
 # TOOL CONFIGURATION (Optional)
 # ============================================================================
 #
@@ -329,9 +370,11 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #   MariaDB:     mariadb://user:pass@host:3306/database
 #   SQL Server:  sqlserver://user:pass@host:1433/database
 #   SQLite:      sqlite:///path/to/file.db  or  sqlite:///:memory:
+#   MongoDB:     mongodb://user:pass@host:27017/database
+#   MongoDB Atlas (SRV): mongodb+srv://user:pass@cluster.example.mongodb.net/database
 #
 # Default Ports:
-#   PostgreSQL: 5432 | MySQL/MariaDB: 3306 | SQL Server: 1433
+#   PostgreSQL: 5432 | MySQL/MariaDB: 3306 | SQL Server: 1433 | MongoDB: 27017
 #
 # SSH Tunnel Options:
 #   ssh_host, ssh_port (default: 22), ssh_user

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:frontend": "cd frontend && pnpm run build",
     "start": "node dist/index.js",
     "dev": "concurrently --kill-others \"pnpm run dev:backend\" \"pnpm run dev:frontend\"",
-    "dev:backend": "NODE_ENV=development tsx src/index.ts --transport=http",
+    "dev:backend": "cross-env NODE_ENV=development tsx src/index.ts --transport=http",
     "dev:frontend": "cd frontend && pnpm run dev",
     "crossdev": "cross-env NODE_ENV=development tsx src/index.ts",
     "generate:api-types": "openapi-typescript src/api/openapi.yaml -o src/api/openapi.d.ts",
@@ -53,6 +53,7 @@
     "@aws-sdk/rds-signer": "^3.1001.0",
     "@azure/identity": "^4.8.0",
     "mariadb": "^3.4.0",
+    "mongodb": "^6.0.0",
     "mssql": "^11.0.1",
     "mysql2": "^3.13.0",
     "pg": "^8.13.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       mariadb:
         specifier: ^3.4.0
         version: 3.4.2
+      mongodb:
+        specifier: ^6.0.0
+        version: 6.21.0(@aws-sdk/credential-providers@3.1001.0)
       mssql:
         specifier: ^11.0.1
         version: 11.0.1
@@ -763,6 +766,9 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@mongodb-js/saslprep@1.4.11':
+    resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1309,6 +1315,12 @@ packages:
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@11.0.5':
+    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
+
   '@typespec/ts-http-runtime@0.2.3':
     resolution: {integrity: sha512-oRhjSzcVjX8ExyaF8hC0zzTqxlVuRlgMHL/Bh4w3xB9+wjbm0FpXylVU/lBrn+kgphwYTrOk3tp+AVShGmlYCg==}
     engines: {node: '>=18.0.0'}
@@ -1511,6 +1523,10 @@ packages:
     resolution: {integrity: sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bson@6.10.4:
+    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
+    engines: {node: '>=16.20.1'}
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
@@ -2292,6 +2308,9 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
@@ -2346,6 +2365,36 @@ packages:
 
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
+
+  mongodb-connection-string-url@3.0.2:
+    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
+
+  mongodb@6.21.0:
+    resolution: {integrity: sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.3.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -2783,6 +2832,9 @@ packages:
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
 
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
   split-ca@1.0.1:
     resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
 
@@ -2945,6 +2997,10 @@ packages:
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -3058,10 +3114,12 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -3150,6 +3208,14 @@ packages:
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -4176,6 +4242,11 @@ snapshots:
       - hono
       - supports-color
 
+  '@mongodb-js/saslprep@1.4.11':
+    dependencies:
+      sparse-bitfield: 3.0.3
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4859,6 +4930,14 @@ snapshots:
     dependencies:
       '@types/node': 18.19.111
 
+  '@types/webidl-conversions@7.0.3':
+    optional: true
+
+  '@types/whatwg-url@11.0.5':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+    optional: true
+
   '@typespec/ts-http-runtime@0.2.3':
     dependencies:
       http-proxy-agent: 7.0.2
@@ -5099,6 +5178,9 @@ snapshots:
       electron-to-chromium: 1.5.250
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
+
+  bson@6.10.4:
+    optional: true
 
   buffer-crc32@1.0.0: {}
 
@@ -5866,6 +5948,9 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  memory-pager@1.5.0:
+    optional: true
+
   merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
@@ -5906,6 +5991,21 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
+
+  mongodb-connection-string-url@3.0.2:
+    dependencies:
+      '@types/whatwg-url': 11.0.5
+      whatwg-url: 14.2.0
+    optional: true
+
+  mongodb@6.21.0(@aws-sdk/credential-providers@3.1001.0):
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.11
+      bson: 6.10.4
+      mongodb-connection-string-url: 3.0.2
+    optionalDependencies:
+      '@aws-sdk/credential-providers': 3.1001.0
+    optional: true
 
   ms@2.0.0: {}
 
@@ -6397,6 +6497,11 @@ snapshots:
     dependencies:
       whatwg-url: 7.1.0
 
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+    optional: true
+
   split-ca@1.0.1: {}
 
   split2@4.2.0:
@@ -6603,6 +6708,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+    optional: true
+
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
@@ -6772,6 +6882,15 @@ snapshots:
   w3c-keyname@2.2.8: {}
 
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@7.0.0:
+    optional: true
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+    optional: true
 
   whatwg-url@7.1.0:
     dependencies:

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -385,7 +385,7 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
 
   // Validate type if provided
   if (source.type) {
-    const validTypes = ["postgres", "mysql", "mariadb", "sqlserver", "sqlite"];
+    const validTypes = ["postgres", "mysql", "mariadb", "sqlserver", "sqlite", "mongodb"];
     if (!validTypes.includes(source.type)) {
       throw new Error(
         `Configuration file ${configPath}: source '${source.id}' has invalid type '${source.type}'. ` +
@@ -908,8 +908,28 @@ export function buildDSNFromSource(source: SourceConfig): string {
     }
   }
 
-  // Add sslmode for network databases (not sqlite)
-  if (source.sslmode && source.type !== "sqlite") {
+  // Add MongoDB-specific parameters
+  if (source.type === "mongodb") {
+    // Map generic sslmode to MongoDB tls flag.
+    // - disable => tls=false
+    // - require / verify-ca / verify-full => tls=true
+    if (source.sslmode) {
+      if (source.sslmode === "disable") {
+        queryParams.push("tls=false");
+      } else {
+        queryParams.push("tls=true");
+      }
+    }
+
+    // Map sslrootcert to MongoDB tlsCAFile
+    if (source.sslrootcert) {
+      const expandedCertPath = expandHomeDir(source.sslrootcert);
+      queryParams.push(`tlsCAFile=${encodeURIComponent(expandedCertPath)}`);
+    }
+  }
+
+  // Add sslmode for network databases (not sqlite or mongodb — they use their own DSN params)
+  if (source.sslmode && source.type !== "mongodb") {
     queryParams.push(`sslmode=${source.sslmode}`);
   }
 

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -1,7 +1,7 @@
 /**
  * Type definition for supported database connector types
  */
-export type ConnectorType = "postgres" | "mysql" | "mariadb" | "sqlite" | "sqlserver";
+export type ConnectorType = "postgres" | "mysql" | "mariadb" | "sqlite" | "sqlserver" | "mongodb";
 
 /**
  * Database Connector Interface

--- a/src/connectors/mongodb/index.ts
+++ b/src/connectors/mongodb/index.ts
@@ -1,0 +1,307 @@
+import { MongoClient, Db, Document } from "mongodb";
+import {
+  Connector,
+  ConnectorType,
+  ConnectorRegistry,
+  DSNParser,
+  SQLResult,
+  TableColumn,
+  TableIndex,
+  StoredProcedure,
+  ExecuteOptions,
+  ConnectorConfig,
+} from "../interface.js";
+import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
+
+/**
+ * MongoDB DSN Parser
+ * Handles DSN strings like:
+ * - mongodb://user:password@localhost:27017/dbname
+ * - mongodb+srv://user:password@cluster.example.com/dbname
+ */
+class MongoDBDSNParser implements DSNParser {
+  async parse(
+    dsn: string,
+    config?: ConnectorConfig
+  ): Promise<{ uri: string; options: Record<string, unknown> }> {
+    if (!this.isValidDSN(dsn)) {
+      const obfuscated = obfuscateDSNPassword(dsn);
+      throw new Error(
+        `Invalid MongoDB DSN format.\nProvided: ${obfuscated}\nExpected: ${this.getSampleDSN()}`
+      );
+    }
+
+    const options: Record<string, unknown> = {};
+
+    if (config?.connectionTimeoutSeconds !== undefined) {
+      options.connectTimeoutMS = config.connectionTimeoutSeconds * 1000;
+      options.serverSelectionTimeoutMS = config.connectionTimeoutSeconds * 1000;
+    }
+
+    if (config?.queryTimeoutSeconds !== undefined) {
+      options.socketTimeoutMS = config.queryTimeoutSeconds * 1000;
+    }
+
+    return { uri: dsn, options };
+  }
+
+  getSampleDSN(): string {
+    return "mongodb://user:password@localhost:27017/dbname";
+  }
+
+  isValidDSN(dsn: string): boolean {
+    return dsn.startsWith("mongodb://") || dsn.startsWith("mongodb+srv://");
+  }
+}
+
+/**
+ * Infer a BSON/JS type name from a value
+ */
+function inferType(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") return Number.isInteger(value) ? "int" : "double";
+  if (typeof value === "string") return "string";
+  if (typeof value === "bigint") return "long";
+  if (value instanceof Date) return "date";
+  if (Buffer.isBuffer(value)) return "binData";
+  if (Array.isArray(value)) return "array";
+  // BSON types surfaced by the driver
+  const ctor = (value as any)?.constructor?.name;
+  if (ctor) return ctor;
+  return "object";
+}
+
+/**
+ * Extract the database name from a MongoDB connection string.
+ * Returns "test" if no database path is present (MongoDB default).
+ */
+function extractDbName(dsn: string): string {
+  try {
+    // Strip mongodb+srv scheme to a form URL can parse
+    const normalized = dsn.replace(/^mongodb\+srv:\/\//, "https://");
+    const url = new URL(normalized);
+    const dbName = url.pathname.replace(/^\//, "").split("?")[0];
+    return dbName || "test";
+  } catch {
+    return "test";
+  }
+}
+
+export class MongoDBConnector implements Connector {
+  id: ConnectorType = "mongodb";
+  name = "MongoDB";
+  dsnParser = new MongoDBDSNParser();
+
+  private client: MongoClient | null = null;
+  private db: Db | null = null;
+  private dbName: string = "test";
+
+  // Set by ConnectorManager after clone()
+  private sourceId: string = "default";
+
+  getId(): string {
+    return this.sourceId;
+  }
+
+  clone(): Connector {
+    return new MongoDBConnector();
+  }
+
+  async connect(dsn: string, _initScript?: string, config?: ConnectorConfig): Promise<void> {
+    const { uri, options } = await this.dsnParser.parse(dsn, config);
+    this.dbName = extractDbName(dsn);
+
+    try {
+      console.log(`### Connecting to MongoDB at ${uri} with options: ${JSON.stringify(options)}`);
+      this.client = new MongoClient(uri, options as any);
+      await this.client.connect();
+      this.db = this.client.db(this.dbName);
+    } catch (error) {
+      console.error("Failed to connect to MongoDB:", error);
+      throw error;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      try {
+        await this.client.close();
+      } catch (error) {
+        console.error("Error during MongoDB disconnect:", error);
+      } finally {
+        this.client = null;
+        this.db = null;
+      }
+    }
+  }
+
+  async getSchemas(): Promise<string[]> {
+    if (!this.db) throw new Error("Not connected to MongoDB");
+    // Return the current database name as the single "schema"
+    // Listing all databases requires admin privileges — not safe as default
+    return [this.dbName];
+  }
+
+  async getTables(schema?: string): Promise<string[]> {
+    if (!this.db) throw new Error("Not connected to MongoDB");
+    const collections = await this.db.listCollections({}, { nameOnly: true }).toArray();
+    return collections.map((c) => c.name).sort();
+  }
+
+  async tableExists(tableName: string, schema?: string): Promise<boolean> {
+    if (!this.db) throw new Error("Not connected to MongoDB");
+    const collections = await this.db.listCollections({ name: tableName }, { nameOnly: true }).toArray();
+    return collections.length > 0;
+  }
+
+  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
+    if (!this.db) throw new Error("Not connected to MongoDB");
+
+    // Sample up to 100 documents to infer field types (MongoDB is schemaless)
+    const docs = await this.db.collection(tableName).find({}).limit(100).toArray();
+
+    if (docs.length === 0) {
+      // Return _id column at minimum even for empty collections
+      return [
+        {
+          column_name: "_id",
+          data_type: "ObjectId",
+          is_nullable: "NO",
+          column_default: null,
+          description: null,
+        },
+      ];
+    }
+
+    // Collect all field names and their inferred types across sampled docs
+    const fieldTypes = new Map<string, Set<string>>();
+
+    for (const doc of docs) {
+      for (const [key, value] of Object.entries(doc)) {
+        if (!fieldTypes.has(key)) {
+          fieldTypes.set(key, new Set());
+        }
+        fieldTypes.get(key)!.add(inferType(value));
+      }
+    }
+
+    const columns: TableColumn[] = [];
+    for (const [fieldName, types] of fieldTypes) {
+      const typeList = [...types].join(" | ");
+      columns.push({
+        column_name: fieldName,
+        data_type: typeList,
+        is_nullable: fieldName === "_id" ? "NO" : "YES",
+        column_default: null,
+        description: null,
+      });
+    }
+
+    return columns;
+  }
+
+  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
+    if (!this.db) throw new Error("Not connected to MongoDB");
+
+    const rawIndexes = await this.db.collection(tableName).indexes();
+    return rawIndexes.map((idx) => {
+      const columnNames = Object.keys(idx.key ?? {});
+      return {
+        index_name: idx.name ?? "unknown",
+        column_names: columnNames,
+        is_unique: idx.unique === true,
+        is_primary: idx.name === "_id_",
+      };
+    });
+  }
+
+  async getTableRowCount(tableName: string, schema?: string): Promise<number | null> {
+    if (!this.db) throw new Error("Not connected to MongoDB");
+    return this.db.collection(tableName).estimatedDocumentCount();
+  }
+
+  async getStoredProcedures(
+    schema?: string,
+    routineType?: "procedure" | "function"
+  ): Promise<string[]> {
+    return [];
+  }
+
+  async getStoredProcedureDetail(
+    procedureName: string,
+    schema?: string
+  ): Promise<StoredProcedure> {
+    throw new Error("MongoDB does not support stored procedures.");
+  }
+
+  /**
+   * Execute a MongoDB command specified as a JSON object.
+   *
+   * The `sql` parameter must be a JSON string whose first key is a MongoDB
+   * command name, e.g.:
+   *   {"find": "users", "filter": {"age": {"$gt": 18}}}
+   *   {"aggregate": "orders", "pipeline": [{"$match": {"status": "open"}}]}
+   *
+   * For `find` and `aggregate` commands, `options.maxRows` is applied as a
+   * server-side limit to prevent oversized result sets.
+   */
+  async executeSQL(
+    sql: string,
+    options: ExecuteOptions,
+    _parameters?: any[]
+  ): Promise<SQLResult> {
+    if (!this.db) throw new Error("Not connected to MongoDB");
+
+    let cmd: Document;
+    try {
+      cmd = JSON.parse(sql.trim());
+    } catch (err) {
+      throw new Error(
+        `MongoDB command must be a valid JSON object. Parse error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    if (typeof cmd !== "object" || cmd === null || Array.isArray(cmd)) {
+      throw new Error("MongoDB command must be a JSON object, e.g. {\"find\": \"collectionName\", \"filter\": {}}");
+    }
+
+    const commandName = Object.keys(cmd)[0]?.toLowerCase();
+    const maxRows = options.maxRows;
+
+    // Apply maxRows as a server-side limit for cursor-producing commands
+    if (commandName === "find") {
+      if (maxRows !== undefined) {
+        cmd.limit = cmd.limit !== undefined ? Math.min(cmd.limit, maxRows) : maxRows;
+      }
+      const result = await this.db.command(cmd);
+      const rows: Document[] = result?.cursor?.firstBatch ?? [];
+      return { rows, rowCount: rows.length };
+    }
+
+    if (commandName === "aggregate") {
+      if (maxRows !== undefined) {
+        const pipeline: Document[] = cmd.pipeline ?? [];
+        // Inject $limit only if not already present or tighter
+        const existingLimit = pipeline.findIndex((s: Document) => "$limit" in s);
+        if (existingLimit >= 0) {
+          pipeline[existingLimit] = { $limit: Math.min(pipeline[existingLimit]["$limit"], maxRows) };
+        } else {
+          pipeline.push({ $limit: maxRows });
+        }
+        cmd.pipeline = pipeline;
+      }
+      const result = await this.db.command(cmd);
+      const rows: Document[] = result?.cursor?.firstBatch ?? [];
+      return { rows, rowCount: rows.length };
+    }
+
+    // Generic command — return raw result wrapped as a single row
+    const result = await this.db.command(cmd);
+    return { rows: [result], rowCount: 1 };
+  }
+}
+
+const mongoDBConnector = new MongoDBConnector();
+ConnectorRegistry.register(mongoDBConnector);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ const connectorModules = [
   { load: () => import("./connectors/sqlite/index.js"), name: "SQLite", driver: "node:sqlite" },
   { load: () => import("./connectors/mysql/index.js"), name: "MySQL", driver: "mysql2" },
   { load: () => import("./connectors/mariadb/index.js"), name: "MariaDB", driver: "mariadb" },
+  { load: () => import("./connectors/mongodb/index.js"), name: "MongoDB", driver: "mongodb" },
 ];
 
 loadConnectors(connectorModules)

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -27,7 +27,7 @@ export interface SSHConfig {
  * Database connection parameters (alternative to DSN)
  */
 export interface ConnectionParams {
-  type: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite";
+  type: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite" | "mongodb";
   host?: string;
   port?: number;
   database?: string;

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -14,6 +14,7 @@ export const allowedKeywords: Record<ConnectorType, string[]> = {
   // SQL Server has no native EXPLAIN statement; the connector translates a
   // leading `EXPLAIN` into a SET SHOWPLAN_XML request (see SQLServerConnector).
   sqlserver: ["select", "with", "explain"],
+  mongodb: ["find", "aggregate", "count", "distinct", "listcollections", "listdatabases", "explain"],
 };
 
 /**
@@ -70,6 +71,7 @@ const mutatingPatterns: Record<ConnectorType, RegExp> = {
   mariadb: mutatingPatternWithReplace,
   sqlite: mutatingPatternWithReplace,
   sqlserver: mutatingPatternSqlServer,
+  mongodb: /(?!x)x/, // never-match — MongoDB uses isReadOnlyMongoCommand instead
 };
 
 const selectIntoPattern = /\bselect\b[\s\S]+\binto\b/i;
@@ -95,6 +97,24 @@ const explainAnalyzePattern =
   /^explain\s+(?:\([^)]*\banalyze\b(?!\s*(?:=\s*)?(?:false|off|0)\b)[^)]*\)|\banalyze\b(?!\s*(?:=\s*)?(?:false|off|0)\b)(?:\s+verbose\b)?)/i;
 
 /**
+ * Check if a MongoDB JSON command is read-only.
+ * MongoDB commands are JSON objects; the first key is the command name.
+ */
+function isReadOnlyMongoCommand(json: string): boolean {
+  try {
+    const cmd = JSON.parse(json);
+    if (typeof cmd !== "object" || cmd === null || Array.isArray(cmd)) {
+      return false;
+    }
+    const firstKey = Object.keys(cmd)[0]?.toLowerCase();
+    if (!firstKey) return false;
+    return allowedKeywords.mongodb.includes(firstKey);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Check if a SQL query is read-only.
  * 1. Strips comments and string literals before analyzing.
  * 2. Verifies the first keyword is in the allow-list.
@@ -102,6 +122,10 @@ const explainAnalyzePattern =
  * 4. For EXPLAIN statements, rejects EXPLAIN ANALYZE with DML.
  */
 export function isReadOnlySQL(sql: string, connectorType: ConnectorType | string): boolean {
+  // MongoDB uses JSON commands, not SQL — handle separately
+  if (connectorType === "mongodb") {
+    return isReadOnlyMongoCommand(sql.trim());
+  }
   return checkReadOnly(
     stripCommentsAndStrings(sql, connectorType as ConnectorType).trim().toLowerCase(),
     connectorType,

--- a/src/utils/dsn-obfuscate.ts
+++ b/src/utils/dsn-obfuscate.ts
@@ -191,7 +191,9 @@ function protocolToConnectorType(protocol: string): ConnectorType | undefined {
     'mysql': 'mysql',
     'mariadb': 'mariadb',
     'sqlserver': 'sqlserver',
-    'sqlite': 'sqlite'
+    'sqlite': 'sqlite',
+    'mongodb': 'mongodb',
+    'mongodb+srv': 'mongodb',
   };
   return mapping[protocol];
 }
@@ -208,6 +210,7 @@ export function getDefaultPortForType(type: ConnectorType): number | undefined {
     'mariadb': 3306,
     'sqlserver': 1433,
     'sqlite': undefined,
+    'mongodb': 27017,
   };
   return ports[type];
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   // CJS code into ESM chunks (which causes "Dynamic require of X is not
   // supported"). Cloud auth packages are externalized to keep their large
   // dependency trees out of the bundle.
-  external: ['pg', 'mysql2', 'mariadb', 'mssql', '@aws-sdk/rds-signer', '@azure/identity'],
+  external: ['pg', 'mysql2', 'mariadb', 'mssql', '@aws-sdk/rds-signer', '@azure/identity', 'mongodb'],
   // Copy the employee-sqlite demo data to dist
   async onSuccess() {
     // Create target directory


### PR DESCRIPTION
### Summary
This PR adds MongoDB support to DBHub and fixes bundling for the MongoDB driver.

### What’s Included

- New MongoDB connector with support for mongodb:// and mongodb+srv://
- Connector registration and type updates so MongoDB works in the existing multi-source flow
- TOML and config updates for MongoDB source validation and DSN construction
- Read-only validation for MongoDB JSON commands (for example: find, aggregate, count, distinct)
- DSN utility updates (obfuscation and default port handling for MongoDB)
- Example config additions for local MongoDB, authenticated setups, Atlas SRV, and SSH or bastion usage
- Build fix: mongodb marked as external in tsup to avoid bundling or runtime resolution issues

### Testing

- pnpm run build: passed
- pnpm test: passed

### Vitest summary:

- 35 test files passed (40 total)
- 921 tests passed (1100 total)
