### PR TITLE
fix(test): isolate config discovery in server-spawning integration tests

### DIFF
--- a/src/__tests__/http-bind-host.integration.test.ts
+++ b/src/__tests__/http-bind-host.integration.test.ts
@@ -7,6 +7,7 @@ import os from 'os';
 describe('HTTP bind host integration', () => {
   let serverProcess: ChildProcess | null = null;
   let testDbPath: string;
+  let isolatedCwd: string;
   const testPort = 3002;
   const testHost = '127.0.0.1';
   const startupLogs: string[] = [];
@@ -14,11 +15,19 @@ describe('HTTP bind host integration', () => {
   beforeAll(async () => {
     testDbPath = path.join(os.tmpdir(), `bind_host_test_${Date.now()}_${Math.random().toString(36).substr(2, 9)}.db`);
 
+    // The server discovers ./dbhub.toml relative to its own cwd, and TOML config
+    // outranks the DSN env var below. Running from the repo root would therefore
+    // silently ignore DSN and connect to whatever a developer's local (gitignored)
+    // dbhub.toml names, so the server would fail to start on any machine that has
+    // one. Spawn from an empty directory to isolate config discovery.
+    isolatedCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'bind_host_cwd_'));
+
     // Invoke tsx directly via node to avoid pnpm.cmd resolution issues on Windows.
     const tsxCli = path.resolve(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
     const entry = path.resolve(process.cwd(), 'src', 'index.ts');
 
     serverProcess = spawn(process.execPath, [tsxCli, entry, '--transport=http'], {
+      cwd: isolatedCwd,
       env: {
         ...process.env,
         DSN: `sqlite://${testDbPath}`,
@@ -76,11 +85,21 @@ describe('HTTP bind host integration', () => {
     if (testDbPath && fs.existsSync(testDbPath)) {
       fs.unlinkSync(testDbPath);
     }
+    if (isolatedCwd && fs.existsSync(isolatedCwd)) {
+      fs.rmSync(isolatedCwd, { recursive: true, force: true });
+    }
   });
 
   it('responds on the configured host', async () => {
     const res = await fetch(`http://${testHost}:${testPort}/healthz`);
     expect(res.status).toBe(200);
+  });
+
+  it('uses the DSN env var, not an ambient dbhub.toml', () => {
+    // Guards the isolated cwd above: if the server is ever spawned from the repo
+    // root again, a developer's local dbhub.toml wins over DSN and this reports
+    // the cause directly instead of an opaque startup timeout.
+    expect(startupLogs.join('')).toContain('Configuration source: environment variable');
   });
 
   it('logs the actual bound address at startup', () => {

--- a/src/__tests__/json-rpc-integration.test.ts
+++ b/src/__tests__/json-rpc-integration.test.ts
@@ -8,17 +8,33 @@ describe('JSON RPC Integration Tests', () => {
   let serverProcess: ChildProcess | null = null;
   let testDbPath: string;
   let baseUrl: string;
+  let isolatedCwd: string;
   const testPort = 3001;
+  const startupLogs: string[] = [];
 
   beforeAll(async () => {
     // Create a temporary SQLite database file
     const tempDir = os.tmpdir();
     testDbPath = path.join(tempDir, `json_rpc_test_${Date.now()}_${Math.random().toString(36).substr(2, 9)}.db`);
-    
+
+    // The server discovers ./dbhub.toml relative to its own cwd, and TOML config
+    // outranks the DSN env var below. Running from the repo root would therefore
+    // silently ignore DSN and connect to whatever a developer's local (gitignored)
+    // dbhub.toml names, so the server would fail to start on any machine that has
+    // one. Spawn from an empty directory to isolate config discovery.
+    isolatedCwd = fs.mkdtempSync(path.join(tempDir, 'json_rpc_cwd_'));
+
     baseUrl = `http://localhost:${testPort}`;
-    
+
+    // Invoke tsx directly via node rather than `pnpm dev`: `pnpm dev` runs the
+    // backend and the Vite frontend under `concurrently`, and the frontend is both
+    // unnecessary here and leaked a stray dev server on every run.
+    const tsxCli = path.resolve(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
+    const entry = path.resolve(process.cwd(), 'src', 'index.ts');
+
     // Start the server as a child process
-    serverProcess = spawn('pnpm', ['dev'], {
+    serverProcess = spawn(process.execPath, [tsxCli, entry, '--transport=http'], {
+      cwd: isolatedCwd,
       env: {
         ...process.env,
         DSN: `sqlite://${testDbPath}`,
@@ -29,13 +45,15 @@ describe('JSON RPC Integration Tests', () => {
       stdio: 'pipe'
     });
 
-    // Handle server output
+    // Handle server output. Retained for the failure message below: without the
+    // server's own logs, a startup failure surfaces only as a timeout with no
+    // indication of the cause.
     serverProcess.stdout?.on('data', (data) => {
-      console.log(`Server stdout: ${data}`);
+      startupLogs.push(data.toString());
     });
 
     serverProcess.stderr?.on('data', (data) => {
-      console.error(`Server stderr: ${data}`);
+      startupLogs.push(data.toString());
     });
 
     // Wait for server to start up
@@ -65,7 +83,7 @@ describe('JSON RPC Integration Tests', () => {
     }
     
     if (!serverReady) {
-      throw new Error('Server did not start within expected time');
+      throw new Error(`Server did not start within expected time. Logs:\n${startupLogs.join('')}`);
     }
     
     // Create test tables and data via HTTP request
@@ -123,6 +141,11 @@ describe('JSON RPC Integration Tests', () => {
     if (testDbPath && fs.existsSync(testDbPath)) {
       fs.unlinkSync(testDbPath);
     }
+
+    // Clean up the isolated working directory
+    if (isolatedCwd && fs.existsSync(isolatedCwd)) {
+      fs.rmSync(isolatedCwd, { recursive: true, force: true });
+    }
   });
 
   async function makeJsonRpcCall(method: string, params: any): Promise<any> {
@@ -150,6 +173,13 @@ describe('JSON RPC Integration Tests', () => {
     // Server uses JSON responses in stateless mode (no SSE)
     return await response.json();
   }
+
+  it('uses the DSN env var, not an ambient dbhub.toml', () => {
+    // Guards the isolated cwd above: if the server is ever spawned from the repo
+    // root again, a developer's local dbhub.toml wins over DSN and this reports
+    // the cause directly instead of an opaque startup timeout.
+    expect(startupLogs.join('')).toContain('Configuration source: environment variable');
+  });
 
   describe('execute_sql JSON RPC calls', () => {
     it('should execute a simple SELECT query successfully', async () => {

--- a/src/__tests__/json-rpc-integration.test.ts
+++ b/src/__tests__/json-rpc-integration.test.ts
@@ -122,17 +122,22 @@ describe('JSON RPC Integration Tests', () => {
       serverProcess.kill('SIGTERM');
       
       // Wait for process to exit
-      await new Promise((resolve) => {
+      await new Promise<void>((resolve) => {
         if (serverProcess) {
-          serverProcess.on('exit', resolve);
-          setTimeout(() => {
+          // Without clearing this on normal exit, the pending timer keeps
+          // the Vitest process alive until the 5s tail elapses.
+          const killTimeout = setTimeout(() => {
             if (serverProcess && !serverProcess.killed) {
               serverProcess.kill('SIGKILL');
             }
-            resolve(void 0);
+            resolve();
           }, 5000);
+          serverProcess.on('exit', () => {
+            clearTimeout(killTimeout);
+            resolve();
+          });
         } else {
-          resolve(void 0);
+          resolve();
         }
       });
     }


### PR DESCRIPTION
Follow-up to #366, where these two tests failed locally and the cause turned out to be unrelated to that PR.

## The bug

`json-rpc-integration.test.ts` and `http-bind-host.integration.test.ts` spawn the server with `DSN` set. But the server discovers `./dbhub.toml` relative to **its own cwd**, and TOML config outranks the `DSN` env var. Spawned from the repo root, the server ignored `DSN` and connected to whatever the developer's local config named:

```
Configuration source: dbhub.toml
  - local_pg: postgres://...@localhost:5432/employee
Failed to connect to PostgreSQL database: error: database "employee" does not exist
```

The backend then exited, nothing ever listened on the test port, and the failure surfaced as:

```
Error: Server did not start within expected time
```

`dbhub.toml` is gitignored, so this reproduces only on machines that have one and never in CI — which is why it looked intermittent and why the message gave no hint of the real cause.

## The fix

- **Isolated cwd.** Both tests now spawn the server from an empty temp directory, so config discovery can't pick up ambient files. Discovery is `path.join(process.cwd(), "dbhub.toml")` with no upward walk, so an empty cwd is sufficient.
- **json-rpc no longer shells out to `pnpm dev`.** It now invokes tsx directly, matching what `http-bind-host` already did. `pnpm dev` runs the backend *and* the Vite frontend under `concurrently`; the frontend was unnecessary and leaked a stray dev server on every run — I found six orphaned on ports 5173-5179 while investigating. Verified no vite process leaks now by counting listeners before and after a run.
- **Startup failures now include the server's own logs**, so the next occurrence of anything like this is diagnosable from the failure message instead of requiring a manual repro.
- **Guard test** asserting `Configuration source: environment variable`, so a regression reports the actual cause rather than a timeout.

Side benefit: json-rpc drops from **~25s to ~1.1s**, since it no longer builds and starts a frontend.

## Verification

- The two tests now pass **with a `dbhub.toml` present in the repo root** — the exact condition that broke them before.
- Full suite: **1100 passing**. The only failure is `sqlserver.integration.test.ts`, whose container doesn't boot on arm64; it fails identically on a clean `main` and is untouched here.

## Honest limitation

The guard test is **not CI-detectable**. With no `dbhub.toml` in CI, the DSN path is taken whether or not the cwd is isolated, so a future revert of the cwd change would still pass CI and only break developers' machines. I considered writing a poisoned `dbhub.toml` into the repo root during the test to force the condition everywhere, but rejected it: the file is gitignored and could clobber a developer's real config. The guard's value is diagnostic — an immediate, explanatory failure instead of a 25s opaque timeout.

## Separate bug found, not fixed here

`--dsn` is also silently ignored when a `dbhub.toml` exists, which contradicts the documented priority order in CLAUDE.md ("1. Command-line arguments (highest), 2. TOML config file"). `resolveSourceConfigs()` in `src/config/env.ts:656` returns the TOML config before `resolveDSN()` is ever consulted. Reproduced directly:

```
$ npx tsx src/index.ts --transport=http --dsn="sqlite://:memory:"
Configuration source: dbhub.toml
Fatal error: error: database "employee" does not exist
```

That's a user-facing behavior/docs mismatch rather than a test issue, and fixing it means deciding whether `--dsn` should override TOML or whether the docs are wrong — so I left it alone. Happy to file or fix it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)