### PR TITLE
feat: support connection charset/collation for MySQL/MariaDB in dbhub.toml

### DIFF
--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -111,11 +111,13 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # dsn = "mysql://root:mysql@localhost:3306/myapp"
 # timezone = "+09:00"       # How the driver interprets DATETIME values: "Z", "local", or "±HH:MM"
 
-# MySQL with explicit connection charset/collation (MySQL/MariaDB only)
+# MySQL with an explicit connection charset or collation (MySQL/MariaDB only).
+# charset and collation are mutually exclusive — set at most one.
 # [[sources]]
 # id = "local_mysql_charset"
 # dsn = "mysql://root:mysql@localhost:3306/myapp"
-# charset = "utf8mb4_0900_ai_ci"  # Connection charset or collation (e.g. "utf8mb4" or "utf8mb4_0900_ai_ci")
+# charset = "utf8mb4"              # Connection character set (uses its default collation)
+# collation = "utf8mb4_0900_ai_ci"  # Or set an explicit collation instead
 
 # MySQL on AWS RDS with IAM authentication (no password in config)
 # [[sources]]
@@ -326,7 +328,8 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #   lazy = true                # Defer connection until first query (default: false)
 #   search_path = "schema1,public"  # PostgreSQL only: comma-separated schemas
 #   timezone = "+09:00"         # MySQL/MariaDB only: "Z", "local", or "±HH:MM"
-#   charset = "utf8mb4_0900_ai_ci"  # MySQL/MariaDB only: charset or collation name
+#   charset = "utf8mb4"         # MySQL/MariaDB only: connection character set (excl. with collation)
+#   collation = "utf8mb4_0900_ai_ci"  # MySQL/MariaDB only: connection collation (excl. with charset)
 #   aws_iam_auth = true         # Optional: enable AWS RDS IAM auth (postgres/mysql/mariadb)
 #   aws_region = "eu-west-1"    # Required when aws_iam_auth = true
 #

--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -111,13 +111,13 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # dsn = "mysql://root:mysql@localhost:3306/myapp"
 # timezone = "+09:00"       # How the driver interprets DATETIME values: "Z", "local", or "±HH:MM"
 
-# MySQL with an explicit connection charset or collation (MySQL/MariaDB only).
-# charset and collation are mutually exclusive — set at most one.
+# MySQL with an explicit connection charset and/or collation (MySQL/MariaDB only).
+# Set either one, or both together (a collation implies its character set).
 # [[sources]]
 # id = "local_mysql_charset"
 # dsn = "mysql://root:mysql@localhost:3306/myapp"
-# charset = "utf8mb4"              # Connection character set (uses its default collation)
-# collation = "utf8mb4_0900_ai_ci"  # Or set an explicit collation instead
+# charset = "utf8mb4"               # Connection character set (uses its default collation)
+# collation = "utf8mb4_0900_ai_ci"  # Connection collation
 
 # MySQL on AWS RDS with IAM authentication (no password in config)
 # [[sources]]
@@ -328,8 +328,8 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #   lazy = true                # Defer connection until first query (default: false)
 #   search_path = "schema1,public"  # PostgreSQL only: comma-separated schemas
 #   timezone = "+09:00"         # MySQL/MariaDB only: "Z", "local", or "±HH:MM"
-#   charset = "utf8mb4"         # MySQL/MariaDB only: connection character set (excl. with collation)
-#   collation = "utf8mb4_0900_ai_ci"  # MySQL/MariaDB only: connection collation (excl. with charset)
+#   charset = "utf8mb4"         # MySQL/MariaDB only: connection character set
+#   collation = "utf8mb4_0900_ai_ci"  # MySQL/MariaDB only: connection collation
 #   aws_iam_auth = true         # Optional: enable AWS RDS IAM auth (postgres/mysql/mariadb)
 #   aws_region = "eu-west-1"    # Required when aws_iam_auth = true
 #

--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -111,6 +111,12 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # dsn = "mysql://root:mysql@localhost:3306/myapp"
 # timezone = "+09:00"       # How the driver interprets DATETIME values: "Z", "local", or "±HH:MM"
 
+# MySQL with explicit connection charset/collation (MySQL/MariaDB only)
+# [[sources]]
+# id = "local_mysql_charset"
+# dsn = "mysql://root:mysql@localhost:3306/myapp"
+# charset = "utf8mb4_0900_ai_ci"  # Connection charset or collation (e.g. "utf8mb4" or "utf8mb4_0900_ai_ci")
+
 # MySQL on AWS RDS with IAM authentication (no password in config)
 # [[sources]]
 # id = "rds_mysql_iam"
@@ -320,6 +326,7 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #   lazy = true                # Defer connection until first query (default: false)
 #   search_path = "schema1,public"  # PostgreSQL only: comma-separated schemas
 #   timezone = "+09:00"         # MySQL/MariaDB only: "Z", "local", or "±HH:MM"
+#   charset = "utf8mb4_0900_ai_ci"  # MySQL/MariaDB only: charset or collation name
 #   aws_iam_auth = true         # Optional: enable AWS RDS IAM auth (postgres/mysql/mariadb)
 #   aws_region = "eu-west-1"    # Required when aws_iam_auth = true
 #

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -446,9 +446,9 @@ Sources define database connections. Each source represents a database that DBHu
 ### charset
 
 <ParamField path="charset" type="string">
-  Sets the connection character set (e.g. `"utf8mb4"`). The connection uses that character set's default collation.
+  Sets the connection character set (e.g. `"utf8mb4"`). On its own, the connection uses that character set's default collation; combine with `collation` to pick a specific one.
 
-  **MySQL / MariaDB only.** Mutually exclusive with `collation`.
+  **MySQL / MariaDB only.**
 
   ```toml
   [[sources]]
@@ -465,9 +465,9 @@ Sources define database connections. Each source represents a database that DBHu
 ### collation
 
 <ParamField path="collation" type="string">
-  Sets the connection collation (e.g. `"utf8mb4_0900_ai_ci"`), which determines how string literals and comparisons are ordered/compared on the connection (`collation_connection`). A collation already implies its character set.
+  Sets the connection collation (e.g. `"utf8mb4_0900_ai_ci"`), which determines how string literals and comparisons are ordered/compared on the connection (`collation_connection`). Can be set on its own or alongside `charset`; a collation already implies its character set, so when both are given the collation is authoritative.
 
-  **MySQL / MariaDB only.** Mutually exclusive with `charset`.
+  **MySQL / MariaDB only.**
 
   ```toml
   [[sources]]
@@ -783,8 +783,8 @@ default = 10
 | `domain` | string | ❌ | Windows domain (NTLM) |
 | `search_path` | string | ❌ | PostgreSQL schema search path (comma-separated) |
 | `timezone` | string | ❌ | MySQL/MariaDB: `Z`, `local`, or offset like `+09:00` |
-| `charset` | string | ❌ | MySQL/MariaDB: connection character set (`utf8mb4`). Mutually exclusive with `collation` |
-| `collation` | string | ❌ | MySQL/MariaDB: connection collation (`utf8mb4_0900_ai_ci`). Mutually exclusive with `charset` |
+| `charset` | string | ❌ | MySQL/MariaDB: connection character set (`utf8mb4`) |
+| `collation` | string | ❌ | MySQL/MariaDB: connection collation (`utf8mb4_0900_ai_ci`) |
 | `ssh_host` | string | ❌ | SSH server hostname |
 | `ssh_port` | number | ❌ | SSH server port (default: 22) |
 | `ssh_user` | string | ❌ | SSH username |

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -446,18 +446,37 @@ Sources define database connections. Each source represents a database that DBHu
 ### charset
 
 <ParamField path="charset" type="string">
-  Sets the connection character set or collation. Accepts a character set (e.g. `"utf8mb4"`) or a collation (e.g. `"utf8mb4_0900_ai_ci"`).
+  Sets the connection character set (e.g. `"utf8mb4"`). The connection uses that character set's default collation.
 
-  **MySQL / MariaDB only.**
+  **MySQL / MariaDB only.** Mutually exclusive with `collation`.
 
   ```toml
   [[sources]]
   id = "production"
   dsn = "mysql://user:pass@localhost:3306/mydb"
-  charset = "utf8mb4_0900_ai_ci"
+  charset = "utf8mb4"
   ```
 
-  Passed through to the driver's `charset` connection option, which determines the collation used for string literals and comparisons on the connection (`collation_connection`). When unset, the driver uses its built-in default (mysql2 defaults to `utf8mb4_unicode_ci`), which may not match your database's collation. Set this to align the connection collation with your schema (e.g. MySQL 8's `utf8mb4_0900_ai_ci`).
+  <Note>
+  This option is **only available via TOML**. It is not supported as a DSN query parameter.
+  </Note>
+</ParamField>
+
+### collation
+
+<ParamField path="collation" type="string">
+  Sets the connection collation (e.g. `"utf8mb4_0900_ai_ci"`), which determines how string literals and comparisons are ordered/compared on the connection (`collation_connection`). A collation already implies its character set.
+
+  **MySQL / MariaDB only.** Mutually exclusive with `charset`.
+
+  ```toml
+  [[sources]]
+  id = "production"
+  dsn = "mysql://user:pass@localhost:3306/mydb"
+  collation = "utf8mb4_0900_ai_ci"
+  ```
+
+  When neither `charset` nor `collation` is set, the driver uses its built-in default (mysql2 defaults to `utf8mb4_unicode_ci`), which may not match your database's collation. Set this to align the connection collation with your schema (e.g. MySQL 8's `utf8mb4_0900_ai_ci`).
 
   <Note>
   This option is **only available via TOML**. It is not supported as a DSN query parameter.
@@ -764,7 +783,8 @@ default = 10
 | `domain` | string | ❌ | Windows domain (NTLM) |
 | `search_path` | string | ❌ | PostgreSQL schema search path (comma-separated) |
 | `timezone` | string | ❌ | MySQL/MariaDB: `Z`, `local`, or offset like `+09:00` |
-| `charset` | string | ❌ | MySQL/MariaDB: character set (`utf8mb4`) or collation (`utf8mb4_0900_ai_ci`) |
+| `charset` | string | ❌ | MySQL/MariaDB: connection character set (`utf8mb4`). Mutually exclusive with `collation` |
+| `collation` | string | ❌ | MySQL/MariaDB: connection collation (`utf8mb4_0900_ai_ci`). Mutually exclusive with `charset` |
 | `ssh_host` | string | ❌ | SSH server hostname |
 | `ssh_port` | number | ❌ | SSH server port (default: 22) |
 | `ssh_user` | string | ❌ | SSH username |

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -443,6 +443,27 @@ Sources define database connections. Each source represents a database that DBHu
   </Note>
 </ParamField>
 
+### charset
+
+<ParamField path="charset" type="string">
+  Sets the connection character set or collation. Accepts a character set (e.g. `"utf8mb4"`) or a collation (e.g. `"utf8mb4_0900_ai_ci"`).
+
+  **MySQL / MariaDB only.**
+
+  ```toml
+  [[sources]]
+  id = "production"
+  dsn = "mysql://user:pass@localhost:3306/mydb"
+  charset = "utf8mb4_0900_ai_ci"
+  ```
+
+  Passed through to the driver's `charset` connection option, which determines the collation used for string literals and comparisons on the connection (`collation_connection`). When unset, the driver uses its built-in default (mysql2 defaults to `utf8mb4_unicode_ci`), which may not match your database's collation. Set this to align the connection collation with your schema (e.g. MySQL 8's `utf8mb4_0900_ai_ci`).
+
+  <Note>
+  This option is **only available via TOML**. It is not supported as a DSN query parameter.
+  </Note>
+</ParamField>
+
 ### SSH Tunnel Options
 
 <ParamField path="ssh_*" type="group">
@@ -743,6 +764,7 @@ default = 10
 | `domain` | string | ❌ | Windows domain (NTLM) |
 | `search_path` | string | ❌ | PostgreSQL schema search path (comma-separated) |
 | `timezone` | string | ❌ | MySQL/MariaDB: `Z`, `local`, or offset like `+09:00` |
+| `charset` | string | ❌ | MySQL/MariaDB: character set (`utf8mb4`) or collation (`utf8mb4_0900_ai_ci`) |
 | `ssh_host` | string | ❌ | SSH server hostname |
 | `ssh_port` | number | ❌ | SSH server port (default: 22) |
 | `ssh_user` | string | ❌ | SSH username |

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1421,7 +1421,7 @@ collation = ["utf8mb4_0900_ai_ci"]
         expect(() => loadTomlConfig()).toThrow('invalid collation');
       });
 
-      it('should throw error when both charset and collation are set', () => {
+      it('should accept charset and collation together', () => {
         const tomlContent = `
 [[sources]]
 id = "test_db"
@@ -1431,7 +1431,11 @@ collation = "utf8mb4_0900_ai_ci"
 `;
         fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
 
-        expect(() => loadTomlConfig()).toThrow("sets both 'charset' and 'collation'");
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].charset).toBe('utf8mb4');
+        expect(result?.sources[0].collation).toBe('utf8mb4_0900_ai_ci');
       });
 
       it('should work without collation (optional field)', () => {

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1303,21 +1303,6 @@ charset = "utf8mb4"
         expect(result?.sources[0].charset).toBe('utf8mb4');
       });
 
-      it('should accept a collation name for a MariaDB source', () => {
-        const tomlContent = `
-[[sources]]
-id = "test_db"
-dsn = "mariadb://user:pass@localhost:3306/testdb"
-charset = "utf8mb4_0900_ai_ci"
-`;
-        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
-
-        const result = loadTomlConfig();
-
-        expect(result).toBeTruthy();
-        expect(result?.sources[0].charset).toBe('utf8mb4_0900_ai_ci');
-      });
-
       it('should throw error when charset is used with non-MySQL/MariaDB source', () => {
         const tomlContent = `
 [[sources]]
@@ -1366,6 +1351,101 @@ dsn = "mysql://user:pass@localhost:3306/testdb"
 
         expect(result).toBeTruthy();
         expect(result?.sources[0].charset).toBeUndefined();
+      });
+    });
+
+    describe('collation validation', () => {
+      it('should accept a collation name for a MySQL source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+collation = "utf8mb4_0900_ai_ci"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].collation).toBe('utf8mb4_0900_ai_ci');
+      });
+
+      it('should accept a collation name for a MariaDB source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mariadb://user:pass@localhost:3306/testdb"
+collation = "utf8mb4_unicode_ci"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].collation).toBe('utf8mb4_unicode_ci');
+      });
+
+      it('should throw error when collation is used with non-MySQL/MariaDB source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+collation = "utf8mb4_0900_ai_ci"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('only supported for MySQL and MariaDB');
+      });
+
+      it('should throw error for empty collation', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+collation = ""
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('invalid collation');
+      });
+
+      it('should throw error for non-string collation (TOML array)', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+collation = ["utf8mb4_0900_ai_ci"]
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('invalid collation');
+      });
+
+      it('should throw error when both charset and collation are set', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+charset = "utf8mb4"
+collation = "utf8mb4_0900_ai_ci"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow("sets both 'charset' and 'collation'");
+      });
+
+      it('should work without collation (optional field)', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].collation).toBeUndefined();
       });
     });
 

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1287,6 +1287,88 @@ dsn = "mysql://user:pass@localhost:3306/testdb"
       });
     });
 
+    describe('charset validation', () => {
+      it('should accept a charset name for a MySQL source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+charset = "utf8mb4"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].charset).toBe('utf8mb4');
+      });
+
+      it('should accept a collation name for a MariaDB source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mariadb://user:pass@localhost:3306/testdb"
+charset = "utf8mb4_0900_ai_ci"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].charset).toBe('utf8mb4_0900_ai_ci');
+      });
+
+      it('should throw error when charset is used with non-MySQL/MariaDB source', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+charset = "utf8mb4"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('only supported for MySQL and MariaDB');
+      });
+
+      it('should throw error for empty charset', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+charset = ""
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('invalid charset');
+      });
+
+      it('should throw error for non-string charset (TOML array)', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+charset = ["utf8mb4"]
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow('invalid charset');
+      });
+
+      it('should work without charset (optional field)', () => {
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/testdb"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        const result = loadTomlConfig();
+
+        expect(result).toBeTruthy();
+        expect(result?.sources[0].charset).toBeUndefined();
+      });
+    });
+
   });
 
   describe('buildDSNFromSource', () => {

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -661,15 +661,6 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
     }
   }
 
-  // charset and collation are mutually exclusive: a collation already implies its
-  // character set, and the drivers resolve the connection to a single collation id.
-  if (source.charset !== undefined && source.collation !== undefined) {
-    throw new Error(
-      `Configuration file ${configPath}: source '${source.id}' sets both 'charset' and 'collation'. ` +
-        `Set only one — a collation already implies its character set.`
-    );
-  }
-
   // Reject readonly and max_rows at source level (they should be set on tools instead)
   if ((source as any).readonly !== undefined) {
     throw new Error(

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -625,6 +625,26 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
     }
   }
 
+  // Validate charset (MySQL/MariaDB only)
+  if (source.charset !== undefined) {
+    if (source.type !== "mysql" && source.type !== "mariadb") {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has 'charset' but it is only supported for MySQL and MariaDB sources.`
+      );
+    }
+    // Accepts a character set (e.g. "utf8mb4") or a collation (e.g. "utf8mb4_0900_ai_ci").
+    // The set of valid names is large and depends on the driver and server version,
+    // so we only require a non-empty string here; the driver rejects unknown names at
+    // connect time. The typeof guard also rejects non-strings (e.g. a TOML array like
+    // ["utf8mb4"]) before they reach the driver.
+    if (typeof source.charset !== "string" || source.charset.trim() === "") {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has invalid charset '${source.charset}'. ` +
+          `Must be a non-empty string naming a character set (e.g. "utf8mb4") or collation (e.g. "utf8mb4_0900_ai_ci").`
+      );
+    }
+  }
+
   // Reject readonly and max_rows at source level (they should be set on tools instead)
   if ((source as any).readonly !== undefined) {
     throw new Error(

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -632,17 +632,42 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
         `Configuration file ${configPath}: source '${source.id}' has 'charset' but it is only supported for MySQL and MariaDB sources.`
       );
     }
-    // Accepts a character set (e.g. "utf8mb4") or a collation (e.g. "utf8mb4_0900_ai_ci").
-    // The set of valid names is large and depends on the driver and server version,
-    // so we only require a non-empty string here; the driver rejects unknown names at
-    // connect time. The typeof guard also rejects non-strings (e.g. a TOML array like
-    // ["utf8mb4"]) before they reach the driver.
+    // The set of valid character sets is large and server-version dependent, so we
+    // only require a non-empty string here; the driver rejects unknown names at
+    // connect time. The typeof guard also rejects non-strings (e.g. a TOML array
+    // like ["utf8mb4"]) before they reach the driver.
     if (typeof source.charset !== "string" || source.charset.trim() === "") {
       throw new Error(
         `Configuration file ${configPath}: source '${source.id}' has invalid charset '${source.charset}'. ` +
-          `Must be a non-empty string naming a character set (e.g. "utf8mb4") or collation (e.g. "utf8mb4_0900_ai_ci").`
+          `Must be a non-empty string naming a character set (e.g. "utf8mb4").`
       );
     }
+  }
+
+  // Validate collation (MySQL/MariaDB only)
+  if (source.collation !== undefined) {
+    if (source.type !== "mysql" && source.type !== "mariadb") {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has 'collation' but it is only supported for MySQL and MariaDB sources.`
+      );
+    }
+    // As with charset, the set of valid collations is large and server-version
+    // dependent, so we only require a non-empty string; the driver validates the name.
+    if (typeof source.collation !== "string" || source.collation.trim() === "") {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has invalid collation '${source.collation}'. ` +
+          `Must be a non-empty string naming a collation (e.g. "utf8mb4_0900_ai_ci").`
+      );
+    }
+  }
+
+  // charset and collation are mutually exclusive: a collation already implies its
+  // character set, and the drivers resolve the connection to a single collation id.
+  if (source.charset !== undefined && source.collation !== undefined) {
+    throw new Error(
+      `Configuration file ${configPath}: source '${source.id}' sets both 'charset' and 'collation'. ` +
+        `Set only one — a collation already implies its character set.`
+    );
   }
 
   // Reject readonly and max_rows at source level (they should be set on tools instead)

--- a/src/connectors/__tests__/mariadb.integration.test.ts
+++ b/src/connectors/__tests__/mariadb.integration.test.ts
@@ -475,6 +475,48 @@ describe('MariaDB Connector Integration Tests', () => {
     });
   });
 
+  describe('charset / collation configuration', () => {
+    it('should set the connection collation from the configured collation', async () => {
+      const connector = new MariaDBConnector();
+      try {
+        await connector.connect(mariadbTest.connectionString, undefined, {
+          collation: 'utf8mb4_unicode_ci',
+        });
+
+        const result = await connector.executeSQL(
+          'SELECT @@session.collation_connection AS collation',
+          {}
+        );
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0].collation).toBe('utf8mb4_unicode_ci');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should honor charset and collation set together', async () => {
+      const connector = new MariaDBConnector();
+      try {
+        await connector.connect(mariadbTest.connectionString, undefined, {
+          charset: 'utf8mb4',
+          collation: 'utf8mb4_unicode_ci',
+        });
+
+        const result = await connector.executeSQL(
+          'SELECT @@session.character_set_connection AS charset, @@session.collation_connection AS collation',
+          {}
+        );
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0].charset).toBe('utf8mb4');
+        expect(result.rows[0].collation).toBe('utf8mb4_unicode_ci');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+  });
+
   describe('Per-tool readonly engine backstop (options.readonly)', () => {
     // The READ ONLY transaction reliably blocks DML. (DDL like DROP performs an
     // implicit commit and escapes the transaction; stacked-DDL payloads such as

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -460,6 +460,29 @@ describe('MySQL Connector Integration Tests', () => {
     });
   });
 
+  describe('charset configuration', () => {
+    it('should set the connection collation from the configured charset', async () => {
+      const connector = new MySQLConnector();
+      try {
+        // utf8mb4_general_ci differs from mysql2's built-in default
+        // (utf8mb4_unicode_ci), so a match proves the option took effect.
+        await connector.connect(mysqlTest.connectionString, undefined, {
+          charset: 'utf8mb4_general_ci',
+        });
+
+        const result = await connector.executeSQL(
+          'SELECT @@session.collation_connection AS collation',
+          {}
+        );
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0].collation).toBe('utf8mb4_general_ci');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+  });
+
   describe('Per-tool readonly engine backstop (options.readonly)', () => {
     // The READ ONLY transaction reliably blocks DML. (DDL like DROP performs an
     // implicit commit and escapes the transaction; stacked-DDL payloads such as

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -501,6 +501,27 @@ describe('MySQL Connector Integration Tests', () => {
         await connector.disconnect();
       }
     });
+
+    it('should honor charset and collation set together', async () => {
+      const connector = new MySQLConnector();
+      try {
+        await connector.connect(mysqlTest.connectionString, undefined, {
+          charset: 'utf8mb4',
+          collation: 'utf8mb4_0900_ai_ci',
+        });
+
+        const result = await connector.executeSQL(
+          'SELECT @@session.character_set_connection AS charset, @@session.collation_connection AS collation',
+          {}
+        );
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0].charset).toBe('utf8mb4');
+        expect(result.rows[0].collation).toBe('utf8mb4_0900_ai_ci');
+      } finally {
+        await connector.disconnect();
+      }
+    });
   });
 
   describe('Per-tool readonly engine backstop (options.readonly)', () => {

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -460,14 +460,15 @@ describe('MySQL Connector Integration Tests', () => {
     });
   });
 
-  describe('charset configuration', () => {
-    it('should set the connection collation from the configured charset', async () => {
+  describe('charset / collation configuration', () => {
+    it('should use the charset default collation when charset is configured', async () => {
       const connector = new MySQLConnector();
       try {
-        // utf8mb4_general_ci differs from mysql2's built-in default
-        // (utf8mb4_unicode_ci), so a match proves the option took effect.
+        // mysql2 maps charset "utf8mb4" to its default collation utf8mb4_general_ci,
+        // which differs from mysql2's built-in default (utf8mb4_unicode_ci), so a
+        // match proves the option took effect.
         await connector.connect(mysqlTest.connectionString, undefined, {
-          charset: 'utf8mb4_general_ci',
+          charset: 'utf8mb4',
         });
 
         const result = await connector.executeSQL(
@@ -477,6 +478,25 @@ describe('MySQL Connector Integration Tests', () => {
 
         expect(result.rows).toHaveLength(1);
         expect(result.rows[0].collation).toBe('utf8mb4_general_ci');
+      } finally {
+        await connector.disconnect();
+      }
+    });
+
+    it('should set the connection collation from the configured collation', async () => {
+      const connector = new MySQLConnector();
+      try {
+        await connector.connect(mysqlTest.connectionString, undefined, {
+          collation: 'utf8mb4_0900_ai_ci',
+        });
+
+        const result = await connector.executeSQL(
+          'SELECT @@session.collation_connection AS collation',
+          {}
+        );
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0].collation).toBe('utf8mb4_0900_ai_ci');
       } finally {
         await connector.disconnect();
       }

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -98,6 +98,14 @@ export interface ConnectorConfig {
    * Passed through to the mysql2 `timezone` connection option.
    */
   timezone?: string;
+  /**
+   * MySQL/MariaDB connection character set or collation.
+   * Accepts a character set (e.g. "utf8mb4") or a collation (e.g. "utf8mb4_0900_ai_ci").
+   * Passed through to the driver's `charset` connection option, which sets the
+   * connection collation used for string literals and comparisons. When unset,
+   * the driver falls back to its built-in default (mysql2: `utf8mb4_unicode_ci`).
+   */
+  charset?: string;
 }
 
 /**

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -107,8 +107,9 @@ export interface ConnectorConfig {
   /**
    * MySQL/MariaDB connection collation (e.g. "utf8mb4_0900_ai_ci").
    * Sets the collation used for string literals and comparisons on the connection.
-   * May be set on its own or together with `charset`. When neither is set, the
-   * driver falls back to its built-in default (mysql2: `utf8mb4_unicode_ci`).
+   * May be set on its own or together with `charset`; when both are set, the
+   * collation takes precedence (it implies its character set). When neither is
+   * set, the driver falls back to its built-in default (mysql2: `utf8mb4_unicode_ci`).
    */
   collation?: string;
 }

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -100,16 +100,15 @@ export interface ConnectorConfig {
   timezone?: string;
   /**
    * MySQL/MariaDB connection character set (e.g. "utf8mb4").
-   * The connection uses that character set's default collation.
-   * Mutually exclusive with `collation`.
+   * May be set on its own (the character set's default collation is used) or
+   * together with `collation`.
    */
   charset?: string;
   /**
    * MySQL/MariaDB connection collation (e.g. "utf8mb4_0900_ai_ci").
-   * Sets the exact collation used for string literals and comparisons on the
-   * connection; a collation already implies its character set. Mutually exclusive
-   * with `charset`. When neither is set, the driver falls back to its built-in
-   * default (mysql2: `utf8mb4_unicode_ci`).
+   * Sets the collation used for string literals and comparisons on the connection.
+   * May be set on its own or together with `charset`. When neither is set, the
+   * driver falls back to its built-in default (mysql2: `utf8mb4_unicode_ci`).
    */
   collation?: string;
 }

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -99,13 +99,19 @@ export interface ConnectorConfig {
    */
   timezone?: string;
   /**
-   * MySQL/MariaDB connection character set or collation.
-   * Accepts a character set (e.g. "utf8mb4") or a collation (e.g. "utf8mb4_0900_ai_ci").
-   * Passed through to the driver's `charset` connection option, which sets the
-   * connection collation used for string literals and comparisons. When unset,
-   * the driver falls back to its built-in default (mysql2: `utf8mb4_unicode_ci`).
+   * MySQL/MariaDB connection character set (e.g. "utf8mb4").
+   * The connection uses that character set's default collation.
+   * Mutually exclusive with `collation`.
    */
   charset?: string;
+  /**
+   * MySQL/MariaDB connection collation (e.g. "utf8mb4_0900_ai_ci").
+   * Sets the exact collation used for string literals and comparisons on the
+   * connection; a collation already implies its character set. Mutually exclusive
+   * with `charset`. When neither is set, the driver falls back to its built-in
+   * default (mysql2: `utf8mb4_unicode_ci`).
+   */
+  collation?: string;
 }
 
 /**

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -273,6 +273,10 @@ export class ConnectorManager {
     if (source.timezone) {
       config.timezone = source.timezone;
     }
+    // Pass charset (character set or collation) for MySQL/MariaDB
+    if (source.charset) {
+      config.charset = source.charset;
+    }
 
     // Connect to the database with config and optional init script
     await connector.connect(actualDSN, source.init_script, config);

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -273,7 +273,7 @@ export class ConnectorManager {
     if (source.timezone) {
       config.timezone = source.timezone;
     }
-    // Pass charset / collation for MySQL/MariaDB (mutually exclusive)
+    // Pass charset / collation for MySQL/MariaDB (either, or both together)
     if (source.charset) {
       config.charset = source.charset;
     }

--- a/src/connectors/manager.ts
+++ b/src/connectors/manager.ts
@@ -273,9 +273,12 @@ export class ConnectorManager {
     if (source.timezone) {
       config.timezone = source.timezone;
     }
-    // Pass charset (character set or collation) for MySQL/MariaDB
+    // Pass charset / collation for MySQL/MariaDB (mutually exclusive)
     if (source.charset) {
       config.charset = source.charset;
+    }
+    if (source.collation) {
+      config.collation = source.collation;
     }
 
     // Connect to the database with config and optional init script

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -61,6 +61,11 @@ class MariadbDSNParser implements DSNParser {
         ...(config?.timezone !== undefined && {
           timezone: config.timezone
         }),
+        // Connection character set or collation ("utf8mb4" or "utf8mb4_0900_ai_ci").
+        // The mariadb driver accepts either a charset or a collation name here.
+        ...(config?.charset !== undefined && {
+          charset: config.charset
+        }),
       };
 
       // Handle query parameters

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -61,10 +61,14 @@ class MariadbDSNParser implements DSNParser {
         ...(config?.timezone !== undefined && {
           timezone: config.timezone
         }),
-        // Connection character set or collation ("utf8mb4" or "utf8mb4_0900_ai_ci").
-        // The mariadb driver accepts either a charset or a collation name here.
+        // Connection character set (e.g. "utf8mb4") and/or collation (e.g.
+        // "utf8mb4_0900_ai_ci"). The mariadb driver exposes both as distinct
+        // options; they are mutually exclusive here, so at most one is set.
         ...(config?.charset !== undefined && {
           charset: config.charset
+        }),
+        ...(config?.collation !== undefined && {
+          collation: config.collation
         }),
       };
 

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -61,15 +61,17 @@ class MariadbDSNParser implements DSNParser {
         ...(config?.timezone !== undefined && {
           timezone: config.timezone
         }),
-        // Connection character set (e.g. "utf8mb4") and/or collation (e.g.
-        // "utf8mb4_0900_ai_ci"). The mariadb driver exposes both as distinct
-        // options; they are mutually exclusive here, so at most one is set.
-        ...(config?.charset !== undefined && {
-          charset: config.charset
-        }),
-        ...(config?.collation !== undefined && {
-          collation: config.collation
-        }),
+        // Connection character set (e.g. "utf8mb4") / collation (e.g.
+        // "utf8mb4_general_ci"). The mariadb driver exposes both as distinct
+        // options, but a configured collation is authoritative (it implies its
+        // character set) and the driver ignores `collation` when `charset` is also
+        // passed. So forward the collation when present, otherwise the charset
+        // (which uses that character set's default collation).
+        ...(config?.collation !== undefined
+          ? { collation: config.collation }
+          : config?.charset !== undefined
+            ? { charset: config.charset }
+            : {}),
       };
 
       // Handle query parameters

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -29,8 +29,9 @@ import { quoteIdentifier } from "../../utils/identifier-quoter.js";
 class MySQLDSNParser implements DSNParser {
   async parse(dsn: string, config?: ConnectorConfig): Promise<mysql.ConnectionOptions> {
     const connectionTimeoutSeconds = config?.connectionTimeoutSeconds;
-    // Capture this before the local `config` (mysql.ConnectionOptions) shadows the param below
+    // Capture these before the local `config` (mysql.ConnectionOptions) shadows the param below
     const timezone = config?.timezone;
+    const charset = config?.charset;
     // Basic validation
     if (!this.isValidDSN(dsn)) {
       const obfuscatedDSN = obfuscateDSNPassword(dsn);
@@ -80,6 +81,13 @@ class MySQLDSNParser implements DSNParser {
       // produce an incorrect instant when the server timezone differs from the data's.
       if (timezone !== undefined) {
         config.timezone = timezone;
+      }
+
+      // Apply charset if specified: sets the connection character set / collation
+      // (e.g. "utf8mb4" or "utf8mb4_0900_ai_ci"). mysql2 accepts either a charset
+      // or a collation name here. Without it, mysql2 defaults to utf8mb4_unicode_ci.
+      if (charset !== undefined) {
+        config.charset = charset;
       }
 
       // Auto-detect AWS IAM authentication tokens and configure cleartext plugin

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -32,6 +32,7 @@ class MySQLDSNParser implements DSNParser {
     // Capture these before the local `config` (mysql.ConnectionOptions) shadows the param below
     const timezone = config?.timezone;
     const charset = config?.charset;
+    const collation = config?.collation;
     // Basic validation
     if (!this.isValidDSN(dsn)) {
       const obfuscatedDSN = obfuscateDSNPassword(dsn);
@@ -83,10 +84,14 @@ class MySQLDSNParser implements DSNParser {
         config.timezone = timezone;
       }
 
-      // Apply charset if specified: sets the connection character set / collation
-      // (e.g. "utf8mb4" or "utf8mb4_0900_ai_ci"). mysql2 accepts either a charset
-      // or a collation name here. Without it, mysql2 defaults to utf8mb4_unicode_ci.
-      if (charset !== undefined) {
+      // Apply charset / collation if specified. mysql2 exposes a single `charset`
+      // connection option that accepts either a character set (e.g. "utf8mb4") or a
+      // collation (e.g. "utf8mb4_0900_ai_ci") name — see its typings. charset and
+      // collation are mutually exclusive upstream, so at most one is set here.
+      // Without either, mysql2 defaults to utf8mb4_unicode_ci.
+      if (collation !== undefined) {
+        config.charset = collation;
+      } else if (charset !== undefined) {
         config.charset = charset;
       }
 

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -85,14 +85,17 @@ class MySQLDSNParser implements DSNParser {
       }
 
       // Apply charset / collation if specified. mysql2 exposes a single `charset`
-      // connection option that accepts either a character set (e.g. "utf8mb4") or a
-      // collation (e.g. "utf8mb4_0900_ai_ci") name — see its typings. charset and
-      // collation are mutually exclusive upstream, so at most one is set here.
-      // Without either, mysql2 defaults to utf8mb4_unicode_ci.
-      if (collation !== undefined) {
-        config.charset = collation;
-      } else if (charset !== undefined) {
-        config.charset = charset;
+      // connection option (it has no separate `collation` option) that accepts
+      // either a character set (e.g. "utf8mb4") or a collation (e.g.
+      // "utf8mb4_0900_ai_ci") name — see its typings. Both resolve to one
+      // connection collation id: a collation implies its character set, so when a
+      // collation is configured we pass that (it sets both character_set_connection
+      // and collation_connection); otherwise we pass the charset (which uses that
+      // character set's default collation). Without either, mysql2 defaults to
+      // utf8mb4_unicode_ci.
+      const charsetOrCollation = collation ?? charset;
+      if (charsetOrCollation !== undefined) {
+        config.charset = charsetOrCollation;
       }
 
       // Auto-detect AWS IAM authentication tokens and configure cleartext plugin

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -56,8 +56,8 @@ export interface SourceConfig extends ConnectionParams, SSHConfig {
   lazy?: boolean; // Defer connection until first query (default: false)
   search_path?: string; // Comma-separated list of schemas for PostgreSQL search_path (e.g., "myschema,public")
   timezone?: string; // MySQL/MariaDB: how the driver interprets DATETIME values. "Z" (UTC), "local", or "±HH:MM" (e.g., "+09:00")
-  charset?: string; // MySQL/MariaDB: connection character set (e.g., "utf8mb4"). May be combined with collation.
-  collation?: string; // MySQL/MariaDB: connection collation (e.g., "utf8mb4_0900_ai_ci"). May be combined with charset.
+  charset?: string; // MySQL/MariaDB: connection character set (e.g., "utf8mb4"). May be combined with collation; when both are set, collation takes precedence (it implies its character set).
+  collation?: string; // MySQL/MariaDB: connection collation (e.g., "utf8mb4_0900_ai_ci"). Takes precedence over charset when both are set.
 }
 
 /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -56,7 +56,8 @@ export interface SourceConfig extends ConnectionParams, SSHConfig {
   lazy?: boolean; // Defer connection until first query (default: false)
   search_path?: string; // Comma-separated list of schemas for PostgreSQL search_path (e.g., "myschema,public")
   timezone?: string; // MySQL/MariaDB: how the driver interprets DATETIME values. "Z" (UTC), "local", or "±HH:MM" (e.g., "+09:00")
-  charset?: string; // MySQL/MariaDB: connection character set or collation (e.g., "utf8mb4" or "utf8mb4_0900_ai_ci")
+  charset?: string; // MySQL/MariaDB: connection character set (e.g., "utf8mb4"). Mutually exclusive with collation.
+  collation?: string; // MySQL/MariaDB: connection collation (e.g., "utf8mb4_0900_ai_ci"). Mutually exclusive with charset.
 }
 
 /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -56,6 +56,7 @@ export interface SourceConfig extends ConnectionParams, SSHConfig {
   lazy?: boolean; // Defer connection until first query (default: false)
   search_path?: string; // Comma-separated list of schemas for PostgreSQL search_path (e.g., "myschema,public")
   timezone?: string; // MySQL/MariaDB: how the driver interprets DATETIME values. "Z" (UTC), "local", or "±HH:MM" (e.g., "+09:00")
+  charset?: string; // MySQL/MariaDB: connection character set or collation (e.g., "utf8mb4" or "utf8mb4_0900_ai_ci")
 }
 
 /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -56,8 +56,8 @@ export interface SourceConfig extends ConnectionParams, SSHConfig {
   lazy?: boolean; // Defer connection until first query (default: false)
   search_path?: string; // Comma-separated list of schemas for PostgreSQL search_path (e.g., "myschema,public")
   timezone?: string; // MySQL/MariaDB: how the driver interprets DATETIME values. "Z" (UTC), "local", or "±HH:MM" (e.g., "+09:00")
-  charset?: string; // MySQL/MariaDB: connection character set (e.g., "utf8mb4"). Mutually exclusive with collation.
-  collation?: string; // MySQL/MariaDB: connection collation (e.g., "utf8mb4_0900_ai_ci"). Mutually exclusive with charset.
+  charset?: string; // MySQL/MariaDB: connection character set (e.g., "utf8mb4"). May be combined with collation.
+  collation?: string; // MySQL/MariaDB: connection collation (e.g., "utf8mb4_0900_ai_ci"). May be combined with charset.
 }
 
 /**


### PR DESCRIPTION
## What

Adds two optional `[[sources]]` fields to `dbhub.toml` for MySQL/MariaDB, letting users configure the connection character set and/or collation:

```toml
[[sources]]
id = "prod"
dsn = "mysql://user:pass@localhost:3306/mydb"
charset = "utf8mb4"                # optional
collation = "utf8mb4_0900_ai_ci"   # optional
```

Closes #353.

## Why

Today there's no way to control the connection charset/collation of a MySQL/MariaDB source:

- DSN query parameters other than `sslmode` are dropped by the parsers, so `?charset=…` is ignored.
- `init_script` is only executed by the SQLite connector, so `SET NAMES … COLLATE …` on connect isn't possible.
- The connection therefore always uses the driver default — for `mysql2` that's `utf8mb4_unicode_ci` — which can silently differ from the database/table collation (e.g. MySQL 8's `utf8mb4_0900_ai_ci`).

## Design

`charset` and `collation` are **separate, independent fields** (either, or both). A connection resolves to a single collation id and a collation already implies its character set, so **when both are set the collation takes precedence**. Mapping per driver:

| dbhub config | mysql2 | mariadb |
|---|---|---|
| `charset` only | `charset` option = charset | `charset` option = charset |
| `collation` only | `charset` option = collation | `collation` option = collation |
| both | `charset` option = collation | `collation` option = collation |

Notes:
- **mysql2** exposes only a single `charset` option (no separate `collation`); it accepts either a charset or a collation name, resolving to one collation id.
- **mariadb** exposes distinct `charset`/`collation` options, but the current driver (3.5.3) ignores `collation` when `charset` is also passed — so a configured collation is forwarded to the native `collation` option.

Both fields are **TOML-only** (not DSN parameters) and gated to MySQL/MariaDB, consistent with the existing `timezone` field.

## Tests

- **Unit** (`toml-loader.test.ts`): charset/collation accepted individually and together, MySQL/MariaDB-only gating, empty/non-string rejection.
- **Integration** (MySQL + MariaDB): assert `@@character_set_connection` and `@@collation_connection` for charset-only, collation-only, and both-set.

All unit tests (812) and MySQL/MariaDB integration suites pass; `pnpm run build:backend` succeeds.

## Docs

- `docs/config/toml.mdx` — `charset` and `collation` field sections + reference-table rows
- `dbhub.toml.example` — commented examples
