### PR TITLE
Add optional 'enabled' field to disable a source without removing it

### DIFF
--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -73,6 +73,8 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # id = "prod_pg"
 # dsn = "postgres://app_user:secure_password@10.0.1.100:5432/myapp_prod?sslmode=require"
 # lazy = true  # Defer connection until first query (avoids startup overhead for remote DBs)
+# enabled = false  # Skip this source entirely at startup: no connection attempt, no tools registered,
+#                  # and any [[tools]] entries targeting this id are dropped too. Default: true
 # connection_timeout = 30
 # # SSH tunnel configuration
 # ssh_host = "bastion.company.com"
@@ -316,6 +318,7 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # Source Fields:
 #   id = "unique_id"           # Required: unique identifier
 #   description = "..."        # Optional: human-readable description
+#   enabled = false             # Skip this source at startup entirely (default: true)
 #   dsn = "..."                # Connection string (or use individual params below)
 #   lazy = true                # Defer connection until first query (default: false)
 #   search_path = "schema1,public"  # PostgreSQL only: comma-separated schemas

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -456,6 +456,139 @@ dsn = "postgres://user:pass@localhost:5432/testdb"
       });
     });
 
+    describe('enabled field', () => {
+      it('should exclude a source with enabled = false from the loaded sources', () => {
+        const tomlContent = `
+[[sources]]
+id = "active_db"
+dsn = "postgres://user:pass@localhost:5432/activedb"
+
+[[sources]]
+id = "disabled_db"
+dsn = "postgres://user:pass@localhost:5432/disableddb"
+enabled = false
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources).toHaveLength(1);
+        expect(result?.sources[0].id).toBe('active_db');
+      });
+
+      it('should include a source when enabled is omitted or true', () => {
+        const tomlContent = `
+[[sources]]
+id = "default_enabled_db"
+dsn = "postgres://user:pass@localhost:5432/db1"
+
+[[sources]]
+id = "explicit_enabled_db"
+dsn = "postgres://user:pass@localhost:5432/db2"
+enabled = true
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources).toHaveLength(2);
+        expect(result?.sources.map((s) => s.id)).toEqual(['default_enabled_db', 'explicit_enabled_db']);
+      });
+
+      it('should drop tools that reference a disabled source instead of failing validation', () => {
+        const tomlContent = `
+[[sources]]
+id = "active_db"
+dsn = "postgres://user:pass@localhost:5432/activedb"
+
+[[sources]]
+id = "disabled_db"
+dsn = "postgres://user:pass@localhost:5432/disableddb"
+enabled = false
+
+[[tools]]
+name = "execute_sql"
+source = "disabled_db"
+readonly = true
+
+[[tools]]
+name = "get_active_users"
+source = "disabled_db"
+description = "Get all active users"
+statement = "SELECT * FROM users WHERE active = true"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources).toHaveLength(1);
+        expect(result?.tools).toEqual([]);
+      });
+
+      it('should keep tools for a still-enabled source when a sibling source is disabled', () => {
+        const tomlContent = `
+[[sources]]
+id = "active_db"
+dsn = "postgres://user:pass@localhost:5432/activedb"
+
+[[sources]]
+id = "disabled_db"
+dsn = "postgres://user:pass@localhost:5432/disableddb"
+enabled = false
+
+[[tools]]
+name = "execute_sql"
+source = "active_db"
+readonly = true
+max_rows = 500
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.tools).toHaveLength(1);
+        expect(result?.tools![0]).toMatchObject({
+          name: 'execute_sql',
+          source: 'active_db',
+          readonly: true,
+          max_rows: 500,
+        });
+      });
+
+      it('should still reject a tool referencing a source id that was never defined (typo), not just silently drop it', () => {
+        const tomlContent = `
+[[sources]]
+id = "active_db"
+dsn = "postgres://user:pass@localhost:5432/activedb"
+
+[[tools]]
+name = "get_active_users"
+source = "actve_db"
+description = "Get all active users"
+statement = "SELECT * FROM users WHERE active = true"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow(/references unknown source 'actve_db'/);
+      });
+
+      it('should reject a non-boolean enabled value instead of silently treating it as enabled', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+enabled = "false"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow(/invalid enabled/);
+      });
+    });
+
     describe('sslmode validation', () => {
       it('should accept sslmode = "disable"', () => {
         const tomlContent = `

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -35,11 +35,22 @@ export function loadTomlConfig(): { sources: SourceConfig[]; tools?: TomlConfig[
 
     // Process first to populate fields from DSN (like type), then validate
     const sources = processSourceConfigs(parsedToml.sources, configPath);
-    validateTomlConfig({ ...parsedToml, sources }, configPath);
+
+    // Tools referencing a disabled source are inert - drop them here so they
+    // don't fail "unknown source" validation or get registered. Only sources
+    // that actually exist and were explicitly disabled are exempted; a tool
+    // pointing at a source id that never existed (e.g. a typo) still hits the
+    // normal "unknown source" validation error below.
+    const disabledSourceIds = new Set(
+      parsedToml.sources.filter((s) => s.enabled === false).map((s) => s.id)
+    );
+    const tools = parsedToml.tools?.filter((tool) => !disabledSourceIds.has(tool.source));
+
+    validateTomlConfig({ ...parsedToml, sources, tools }, configPath);
 
     return {
       sources,
-      tools: parsedToml.tools,
+      tools,
       source: path.basename(configPath),
     };
   } catch (error) {
@@ -394,6 +405,17 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
     }
   }
 
+  // Validate enabled field. Only a strict boolean `false` is treated as
+  // "disabled" by processSourceConfigs' filter, so a non-boolean value (e.g.
+  // a stringified "false" from an env var, or a number) would otherwise be
+  // silently kept enabled instead of surfacing the user's mistake.
+  if (source.enabled !== undefined && typeof source.enabled !== "boolean") {
+    throw new Error(
+      `Configuration file ${configPath}: source '${source.id}' has invalid enabled. ` +
+        `Must be a boolean (true or false).`
+    );
+  }
+
   // Validate AWS IAM auth fields
   if (
     source.aws_iam_auth !== undefined &&
@@ -647,7 +669,9 @@ function processSourceConfigs(
   sources: SourceConfig[],
   configPath: string
 ): SourceConfig[] {
-  return sources.map((source) => {
+  return sources
+    .filter((source) => source.enabled !== false)
+    .map((source) => {
     const processed = { ...source };
 
     // Expand ~ in SSH key path

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -49,6 +49,7 @@ export interface ConnectionParams {
 export interface SourceConfig extends ConnectionParams, SSHConfig {
   id: string;
   description?: string; // Human-readable description of this data source
+  enabled?: boolean; // Set to false to skip this source entirely at startup (default: true)
   dsn?: string;
   connection_timeout?: number; // Connection timeout in seconds
   query_timeout?: number; // Query timeout in seconds (PostgreSQL, MySQL, MariaDB, SQL Server)


### PR DESCRIPTION
## Summary
- Adds an optional `enabled` field to `[[sources]]` in the TOML config. Setting `enabled = false` keeps the block on disk but skips it entirely at startup: no connection attempt, no `execute_sql`/`search_objects` tools registered, and it's absent from the startup summary table.
- Any `[[tools]]` entries targeting a disabled source are dropped too, so you don't have to also comment those out. A tool referencing a source id that was never defined (a typo) still raises the existing "references unknown source" validation error - only sources explicitly marked `enabled = false` are exempted.
- Omitting the field, or setting `enabled = true`, is unchanged from current behavior.
- A non-boolean value (e.g. a stringified `"false"`) is rejected at validation time rather than silently kept enabled.

This is useful for sources that are slow or flaky to connect (SSH-tunneled, IAM/AWS, cert-based auth) when you want to temporarily exclude one from a run without hand-editing/re-adding a multi-line TOML block each time.

## Test plan
- [x] `pnpm test src/config/__tests__/toml-loader.test.ts` - 138/138 passing, including new cases: disabled source excluded from `sources`, default/`enabled = true` unaffected, tools for a disabled source dropped, tools for a still-enabled sibling source kept, typo'd source id still errors, non-boolean `enabled` still errors
- [x] Updated `dbhub.toml.example` with a commented example and quick-reference entry
- [x] Verified hot reload (`config-watcher.ts`) picks up an `enabled` toggle correctly since it does a full disconnect/reconnect using the freshly filtered source list