### PR TITLE
fix: scope view search to the default schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Key architectural patterns:
   - Runs in stateless mode (no SSE support) - GET requests to `/mcp` return 405 Method Not Allowed
   - Tests in `src/__tests__/json-rpc-integration.test.ts`
 - **Tool Handlers**: Clean separation of MCP protocol concerns
-  - Tools accept optional `source_id` parameter for multi-database routing
+  - Multi-database routing is by tool name, not by parameter: one tool instance is registered per source, named `execute_sql_{source_id}` / `search_objects_{source_id}` (single-source configs keep the bare `execute_sql` / `search_objects` names). See `src/tools/index.ts` and `src/utils/tool-metadata.ts`. `source_id` appears in tool *output* metadata only.
 - **Token-Efficient Schema Exploration**: Unified search/list tool with progressive disclosure
   - `search_objects`: Single tool for both pattern-based search and listing all objects
   - Pattern parameter defaults to `%` (match all) - optional for listing use cases
@@ -107,7 +107,7 @@ DBHub supports three configuration methods (in priority order):
   - Path expansion for `~/` in file paths
   - Automatic password redaction in logs
   - First source is the default database
-- Usage in MCP tools: Add optional `source_id` parameter (e.g., `execute_sql(sql, source_id="prod_pg")`)
+- Usage in MCP tools: each source gets its own tool, suffixed with the normalized source id (e.g. `execute_sql_prod_pg(sql)`, `search_objects_staging_mysql(...)`)
 - See `dbhub.toml.example` for complete configuration reference
 - Documentation: https://dbhub.ai/config/toml
 

--- a/src/tools/__tests__/search-objects.test.ts
+++ b/src/tools/__tests__/search-objects.test.ts
@@ -1351,6 +1351,11 @@ describe('search_database_objects tool', () => {
         if (schema === 'other_db') return ['secrets'];
         return ['misc'];
       });
+      vi.mocked(mockConnector.getViews).mockImplementation(async (schema?: string) => {
+        if (schema === 'configured_db') return ['order_summary'];
+        if (schema === 'other_db') return ['secret_view'];
+        return ['misc_view'];
+      });
     });
 
     it('scopes table search to the default schema and never fans out to other databases', async () => {
@@ -1368,6 +1373,40 @@ describe('search_database_objects tool', () => {
       // Only the configured database should have been inspected.
       expect(mockConnector.getTables).toHaveBeenCalledTimes(1);
       expect(mockConnector.getTables).toHaveBeenCalledWith('configured_db');
+    });
+
+    it('scopes view search to the default schema and never fans out to other databases', async () => {
+      vi.mocked((mockConnector as any).getDefaultSchema).mockResolvedValue('configured_db');
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        { object_type: 'view', pattern: '%', detail_level: 'names' },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results.map((r: any) => r.schema)).toEqual(['configured_db']);
+      expect(parsed.data.results.map((r: any) => r.name)).toEqual(['order_summary']);
+      // Only the configured database should have been inspected.
+      expect(mockConnector.getViews).toHaveBeenCalledTimes(1);
+      expect(mockConnector.getViews).toHaveBeenCalledWith('configured_db');
+    });
+
+    it('falls back to the full schema list for views when no default is configured (null)', async () => {
+      vi.mocked((mockConnector as any).getDefaultSchema).mockResolvedValue(null);
+
+      const handler = createSearchDatabaseObjectsToolHandler();
+      const result = await handler(
+        { object_type: 'view', pattern: '%', detail_level: 'names' },
+        null
+      );
+
+      const parsed = parseToolResponse(result);
+      expect(parsed.data.results.map((r: any) => r.schema)).toEqual([
+        'configured_db',
+        'other_db',
+        'third_db',
+      ]);
     });
 
     it('scopes schema listing to the default schema', async () => {

--- a/src/tools/search-objects.ts
+++ b/src/tools/search-objects.ts
@@ -296,7 +296,7 @@ async function searchViews(
   if (schemaFilter) {
     schemasToSearch = [schemaFilter];
   } else {
-    schemasToSearch = await connector.getSchemas();
+    schemasToSearch = await resolveDefaultSchemas(connector);
   }
 
   // Search views in each schema


### PR DESCRIPTION
## Problem

`searchViews` called `connector.getSchemas()` directly instead of `resolveDefaultSchemas()`, unlike the tables / columns / procedures / indexes paths which all use the helper.

For MySQL/MariaDB, `getSchemas()` queries `INFORMATION_SCHEMA.SCHEMATA` server-wide (excluding only `information_schema`, `performance_schema`, `mysql`, `sys`). So `search_objects` with `object_type: "view"` and no `schema` filter enumerated views across **every user database on the host**, even when the DSN named one specific database.

That contradicts the intent documented on `resolveDefaultSchemas` itself:

> Prefers the connector's default schema (e.g. the database named in a MySQL/MariaDB DSN) so searches don't leak across every database on the server.

This looks like an oversight rather than a deliberate difference — it was the only one of the five search paths not using the helper.

## Fix

One-line change at `src/tools/search-objects.ts:299` to use `resolveDefaultSchemas(connector)`.

Connectors reporting no default schema (e.g. a MySQL DSN with no database name, where `DATABASE()` returns null) still fall back to the full list, so db-less connections keep working as designed.

The other `getSchemas()` callsite (`:666`) is left alone — it validates an explicit `schema` argument for existence, where the server-wide list is correct.

## Tests

Two tests added to the existing `default schema scoping` block, mirroring the table-scoping coverage:

- views stay within the default schema and never fan out
- null-default still falls back to the full schema list

Verified as a genuine regression guard: stashing the fix makes exactly the first test fail; restoring it passes. 937 unit tests pass. (Integration tests need Docker, unavailable in this environment.)

## Also

Corrects `CLAUDE.md`, which documented an optional `source_id` tool parameter that does not exist — tool input schemas have no such field. Multi-database routing is bind-time via tool name (`execute_sql_{source_id}`, registered per source in `src/tools/index.ts`); `source_id` appears in tool *output* metadata only. Came up while answering #360; public docs under `docs/` were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)