### PR TITLE
fix: reject MySQL/MariaDB DSNs that name no database

### DIFF
--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -181,33 +181,16 @@ Command-line flags are passed when starting DBHub. These have the highest priori
   </Tabs>
 
   <Note>
-    **One connection targets one database.** The database named in the DSN is
-    fixed for the life of the connection. `USE other_db;` does not switch it:
-    the statement is rejected in read-only mode, and even with writes enabled
-    each query checks out a fresh pooled connection, so the change would not
-    carry to the next tool call.
+    **One connection targets one database.** The database component is required,
+    and the database it names is fixed for the life of the connection.
+    `USE other_db;` does not switch it: the statement is rejected in read-only
+    mode, and even with writes enabled each query checks out a fresh pooled
+    connection, so the change would not carry to the next tool call.
 
     To work with several databases, define one `[[sources]]` entry per database
     in a [TOML config file](/config/toml) and run a single DBHub instance —
     each source gets its own set of tools.
   </Note>
-
-  <Warning>
-    **The database component is required.** For MySQL and MariaDB, a DSN that
-    names no database — `mysql://user:pass@localhost:3306/` or
-    `mysql://user:pass@localhost:3306` — is rejected at startup:
-
-    ```
-    MySQL DSN must name a database.
-    Provided: mysql://user:*******@localhost:3306/
-    Add the database to the DSN, e.g. ...:3306/mydb
-    ```
-
-    MySQL can connect without a default database, but DBHub does not support
-    it: unqualified SQL fails with "No database selected", and schema discovery
-    would fan out across every database on the server. Use a
-    [TOML config](/config/toml) with one source per database instead.
-  </Warning>
 
   **DSN Query Parameters:**
 

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -180,18 +180,6 @@ Command-line flags are passed when starting DBHub. These have the highest priori
     </Tab>
   </Tabs>
 
-  <Note>
-    **One connection targets one database.** The database component is required,
-    and the database it names is fixed for the life of the connection.
-    `USE other_db;` does not switch it: the statement is rejected in read-only
-    mode, and even with writes enabled each query checks out a fresh pooled
-    connection, so the change would not carry to the next tool call.
-
-    To work with several databases, define one `[[sources]]` entry per database
-    in a [TOML config file](/config/toml) and run a single DBHub instance —
-    each source gets its own set of tools.
-  </Note>
-
   **DSN Query Parameters:**
 
   | Parameter | Databases | Description | Example |

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -193,12 +193,20 @@ Command-line flags are passed when starting DBHub. These have the highest priori
   </Note>
 
   <Warning>
-    **Omitting the database component is not supported.** For MySQL and MariaDB
-    a DSN such as `mysql://user:pass@localhost:3306/` is currently accepted and
-    connects without a default database, which makes schema discovery enumerate
-    every database on the server. This behavior is untested and may change —
-    do not rely on it. Always name a database, and use a TOML config for
-    multi-database setups.
+    **The database component is required.** For MySQL and MariaDB, a DSN that
+    names no database — `mysql://user:pass@localhost:3306/` or
+    `mysql://user:pass@localhost:3306` — is rejected at startup:
+
+    ```
+    MySQL DSN must name a database.
+    Provided: mysql://user:*******@localhost:3306/
+    Add the database to the DSN, e.g. ...:3306/mydb
+    ```
+
+    MySQL can connect without a default database, but DBHub does not support
+    it: unqualified SQL fails with "No database selected", and schema discovery
+    would fan out across every database on the server. Use a
+    [TOML config](/config/toml) with one source per database instead.
   </Warning>
 
   **DSN Query Parameters:**

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -180,6 +180,27 @@ Command-line flags are passed when starting DBHub. These have the highest priori
     </Tab>
   </Tabs>
 
+  <Note>
+    **One connection targets one database.** The database named in the DSN is
+    fixed for the life of the connection. `USE other_db;` does not switch it:
+    the statement is rejected in read-only mode, and even with writes enabled
+    each query checks out a fresh pooled connection, so the change would not
+    carry to the next tool call.
+
+    To work with several databases, define one `[[sources]]` entry per database
+    in a [TOML config file](/config/toml) and run a single DBHub instance —
+    each source gets its own set of tools.
+  </Note>
+
+  <Warning>
+    **Omitting the database component is not supported.** For MySQL and MariaDB
+    a DSN such as `mysql://user:pass@localhost:3306/` is currently accepted and
+    connects without a default database, which makes schema discovery enumerate
+    every database on the server. This behavior is untested and may change —
+    do not rely on it. Always name a database, and use a TOML config for
+    multi-database setups.
+  </Warning>
+
   **DSN Query Parameters:**
 
   | Parameter | Databases | Description | Example |

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -217,6 +217,8 @@ Sources define database connections. Each source represents a database that DBHu
   **Mixing `dsn` with individual fields.** A `dsn` already encodes the connection identity (type, host, port, database, user, password). Fields that can also live in the DSN query string — `sslmode`, `sslrootcert`, `instanceName`, `authentication`, `domain` — may be set alongside a `dsn` and are applied when the DSN omits them.
 
   If such a field is set to a value that **contradicts** the DSN (e.g. `dsn = "...?sslmode=disable"` together with `sslmode = "require"`, or a `host`/`user`/`database` that differs from the DSN), DBHub rejects the configuration at startup rather than silently ignoring the field. Set each value in only one place, or make the two values match.
+
+  The conflict check compares values that are present in **both** places, so it cannot catch a field the DSN omits entirely. In particular, a `database` field alongside a DSN with no database component (`dsn = "mysql://user:pass@host:3306/"`) is ignored rather than rejected — the connection is made without a default database. Name the database inside the DSN.
   </Note>
 </ParamField>
 

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -218,7 +218,7 @@ Sources define database connections. Each source represents a database that DBHu
 
   If such a field is set to a value that **contradicts** the DSN (e.g. `dsn = "...?sslmode=disable"` together with `sslmode = "require"`, or a `host`/`user`/`database` that differs from the DSN), DBHub rejects the configuration at startup rather than silently ignoring the field. Set each value in only one place, or make the two values match.
 
-  A `database` field is never injected into a `dsn`, so pairing one with a DSN that names no database (`dsn = "mysql://user:pass@host:3306/"`) is also rejected at startup rather than silently ignored. Name the database inside the DSN, or drop the `dsn` and use individual connection parameters.
+  This includes a field the DSN omits entirely: a `database` alongside a DSN that names none is rejected too, since the field is never injected into the DSN.
   </Note>
 </ParamField>
 

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -218,7 +218,7 @@ Sources define database connections. Each source represents a database that DBHu
 
   If such a field is set to a value that **contradicts** the DSN (e.g. `dsn = "...?sslmode=disable"` together with `sslmode = "require"`, or a `host`/`user`/`database` that differs from the DSN), DBHub rejects the configuration at startup rather than silently ignoring the field. Set each value in only one place, or make the two values match.
 
-  The conflict check compares values that are present in **both** places, so it cannot catch a field the DSN omits entirely. In particular, a `database` field alongside a DSN with no database component (`dsn = "mysql://user:pass@host:3306/"`) is ignored rather than rejected — the connection is made without a default database. Name the database inside the DSN.
+  A `database` field is never injected into a `dsn`, so pairing one with a DSN that names no database (`dsn = "mysql://user:pass@host:3306/"`) is also rejected at startup rather than silently ignored. Name the database inside the DSN, or drop the `dsn` and use individual connection parameters.
   </Note>
 </ParamField>
 

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -587,6 +587,20 @@ database = "other_db"
         expect(() => loadTomlConfig()).toThrow("conflicting database");
       });
 
+      it('should throw error when a database field is paired with a DSN naming no database', () => {
+        // The field is never injected into the DSN, so accepting this would
+        // silently connect without a default database
+        const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "mysql://user:pass@localhost:3306/"
+database = "myapp"
+`;
+        fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+        expect(() => loadTomlConfig()).toThrow("the DSN names no database");
+      });
+
       it('should throw error when password field conflicts with DSN password', () => {
         const tomlContent = `
 [[sources]]

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -314,6 +314,15 @@ function validateDSNFieldConflicts(source: SourceConfig, configPath: string): vo
     if (source.database && info.database && source.database !== info.database) {
       conflict("database", source.database, info.database);
     }
+    // A `database` field is never injected into the DSN, so pairing one with a
+    // DSN that names no database would silently connect without a default
+    // database. Fail loudly instead, mirroring the password check below.
+    if (source.database && !info.database) {
+      throw new Error(
+        `Configuration file ${configPath}: source '${source.id}' has a 'database' field but the DSN names no database. ` +
+          `The field is ignored at connection time — add the database to the DSN, or use individual connection parameters instead of a DSN.`
+      );
+    }
     if (source.user && info.user && source.user !== info.user) {
       conflict("user", source.user, info.user);
     }

--- a/src/connectors/__tests__/dsn-parser.test.ts
+++ b/src/connectors/__tests__/dsn-parser.test.ts
@@ -223,3 +223,40 @@ describe('DSN Parser - SQL Server NTLM Authentication', () => {
     expect(config.password).toBe('password');
   });
 });
+
+describe('DSN Parser - missing database component', () => {
+  describe.each([
+    { label: 'MySQL', connector: () => new MySQLConnector(), scheme: 'mysql' },
+    { label: 'MariaDB', connector: () => new MariaDBConnector(), scheme: 'mariadb' },
+  ])('$label', ({ label, connector, scheme }) => {
+    const parser = connector().dsnParser;
+
+    it.each([
+      { form: 'trailing slash', dsn: `${scheme}://user:pass@localhost:3306/` },
+      { form: 'no path', dsn: `${scheme}://user:pass@localhost:3306` },
+      { form: 'query string only', dsn: `${scheme}://user:pass@localhost:3306/?sslmode=disable` },
+    ])('rejects a DSN with $form', async ({ dsn }) => {
+      await expect(parser.parse(dsn)).rejects.toThrow(`${label} DSN must name a database`);
+    });
+
+    it('points the user at the TOML config for multi-database setups', async () => {
+      await expect(parser.parse(`${scheme}://user:pass@localhost:3306/`)).rejects.toThrow(
+        /https:\/\/dbhub\.ai\/config\/toml/
+      );
+    });
+
+    it('does not leak the password in the error message', async () => {
+      // The error echoes the DSN back, so it must be obfuscated first
+      await expect(parser.parse(`${scheme}://user:hunter2@localhost:3306/`)).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.not.stringContaining('hunter2'),
+        })
+      );
+    });
+
+    it('still accepts a DSN that names a database', async () => {
+      const config = await parser.parse(`${scheme}://user:pass@localhost:3306/mydb`);
+      expect(config.database).toBe('mydb');
+    });
+  });
+});

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -13,6 +13,7 @@ import {
 } from "../interface.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
+import { requireDatabaseInDSN, MissingDatabaseError } from "../../utils/dsn-database.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
@@ -46,10 +47,13 @@ class MariadbDSNParser implements DSNParser {
       // This will handle special characters in passwords, etc.
       const url = new SafeURL(dsn);
 
+      const database = url.pathname ? url.pathname.substring(1) : ''; // Remove leading '/' if exists
+      requireDatabaseInDSN(database, dsn, "MariaDB");
+
       const connectionConfig: mariadb.ConnectionConfig = {
         host: url.hostname,
         port: url.port ? parseInt(url.port) : 3306,
-        database: url.pathname ? url.pathname.substring(1) : '', // Remove leading '/' if exists
+        database,
         user: url.username,
         password: url.password,
         multipleStatements: true, // Enable native multi-statement support
@@ -103,6 +107,10 @@ class MariadbDSNParser implements DSNParser {
 
       return connectionConfig;
     } catch (error) {
+      // Surface the actionable missing-database message as-is
+      if (error instanceof MissingDatabaseError) {
+        throw error;
+      }
       throw new Error(
         `Failed to parse MariaDB DSN: ${error instanceof Error ? error.message : String(error)}`
       );

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -13,6 +13,7 @@ import {
 } from "../interface.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
+import { requireDatabaseInDSN, MissingDatabaseError } from "../../utils/dsn-database.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
 import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
@@ -49,10 +50,13 @@ class MySQLDSNParser implements DSNParser {
       // This will handle special characters in passwords, etc.
       const url = new SafeURL(dsn);
 
+      const database = url.pathname ? url.pathname.substring(1) : ''; // Remove leading '/' if exists
+      requireDatabaseInDSN(database, dsn, "MySQL");
+
       const config: mysql.ConnectionOptions = {
         host: url.hostname,
         port: url.port ? parseInt(url.port) : 3306,
-        database: url.pathname ? url.pathname.substring(1) : '', // Remove leading '/' if exists
+        database,
         user: url.username,
         password: url.password,
         multipleStatements: true, // Enable native multi-statement support
@@ -116,6 +120,10 @@ class MySQLDSNParser implements DSNParser {
 
       return config;
     } catch (error) {
+      // Surface the actionable missing-database message as-is
+      if (error instanceof MissingDatabaseError) {
+        throw error;
+      }
       throw new Error(
         `Failed to parse MySQL DSN: ${error instanceof Error ? error.message : String(error)}`
       );

--- a/src/utils/dsn-database.ts
+++ b/src/utils/dsn-database.ts
@@ -1,0 +1,42 @@
+import { obfuscateDSNPassword } from "./dsn-obfuscate.js";
+
+/**
+ * Raised when a DSN omits the database component for a connector that requires
+ * one. Distinct from a generic parse failure so DSN parsers can rethrow it
+ * unchanged instead of burying it under "Failed to parse ... DSN:".
+ */
+export class MissingDatabaseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MissingDatabaseError";
+  }
+}
+
+/**
+ * Reject a DSN that names no database.
+ *
+ * MySQL/MariaDB can connect without a default database, but DBHub does not
+ * support it: `USE other_db` cannot switch databases (it is not a read-only
+ * allowed keyword, and each query checks a connection out of the pool and
+ * releases it, so the change would not persist), unqualified SQL fails with
+ * "No database selected", and schema discovery would fan out across every
+ * database on the server. Multi-database setups belong in a TOML config with
+ * one source per database.
+ *
+ * @param database  Database component extracted from the DSN (may be empty)
+ * @param dsn       Original DSN, used to build an obfuscated error message
+ * @param label     Human-readable connector name, e.g. "MySQL"
+ */
+export function requireDatabaseInDSN(database: string, dsn: string, label: string): void {
+  if (database) {
+    return;
+  }
+
+  throw new MissingDatabaseError(
+    `${label} DSN must name a database.\n` +
+      `Provided: ${obfuscateDSNPassword(dsn)}\n` +
+      `Add the database to the DSN, e.g. ...:3306/mydb\n` +
+      `To work with several databases, define one [[sources]] entry per ` +
+      `database in a TOML config file: https://dbhub.ai/config/toml`
+  );
+}


### PR DESCRIPTION
Follow-up to #360, where a user asked to connect without a database name and switch with `USE dbname;`.

MySQL/MariaDB DSNs with no database component were silently tolerated — `isValidDSN` is a bare prefix check (`mysql/index.ts:131`), and an empty URL path became `database: ''`, which both drivers happily accept. This PR rejects them and documents why.

## Why reject rather than support

The mode is not merely untested — it's actively broken in three ways:

- **Unqualified SQL fails.** MySQL raises ER_NO_DB_ERROR ("No database selected") for any unqualified table reference. That error isn't classified (`error-classifier.ts` covers only `SOURCE_UNREACHABLE`/`AUTH_FAILED`/`TUNNEL_FAILED`), so it surfaces as a raw driver string with no guidance. LLM-authored SQL is frequently unqualified.
- **Schema discovery fans out.** `getDefaultSchema()` returns null, so `resolveDefaultSchemas` falls back to every database on the server — with per-table column lookups and a `COUNT(*)` fallback per table at `summary` detail, since MySQL/MariaDB don't implement `getTableRowCount`. This is exactly the fan-out that scoping to the configured database was added to prevent, and it cuts against the project's token-efficiency claim.
- **It can't deliver the workflow it appears to offer.** `USE other_db;` is not in the read-only allowed-keyword list (`allowed-keywords.ts:12-13`), so it's rejected whenever `readonly` is set. Even with writes enabled it wouldn't persist — `executeSQL` releases its pooled connection in `finally` (`mysql/index.ts:642, 717-720`), so the next call may land elsewhere.

TOML multi-source already covers the real need, explicitly and per-source.

## Changes

**1. Reject in `parse()`** (`mysql/index.ts`, `mariadb/index.ts`) via a shared `requireDatabaseInDSN` helper (`src/utils/dsn-database.ts`):

```
MySQL DSN must name a database.
Provided: mysql://user:*******@localhost:3306/
Add the database to the DSN, e.g. ...:3306/mydb
To work with several databases, define one [[sources]] entry per database in a TOML config file: https://dbhub.ai/config/toml
```

Two deliberate placement choices:

- **Not in `isValidDSN`**, which drives connector routing in `ConnectorRegistry.getConnectorForDSN` (`interface.ts:294-301`). Tightening it there would make a db-less DSN match no connector, replacing the actionable message with a generic "no connector found".
- **`MissingDatabaseError` is rethrown unwrapped** by each parser's catch block, so the message isn't buried under `Failed to parse MySQL DSN: …`.

The DSN is obfuscated before being echoed, and there's a test asserting the password doesn't leak.

**2. Close the matching TOML gap** (`toml-loader.ts`). A `database` field is never injected into a `dsn` (`:724` only copies DSN→config), so pairing one with a db-less DSN silently connected without a default database. The existing conflict check missed it by requiring the value in **both** places (`:314`). Now a startup error, mirroring the adjacent password check at `:324-330`. Catching it at load time matters for `lazy = true` sources, where the connector-level error would otherwise be deferred to the first query.

**3. Docs** (`docs/config/toml.mdx`) — one line, covering only the behavior this PR changes: the `database`-alongside-db-less-DSN case is now rejected rather than silently ignored. The startup error is self-explanatory and links the TOML config, so nothing else needed documenting.

## Tests

13 new unit tests. Both connectors × three db-less DSN forms (trailing slash, no path, query-string-only), plus password redaction, the TOML pointer, and that a normal DSN still parses. One TOML test for the ignored-`database`-field case.

950 unit tests pass (was 937). `tsc --noEmit` unchanged at its 190-error baseline — note the repo does not currently typecheck clean, independent of this change. The 7 failing integration files are Docker-dependent and fail identically on `main` in this environment.

## Compatibility

This is a **breaking change** for anyone currently relying on the tolerated behavior. It was undocumented, untested, and degraded as described above, so that population is likely near zero — but it's a judgment call worth your explicit sign-off, and it argues for a minor version rather than a patch.

## Not included

`getCurrentSchema()` is typed `Promise<string>` but returns null on a db-less connection (`mysql/index.ts:617`, `mariadb/index.ts:598`). Now unreachable via the DSN path, but still a latent trap worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

