### PR TITLE
fix: support TiDB in readonly mode for MySQL/MariaDB connectors

### DIFF
--- a/src/connectors/__tests__/readonly-transaction-strategy.test.ts
+++ b/src/connectors/__tests__/readonly-transaction-strategy.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Unit coverage for the readonly transaction strategy in the MySQL/MariaDB
+ * connectors.
+ *
+ * The integration tests exercise the MySQL/MariaDB path against real containers,
+ * but they cannot cover the TiDB branch (no TiDB container, and TiDB's behavior
+ * is precisely that it *rejects* the statement the other engines accept). These
+ * tests mock the driver so both branches are asserted at the statement level:
+ *
+ *   MySQL/MariaDB -> START TRANSACTION READ ONLY ... COMMIT
+ *   TiDB          -> START TRANSACTION ... ROLLBACK   (writes discarded)
+ */
+
+const mysqlCreatePool = vi.fn();
+const mariadbCreatePool = vi.fn();
+
+vi.mock("mysql2/promise", () => ({
+  default: {
+    get createPool() {
+      return mysqlCreatePool;
+    },
+  },
+}));
+
+vi.mock("mariadb", () => ({
+  createPool: (...args: any[]) => mariadbCreatePool(...args),
+}));
+
+const { MySQLConnector } = await import("../mysql/index.js");
+const { MariaDBConnector } = await import("../mariadb/index.js");
+
+const MYSQL_VERSION = "8.0.36";
+const MARIADB_VERSION = "11.4.2-MariaDB-ubu2404";
+const TIDB_VERSION = "8.0.11-TiDB-v7.5.0";
+
+/** Records every statement issued on the dedicated connection. */
+function makeFakePool(version: string, wrapResults: (rows: any[]) => any) {
+  const statements: string[] = [];
+  const conn = {
+    query: vi.fn(async (arg: any) => {
+      const sql = typeof arg === "string" ? arg : arg.sql;
+      statements.push(sql);
+      return wrapResults([{ id: 1 }]);
+    }),
+    release: vi.fn(),
+  };
+  const pool = {
+    // Connect-time flavor probe.
+    query: vi.fn(async () => wrapResults([{ version }])),
+    getConnection: vi.fn(async () => conn),
+    end: vi.fn(),
+  };
+  return { pool, conn, statements };
+}
+
+// mysql2 returns [rows, fields]; mariadb returns rows directly.
+const asMysql = (rows: any[]) => [rows, []];
+const asMariadb = (rows: any[]) => rows;
+
+describe("readonly transaction strategy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("MySQL connector", () => {
+    it("uses READ ONLY transaction + COMMIT on stock MySQL", async () => {
+      const { pool, statements } = makeFakePool(MYSQL_VERSION, asMysql);
+      mysqlCreatePool.mockReturnValue(pool);
+
+      const connector = new MySQLConnector();
+      await connector.connect("mysql://user:pass@localhost:3306/db");
+      await connector.executeSQL("SELECT 1", { readonly: true });
+
+      expect(statements[0]).toBe("START TRANSACTION READ ONLY");
+      expect(statements[statements.length - 1]).toBe("COMMIT");
+    });
+
+    it("falls back to a plain transaction + ROLLBACK on TiDB", async () => {
+      const { pool, statements } = makeFakePool(TIDB_VERSION, asMysql);
+      mysqlCreatePool.mockReturnValue(pool);
+
+      const connector = new MySQLConnector();
+      await connector.connect("mysql://user:pass@localhost:3306/db");
+      await connector.executeSQL("SELECT 1", { readonly: true });
+
+      // TiDB rejects the READ ONLY modifier, so it must never be sent...
+      expect(statements).not.toContain("START TRANSACTION READ ONLY");
+      expect(statements[0]).toBe("START TRANSACTION");
+      // ...and the transaction is discarded so any missed DML never persists.
+      expect(statements[statements.length - 1]).toBe("ROLLBACK");
+    });
+
+    it("opens no transaction when readonly is off", async () => {
+      const { pool, statements } = makeFakePool(TIDB_VERSION, asMysql);
+      mysqlCreatePool.mockReturnValue(pool);
+
+      const connector = new MySQLConnector();
+      await connector.connect("mysql://user:pass@localhost:3306/db");
+      await connector.executeSQL("SELECT 1", {});
+
+      expect(statements).toEqual(["SELECT 1"]);
+    });
+  });
+
+  describe("MariaDB connector", () => {
+    it("uses READ ONLY transaction + COMMIT on stock MariaDB", async () => {
+      const { pool, statements } = makeFakePool(MARIADB_VERSION, asMariadb);
+      mariadbCreatePool.mockReturnValue(pool);
+
+      const connector = new MariaDBConnector();
+      await connector.connect("mariadb://user:pass@localhost:3306/db");
+      await connector.executeSQL("SELECT 1", { readonly: true });
+
+      expect(statements[0]).toBe("START TRANSACTION READ ONLY");
+      expect(statements[statements.length - 1]).toBe("COMMIT");
+    });
+
+    it("falls back to a plain transaction + ROLLBACK on TiDB", async () => {
+      const { pool, statements } = makeFakePool(TIDB_VERSION, asMariadb);
+      mariadbCreatePool.mockReturnValue(pool);
+
+      const connector = new MariaDBConnector();
+      await connector.connect("mariadb://user:pass@localhost:3306/db");
+      await connector.executeSQL("SELECT 1", { readonly: true });
+
+      expect(statements).not.toContain("START TRANSACTION READ ONLY");
+      expect(statements[0]).toBe("START TRANSACTION");
+      expect(statements[statements.length - 1]).toBe("ROLLBACK");
+    });
+  });
+});

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -17,6 +17,7 @@ import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
 import { quoteIdentifier } from "../../utils/identifier-quoter.js";
+import { isTiDBVersion } from "../../utils/server-flavor.js";
 
 /**
  * MariaDB DSN Parser
@@ -131,6 +132,9 @@ export class MariaDBConnector implements Connector {
   private pool: mariadb.Pool | null = null;
   // Source ID is set by ConnectorManager after cloning
   private sourceId: string = "default";
+  // TiDB speaks the MySQL protocol but rejects `START TRANSACTION READ ONLY`
+  // unless tidb_enable_noop_functions is on. Detected once at connect time.
+  private supportsReadOnlyTransaction: boolean = true;
 
   getId(): string {
     return this.sourceId;
@@ -146,8 +150,9 @@ export class MariaDBConnector implements Connector {
 
       this.pool = mariadb.createPool(connectionConfig);
 
-      // Test the connection
-      await this.pool.query("SELECT 1");
+      // Test the connection and detect the server flavor in the same round trip.
+      const rows = await this.pool.query("SELECT VERSION() AS version");
+      this.supportsReadOnlyTransaction = !isTiDBVersion(rows?.[0]?.version);
     } catch (err) {
       console.error("Failed to connect to MariaDB database:", err);
       throw err;
@@ -618,8 +623,15 @@ export class MariaDBConnector implements Connector {
       // payloads (e.g. `SELECT 1--1;DROP TABLE t`) are instead rejected upstream by
       // the read-only classifier, which now splits `--`-hidden statements (see
       // scanSingleLineCommentMySQL in sql-parser.ts).
+      //
+      // TiDB rejects the READ ONLY modifier (see isTiDBVersion), so there we open
+      // a plain transaction and always ROLLBACK instead of COMMIT: any DML the
+      // classifier missed is discarded rather than persisted, while SELECT results
+      // are unaffected.
       if (options.readonly) {
-        await conn.query("START TRANSACTION READ ONLY");
+        await conn.query(
+          this.supportsReadOnlyTransaction ? "START TRANSACTION READ ONLY" : "START TRANSACTION"
+        );
       }
 
       // Apply maxRows limit to SELECT queries if specified
@@ -659,7 +671,7 @@ export class MariaDBConnector implements Connector {
       const rowCount = extractAffectedRows(results);
 
       if (options.readonly) {
-        await conn.query("COMMIT");
+        await conn.query(this.supportsReadOnlyTransaction ? "COMMIT" : "ROLLBACK");
       }
       return { rows, rowCount };
     } catch (error) {

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -17,6 +17,7 @@ import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
 import { quoteIdentifier } from "../../utils/identifier-quoter.js";
+import { isTiDBVersion } from "../../utils/server-flavor.js";
 
 /**
  * MySQL DSN Parser
@@ -145,6 +146,9 @@ export class MySQLConnector implements Connector {
   // Source ID is set by ConnectorManager after cloning
   private sourceId: string = "default";
   private queryTimeoutMs?: number;
+  // TiDB speaks the MySQL protocol but rejects `START TRANSACTION READ ONLY`
+  // unless tidb_enable_noop_functions is on. Detected once at connect time.
+  private supportsReadOnlyTransaction: boolean = true;
 
   getId(): string {
     return this.sourceId;
@@ -164,8 +168,9 @@ export class MySQLConnector implements Connector {
         this.queryTimeoutMs = config.queryTimeoutSeconds * 1000;
       }
 
-      // Test the connection
-      const [rows] = await this.pool.query("SELECT 1");
+      // Test the connection and detect the server flavor in the same round trip.
+      const [rows] = (await this.pool.query("SELECT VERSION() AS version")) as [any[], any];
+      this.supportsReadOnlyTransaction = !isTiDBVersion(rows[0]?.version);
     } catch (err) {
       console.error("Failed to connect to MySQL database:", err);
       throw err;
@@ -636,8 +641,15 @@ export class MySQLConnector implements Connector {
       // payloads (e.g. `SELECT 1--1;DROP TABLE t`) are instead rejected upstream by
       // the read-only classifier, which now splits `--`-hidden statements (see
       // scanSingleLineCommentMySQL in sql-parser.ts).
+      //
+      // TiDB rejects the READ ONLY modifier (see isTiDBVersion), so there we open
+      // a plain transaction and always ROLLBACK instead of COMMIT: any DML the
+      // classifier missed is discarded rather than persisted, while SELECT results
+      // are unaffected.
       if (options.readonly) {
-        await conn.query("START TRANSACTION READ ONLY");
+        await conn.query(
+          this.supportsReadOnlyTransaction ? "START TRANSACTION READ ONLY" : "START TRANSACTION"
+        );
       }
 
       // Apply maxRows limit to SELECT queries if specified
@@ -681,7 +693,7 @@ export class MySQLConnector implements Connector {
       const rowCount = extractAffectedRows(firstResult);
 
       if (options.readonly) {
-        await conn.query("COMMIT");
+        await conn.query(this.supportsReadOnlyTransaction ? "COMMIT" : "ROLLBACK");
       }
       return { rows, rowCount };
     } catch (error) {

--- a/src/utils/__tests__/server-flavor.test.ts
+++ b/src/utils/__tests__/server-flavor.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { isTiDBVersion } from "../server-flavor.js";
+
+describe("isTiDBVersion", () => {
+  it("detects TiDB version strings", () => {
+    expect(isTiDBVersion("8.0.11-TiDB-v7.5.0")).toBe(true);
+    expect(isTiDBVersion("5.7.25-TiDB-v6.1.0-serverless")).toBe(true);
+    expect(isTiDBVersion("8.0.11-tidb-v7.5.0")).toBe(true);
+  });
+
+  it("treats stock MySQL and MariaDB as supporting READ ONLY transactions", () => {
+    expect(isTiDBVersion("8.0.36")).toBe(false);
+    expect(isTiDBVersion("5.7.44-log")).toBe(false);
+    expect(isTiDBVersion("11.4.2-MariaDB-ubu2404")).toBe(false);
+  });
+
+  it("is safe when the version is missing or not a string", () => {
+    expect(isTiDBVersion(undefined)).toBe(false);
+    expect(isTiDBVersion(null)).toBe(false);
+    expect(isTiDBVersion(80036)).toBe(false);
+  });
+});

--- a/src/utils/server-flavor.ts
+++ b/src/utils/server-flavor.ts
@@ -1,0 +1,14 @@
+/**
+ * Helpers for detecting MySQL-protocol server flavors that need behavior tweaks.
+ */
+
+/**
+ * TiDB reports a MySQL-compatible version string that embeds its own version,
+ * e.g. `8.0.11-TiDB-v7.5.0`. It matters because TiDB treats the `READ ONLY`
+ * transaction modifier as a noop function and rejects it unless
+ * `tidb_enable_noop_functions` is enabled, so the engine-level read-only
+ * backstop has to take a different form there.
+ */
+export function isTiDBVersion(version: unknown): boolean {
+  return typeof version === "string" && /tidb/i.test(version);
+}


### PR DESCRIPTION
Fixes #359.

## Root cause

TiDB speaks the MySQL protocol but treats the `READ ONLY` transaction modifier as a [noop function](https://github.com/pingcap/tidb/issues/34626), rejecting `START TRANSACTION READ ONLY` unless `tidb_enable_noop_functions` is enabled. Since the engine-level readonly backstop was added, every readonly `execute_sql` call against TiDB fails before the user SQL runs:

```
function READ ONLY has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions
```

## Fix

- `src/utils/server-flavor.ts` (new): `isTiDBVersion()` — TiDB reports versions like `8.0.11-TiDB-v7.5.0`.
- MySQL + MariaDB connectors: `connect()` now probes `SELECT VERSION()` instead of `SELECT 1` (same round trip, no added cost) and caches `supportsReadOnlyTransaction`.
- In readonly `executeSQL`, TiDB opens a plain `START TRANSACTION` and ends with `ROLLBACK` instead of `COMMIT`. Any DML that slipped past the keyword classifier is discarded rather than persisted; SELECT results are unaffected. **Non-TiDB behavior is byte-identical to before.**

The upstream keyword classifier in `src/tools/execute-sql.ts` runs regardless of connector, so TiDB users keep the primary readonly enforcement plus a rollback backstop — this is issue option 1 combined with option 4, without requiring any new user configuration.

## Verification

- `pnpm run build` passes.
- Full unit suite passes (815 tests), including 3 new tests for `isTiDBVersion`.
- **Not verified:** integration tests did not run — Docker was unavailable in the authoring environment — so the live `START TRANSACTION` / `ROLLBACK` path is unexercised, and no TiDB instance was available to confirm the end-to-end fix. Please run `pnpm test:integration` (CI should cover this) and ideally have the reporter confirm against real TiDB.

## Notes for review

- The MariaDB connector got the same change for parity even though the issue only covers MySQL.
- Chose rollback-based enforcement over the alternatives (a `dialect = "tidb"` source option, or `SET tidb_enable_noop_functions = 1`) because it needs no user config and preserves a real write-discard guarantee. Happy to switch to an explicit option if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)