### PR TITLE
fix: close half-built connections when connect() fails

### DIFF
--- a/src/connectors/__tests__/connect-failure-cleanup.test.ts
+++ b/src/connectors/__tests__/connect-failure-cleanup.test.ts
@@ -36,6 +36,16 @@ vi.mock("pg", () => ({
   },
 }));
 
+const mssqlPoolCtor = vi.fn();
+
+vi.mock("mssql", () => ({
+  default: {
+    ConnectionPool: function (this: any, ...args: any[]) {
+      return mssqlPoolCtor(...args);
+    },
+  },
+}));
+
 const { MySQLConnector } = await import("../mysql/index.js");
 const { MariaDBConnector } = await import("../mariadb/index.js");
 const { PostgresConnector } = await import("../postgres/index.js");
@@ -104,6 +114,21 @@ describe("connect() failure cleanup", () => {
       "ECONNREFUSED"
     );
     expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it("SQL Server closes the pool when the connection probe fails", async () => {
+    const { SQLServerConnector } = await import("../sqlserver/index.js");
+    const close = vi.fn();
+    mssqlPoolCtor.mockReturnValue({
+      connect: vi.fn().mockRejectedValue(PROBE_FAILURE),
+      close,
+    });
+
+    const connector = new SQLServerConnector();
+    await expect(connector.connect("sqlserver://u:p@localhost:1433/db")).rejects.toThrow(
+      "ECONNREFUSED"
+    );
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("SQLite releases the handle when the init script fails", async () => {

--- a/src/connectors/__tests__/connect-failure-cleanup.test.ts
+++ b/src/connectors/__tests__/connect-failure-cleanup.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * A connect() that fails after creating its pool must close it.
+ *
+ * `ConnectorManager.connectSource` only registers a connector in `this.connectors`
+ * *after* connect() resolves, so a pool stranded by a failed attempt is never
+ * reachable from `disconnect()`. Lazy sources retry on every tool call, so an
+ * unreachable database would otherwise strand a fresh pool per invocation.
+ */
+
+const mysqlCreatePool = vi.fn();
+const mariadbCreatePool = vi.fn();
+const pgPoolCtor = vi.fn();
+
+vi.mock("mysql2/promise", () => ({
+  default: {
+    get createPool() {
+      return mysqlCreatePool;
+    },
+  },
+}));
+
+vi.mock("mariadb", () => ({
+  createPool: (...args: any[]) => mariadbCreatePool(...args),
+}));
+
+vi.mock("pg", () => ({
+  default: {
+    Pool: function (this: any, ...args: any[]) {
+      return pgPoolCtor(...args);
+    },
+  },
+}));
+
+const { MySQLConnector } = await import("../mysql/index.js");
+const { MariaDBConnector } = await import("../mariadb/index.js");
+const { PostgresConnector } = await import("../postgres/index.js");
+
+const PROBE_FAILURE = new Error("ECONNREFUSED");
+
+describe("connect() failure cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The connectors log the failure; keep test output readable.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("MySQL closes the pool when the version probe fails", async () => {
+    const end = vi.fn();
+    mysqlCreatePool.mockReturnValue({
+      query: vi.fn().mockRejectedValue(PROBE_FAILURE),
+      end,
+    });
+
+    const connector = new MySQLConnector();
+    await expect(connector.connect("mysql://u:p@localhost:3306/db")).rejects.toThrow(
+      "ECONNREFUSED"
+    );
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it("MariaDB closes the pool when the version probe fails", async () => {
+    const end = vi.fn();
+    mariadbCreatePool.mockReturnValue({
+      query: vi.fn().mockRejectedValue(PROBE_FAILURE),
+      end,
+    });
+
+    const connector = new MariaDBConnector();
+    await expect(connector.connect("mariadb://u:p@localhost:3306/db")).rejects.toThrow(
+      "ECONNREFUSED"
+    );
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it("PostgreSQL closes the pool when the connection probe fails", async () => {
+    const end = vi.fn();
+    pgPoolCtor.mockReturnValue({
+      connect: vi.fn().mockRejectedValue(PROBE_FAILURE),
+      end,
+    });
+
+    const connector = new PostgresConnector();
+    await expect(connector.connect("postgres://u:p@localhost:5432/db")).rejects.toThrow(
+      "ECONNREFUSED"
+    );
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the original error even when teardown itself fails", async () => {
+    const end = vi.fn().mockRejectedValue(new Error("pool.end exploded"));
+    mysqlCreatePool.mockReturnValue({
+      query: vi.fn().mockRejectedValue(PROBE_FAILURE),
+      end,
+    });
+
+    const connector = new MySQLConnector();
+    // The connection error is the diagnostic one; a noisy teardown must not mask it.
+    await expect(connector.connect("mysql://u:p@localhost:3306/db")).rejects.toThrow(
+      "ECONNREFUSED"
+    );
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it("SQLite releases the handle when the init script fails", async () => {
+    // Real node:sqlite (not mocked): the handle opens fine, then exec() throws.
+    const { SQLiteConnector } = await import("../sqlite/index.js");
+    const dbPath = path.join(os.tmpdir(), `dbhub-cleanup-${process.pid}.db`);
+    const connector = new SQLiteConnector();
+
+    try {
+      await expect(
+        connector.connect(`sqlite:///${dbPath}`, "THIS IS NOT VALID SQL;")
+      ).rejects.toThrow();
+
+      // Handle released -> the connector reports itself disconnected rather than
+      // holding an open database it can never close.
+      await expect(connector.executeSQL("SELECT 1", {})).rejects.toThrow(/not connected/i);
+    } finally {
+      await fs.promises.rm(dbPath, { force: true });
+    }
+  });
+
+  it("repeated failed attempts do not strand pools", async () => {
+    const ends: ReturnType<typeof vi.fn>[] = [];
+    mysqlCreatePool.mockImplementation(() => {
+      const end = vi.fn();
+      ends.push(end);
+      return { query: vi.fn().mockRejectedValue(PROBE_FAILURE), end };
+    });
+
+    // Mirrors a lazy source retrying on each tool call.
+    const connector = new MySQLConnector();
+    for (let i = 0; i < 3; i++) {
+      await expect(connector.connect("mysql://u:p@localhost:3306/db")).rejects.toThrow();
+    }
+
+    expect(ends).toHaveLength(3);
+    expect(ends.every((end) => end.mock.calls.length === 1)).toBe(true);
+  });
+});

--- a/src/connectors/__tests__/connect-failure-cleanup.test.ts
+++ b/src/connectors/__tests__/connect-failure-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -57,6 +57,12 @@ describe("connect() failure cleanup", () => {
     vi.clearAllMocks();
     // The connectors log the failure; keep test output readable.
     vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restore the console spy: clearAllMocks() resets calls but leaves the spy
+    // installed, so without this each test stacks another wrapper on the last.
+    vi.restoreAllMocks();
   });
 
   it("MySQL closes the pool when the version probe fails", async () => {

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -18,6 +18,7 @@ import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statem
 import { splitSQLStatements } from "../../utils/sql-parser.js";
 import { quoteIdentifier } from "../../utils/identifier-quoter.js";
 import { isTiDBVersion } from "../../utils/server-flavor.js";
+import { closeQuietly } from "../../utils/resource-cleanup.js";
 
 /**
  * MariaDB DSN Parser
@@ -154,6 +155,13 @@ export class MariaDBConnector implements Connector {
       const rows = await this.pool.query("SELECT VERSION() AS version");
       this.supportsReadOnlyTransaction = !isTiDBVersion(rows?.[0]?.version);
     } catch (err) {
+      // Tear down the pool if it was created before the failure, otherwise it
+      // strands sockets and keeps the event loop alive (see closeQuietly).
+      if (this.pool) {
+        const pool = this.pool;
+        this.pool = null;
+        await closeQuietly(() => pool.end());
+      }
       console.error("Failed to connect to MariaDB database:", err);
       throw err;
     }

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -18,6 +18,7 @@ import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statem
 import { splitSQLStatements } from "../../utils/sql-parser.js";
 import { quoteIdentifier } from "../../utils/identifier-quoter.js";
 import { isTiDBVersion } from "../../utils/server-flavor.js";
+import { closeQuietly } from "../../utils/resource-cleanup.js";
 
 /**
  * MySQL DSN Parser
@@ -172,6 +173,13 @@ export class MySQLConnector implements Connector {
       const [rows] = (await this.pool.query("SELECT VERSION() AS version")) as [any[], any];
       this.supportsReadOnlyTransaction = !isTiDBVersion(rows[0]?.version);
     } catch (err) {
+      // Tear down the pool if it was created before the failure, otherwise it
+      // strands sockets and keeps the event loop alive (see closeQuietly).
+      if (this.pool) {
+        const pool = this.pool;
+        this.pool = null;
+        await closeQuietly(() => pool.end());
+      }
       console.error("Failed to connect to MySQL database:", err);
       throw err;
     }

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -21,6 +21,7 @@ import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { quoteIdentifier } from "../../utils/identifier-quoter.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
 import { FailedToReadCertificate } from "./failed-to-read-certificate.js";
+import { closeQuietly } from "../../utils/resource-cleanup.js";
 
 /**
  * PostgreSQL DSN Parser
@@ -195,6 +196,13 @@ export class PostgresConnector implements Connector {
       const client = await this.pool.connect();
       client.release();
     } catch (err) {
+      // Tear down the pool if it was created before the failure, otherwise it
+      // strands sockets and keeps the event loop alive (see closeQuietly).
+      if (this.pool) {
+        const pool = this.pool;
+        this.pool = null;
+        await closeQuietly(() => pool.end());
+      }
       console.error("Failed to connect to PostgreSQL database:", err);
       throw err;
     }

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -26,6 +26,7 @@ import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
+import { closeQuietly } from "../../utils/resource-cleanup.js";
 
 /**
  * SQLite DSN Parser
@@ -200,6 +201,13 @@ export class SQLiteConnector implements Connector {
         this.db.exec(initScript);
       }
     } catch (error) {
+      // Close the handle if it was opened before the failure (e.g. a throwing
+      // init script), otherwise the database file stays locked (see closeQuietly).
+      if (this.db) {
+        const db = this.db;
+        this.db = null;
+        await closeQuietly(() => db.close());
+      }
       console.error("Failed to connect to SQLite database:", error);
       throw error;
     }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -198,17 +198,18 @@ export class SQLServerConnector implements Connector {
         this.config.options = {};
       }
 
-      // Hold the pool in a local so a failing connect() can still close it —
-      // `this.connection` is only assigned once connect() resolves, so without
-      // this the half-open pool would be unreachable (see closeQuietly).
-      const pool = new sql.ConnectionPool(this.config);
-      try {
-        this.connection = await pool.connect();
-      } catch (error) {
-        await closeQuietly(() => pool.close());
-        throw error;
-      }
+      // Assign before connecting so a failed connect() leaves the pool reachable
+      // for teardown below. connect() resolves to this same ConnectionPool.
+      this.connection = new sql.ConnectionPool(this.config);
+      await this.connection.connect();
     } catch (error) {
+      // Tear down the pool if it was created before the failure, otherwise it
+      // strands sockets and keeps the event loop alive (see closeQuietly).
+      if (this.connection) {
+        const connection = this.connection;
+        this.connection = undefined;
+        await closeQuietly(() => connection.close());
+      }
       throw error;
     }
   }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -17,6 +17,7 @@ import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { stripCommentsAndStrings } from "../../utils/sql-parser.js";
+import { closeQuietly } from "../../utils/resource-cleanup.js";
 
 /**
  * SQL Server DSN parser
@@ -197,7 +198,16 @@ export class SQLServerConnector implements Connector {
         this.config.options = {};
       }
 
-      this.connection = await new sql.ConnectionPool(this.config).connect();
+      // Hold the pool in a local so a failing connect() can still close it —
+      // `this.connection` is only assigned once connect() resolves, so without
+      // this the half-open pool would be unreachable (see closeQuietly).
+      const pool = new sql.ConnectionPool(this.config);
+      try {
+        this.connection = await pool.connect();
+      } catch (error) {
+        await closeQuietly(() => pool.close());
+        throw error;
+      }
     } catch (error) {
       throw error;
     }

--- a/src/utils/resource-cleanup.ts
+++ b/src/utils/resource-cleanup.ts
@@ -1,0 +1,22 @@
+/**
+ * Helpers for tearing down half-built resources on a failed connect().
+ */
+
+/**
+ * Run a close/teardown callback, swallowing any error it raises.
+ *
+ * Used on connect() failure paths: the connection error is the one worth
+ * surfacing, and a teardown that also fails (e.g. closing a pool that never
+ * finished opening) must not mask it. Without this, a pool created before a
+ * failing probe is never closed — `ConnectorManager.connectSource` only
+ * registers a connector *after* connect() resolves, so `disconnect()` never
+ * sees it. Lazy sources retry on every tool call, so each failed attempt would
+ * otherwise strand another pool holding sockets and timers.
+ */
+export async function closeQuietly(close: () => void | Promise<void>): Promise<void> {
+  try {
+    await close();
+  } catch {
+    // Ignore: the original connection error is the useful one.
+  }
+}


### PR DESCRIPTION
Follow-up to #362, addressing the resource-leak comment Copilot raised there (and suppressed as low-confidence). I deferred it at the time as out of scope for a TiDB fix; this is that fix, generalized across all connectors.

## The bug

Every connector creates its pool/handle, then runs a probe that can throw — a version query (MySQL/MariaDB), a test connection (PostgreSQL/SQL Server), or an init script (SQLite). On failure the resource was never closed.

Nothing else cleans it up: `ConnectorManager.connectSource` only registers a connector in `this.connectors` **after** `connect()` resolves (`manager.ts:285-288`), so `disconnect()` — which iterates that map — never sees a connector whose `connect()` threw. The stranded pool holds sockets and timers that keep the event loop alive.

**This is worse than a one-shot startup leak.** `ensureConnected()` leaves a failed source in `lazySources` and clears `pendingConnections`, so every subsequent tool call retries. An unreachable lazy source strands one more pool *per tool invocation*, without bound.

Predates #362 — the previous `SELECT 1` probe leaked identically.

## The fix

- `src/utils/resource-cleanup.ts`: `closeQuietly()` — runs a teardown callback, swallowing its errors so a failing close can't mask the connection error that actually explains the failure.
- Applied to the failure path of all five connectors, clearing the field so the connector reports itself disconnected rather than holding a resource it can never close.

All five now use an identical catch block. SQL Server initially needed a workaround, but that turned out to be an artifact of our own code rather than anything about `mssql`: `this.connection = await new ConnectionPool(cfg).connect()` assigns only once `connect()` resolves, leaving a failed pool unreachable. Since `ConnectionPool.connect()` resolves to the same pool, assigning first and awaiting after is equivalent and removes the special case (also drops a pre-existing `catch (error) { throw error }` no-op).

## Verification

`src/connectors/__tests__/connect-failure-cleanup.test.ts` — 7 tests:
- pool closed on probe failure: MySQL, MariaDB, PostgreSQL, SQL Server (driver-mocked)
- SQLite handle released on init-script failure (real `node:sqlite`)
- original error survives a throwing teardown
- 3 sequential failed attempts strand nothing (the lazy-retry case)

**Confirmed non-vacuous** by mutation, not just a green checkmark: reverting each connector individually fails its own test and only its own.

Full unit suite: 827 passing. `pnpm run build` clean. `tsc` error count identical before/after (132 — all pre-existing in test files and an unrelated `pg` typing).

## Not covered

Integration tests weren't run locally (no Docker); CI covers them.