### PR TITLE
fix: load .env files before TOML config interpolation

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -651,9 +651,21 @@ export function resolveSSHConfig(): { config: SSHTunnelConfig; source: string } 
 /**
  * Resolve source configurations from TOML config or fallback to single DSN
  * Priority: TOML config (--config flag or ./dbhub.toml) > single DSN/env vars
+ *
+ * Loads .env files first so that environment variables are available for
+ * ${VAR_NAME} interpolation in dbhub.toml. Without this, .env is only loaded
+ * inside resolveDSN() (the fallback path), meaning TOML configs never get
+ * .env-backed variable resolution.
+ *
  * Returns array of source configs and the source of the configuration
  */
 export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[]; tools?: import("../types/config.js").ToolConfig[]; source: string } | null> {
+  // 0. Load .env files first so that environment variables are available
+  //    for TOML interpolation (${VAR_NAME}) when using --config.
+  //    Without this, .env is only loaded inside resolveDSN() (the fallback
+  //    path), meaning TOML configs never get .env-backed variable resolution.
+  loadEnvFiles();
+
   // 1. Try loading from TOML configuration file (skip if --demo flag is set)
   if (!isDemoMode()) {
     const tomlConfig = loadTomlConfig();


### PR DESCRIPTION
## Problem

When using `--config` with `dbhub.toml`, `.env` files are never loaded. This is because `loadEnvFiles()` (which calls `dotenv.config()`) is only called inside `resolveDSN()` — the fallback path that runs ONLY when no TOML config is found.

As a result, `${VAR_NAME}` interpolation in `dbhub.toml` (handled by `interpolateEnvVars()` in `toml-loader.ts`) can only resolve from system environment variables, not from `.env` files.

This contradicts the [official documentation](https://dbhub.ai/config/toml#environment-variable-interpolation) which states that `.env` files are supported.

## Root Cause

In `resolveSourceConfigs()` (`src/config/env.ts`):

1. If a TOML config exists → `loadTomlConfig()` runs `interpolateEnvVars()` reading from `process.env` → returns immediately
2. `loadEnvFiles()` / `dotenv.config()` lives inside `resolveDSN()` — which is **never reached** when TOML config exists

## Fix

Call `loadEnvFiles()` at the start of `resolveSourceConfigs()`, before `loadTomlConfig()`. This ensures `.env` variables are loaded into `process.env` and available for TOML interpolation.

The redundant call inside `resolveDSN()` is harmless (dotenv just re-reads the same file).

## Testing

- [x] Verified that with the fix, `.env` files are loaded when using `--config dbhub.toml`
- [x] `${VAR_NAME}` interpolation in TOML now correctly resolves from `.env` files
- [x] No breaking changes to existing `resolveDSN()` fallback path
