### PR TITLE
fix: TOML config loading, DSN conflict, and .env interpolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,12 @@ DBHub supports three configuration methods:
 ### Configuration Priority Order
 
 **Database sources** come from either a TOML file (`--config`) or a DSN. TOML defines
-sources for one or more databases; a DSN configures exactly one. Passing both throws
-an error naming the conflicting DSN source — see `detectDSNConfig` and
-`resolveSourceConfigs` in `src/config/env.ts`.
+sources for one or more databases; a DSN configures exactly one, so `--config` and
+`--dsn` together throw — see `resolveSourceConfigs` in `src/config/env.ts`.
+
+The guard is deliberately limited to the `--dsn` flag. `DSN` and `DB_*` environment
+variables (exported or from `.env`) are left alone because TOML `${VAR}` interpolation
+reads them: `dsn = "${DSN}"` is a supported way to keep credentials out of the file.
 
 Without `--config`, the DSN is resolved in this order:
 1. `--dsn` command-line argument

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,8 @@ DBHub supports three configuration methods (in priority order):
   - Set individual parameters: `DB_TYPE`, `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`
 - SSH tunnel via environment: `SSH_HOST`, `SSH_PORT`, `SSH_USER`, `SSH_PASSWORD`, `SSH_KEY`, `SSH_PASSPHRASE`
 
-### 3. Command-Line Arguments (Single Database, Highest Priority)
-- `--dsn`: Database connection string
+### 3. Command-Line Arguments
+- `--dsn`: Database connection string (single database; cannot be combined with TOML config)
 - `--transport`: `stdio` (default) or `http` for streamable HTTP transport (endpoint: `/mcp`)
 - `--port`: HTTP server port (default: 8080)
 - `--host`: HTTP bind host (default: `0.0.0.0`; env `DBHUB_HOST`)
@@ -132,10 +132,25 @@ DBHub supports three configuration methods (in priority order):
 - Documentation: https://dbhub.ai/config/command-line
 
 ### Configuration Priority Order
-1. Command-line arguments (highest)
-2. TOML config file (if present)
-3. Environment variables
+
+**Database sources** are configured either by TOML *or* by a DSN — never both. TOML
+defines sources for one or more databases; a DSN configures exactly one. Supplying
+both is rejected at startup with an error naming the conflicting DSN source, rather
+than silently preferring one. See `detectDSNConfig`/`resolveSourceConfigs` in
+`src/config/env.ts`.
+
+When no TOML config is present, the DSN is resolved in this order:
+1. `--dsn` command-line argument (highest)
+2. `DSN` environment variable
+3. Individual `DB_*` environment variables
 4. `.env` files (`.env.local` in development, `.env` in production)
+
+**All other settings** (`--transport`, `--port`, `--host`, `--allowed-hosts`, …) are
+not expressible in TOML and follow the conventional order:
+1. Command-line arguments (highest)
+2. Environment variables
+3. `.env` files
+4. Built-in defaults
 
 ## Database Connectors
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ DBHub supports three configuration methods (in priority order):
 ### 1. TOML Configuration File (Multi-Database)
 **Recommended for projects requiring multiple database connections**
 
-- Create `dbhub.toml` in your project directory or use `--config=path/to/config.toml`
+- Loaded only via `--config=path/to/config.toml`. A `dbhub.toml` in the current directory is **not** auto-discovered (removed deliberately — see `resolveTomlConfigPath` in `src/config/toml-loader.ts`); pass `--config=dbhub.toml` to load it
 - Configuration structure:
   - `[[sources]]` - Database connection definitions with unique `id` fields
   - `[[tools]]` - Tool configuration (execution settings, custom tools)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,12 +64,12 @@ Key architectural patterns:
 
 ## Configuration
 
-DBHub supports three configuration methods (in priority order):
+DBHub supports three configuration methods:
 
 ### 1. TOML Configuration File (Multi-Database)
 **Recommended for projects requiring multiple database connections**
 
-- Loaded only via `--config=path/to/config.toml`. A `dbhub.toml` in the current directory is **not** auto-discovered (removed deliberately — see `resolveTomlConfigPath` in `src/config/toml-loader.ts`); pass `--config=dbhub.toml` to load it
+- Load with `--config=path/to/config.toml` (see `resolveTomlConfigPath` in `src/config/toml-loader.ts`)
 - Configuration structure:
   - `[[sources]]` - Database connection definitions with unique `id` fields
   - `[[tools]]` - Tool configuration (execution settings, custom tools)
@@ -133,21 +133,20 @@ DBHub supports three configuration methods (in priority order):
 
 ### Configuration Priority Order
 
-**Database sources** are configured either by TOML *or* by a DSN — never both. TOML
-defines sources for one or more databases; a DSN configures exactly one. Supplying
-both is rejected at startup with an error naming the conflicting DSN source, rather
-than silently preferring one. See `detectDSNConfig`/`resolveSourceConfigs` in
-`src/config/env.ts`.
+**Database sources** come from either a TOML file (`--config`) or a DSN. TOML defines
+sources for one or more databases; a DSN configures exactly one. Passing both throws
+an error naming the conflicting DSN source — see `detectDSNConfig` and
+`resolveSourceConfigs` in `src/config/env.ts`.
 
-When no TOML config is present, the DSN is resolved in this order:
-1. `--dsn` command-line argument (highest)
+Without `--config`, the DSN is resolved in this order:
+1. `--dsn` command-line argument
 2. `DSN` environment variable
 3. Individual `DB_*` environment variables
 4. `.env` files (`.env.local` in development, `.env` in production)
 
-**All other settings** (`--transport`, `--port`, `--host`, `--allowed-hosts`, …) are
-not expressible in TOML and follow the conventional order:
-1. Command-line arguments (highest)
+**All other settings** (`--transport`, `--port`, `--host`, `--allowed-hosts`, …) live
+outside TOML and follow the same order:
+1. Command-line arguments
 2. Environment variables
 3. `.env` files
 4. Built-in defaults

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -5,14 +5,15 @@ title: "Command-Line Options"
 DBHub is configured by command-line flags, environment variables, `.env` files, and an optional [TOML configuration file](/config/toml).
 
 <Note>
-**TOML config and a DSN cannot be combined.** A TOML file defines database sources
-directly and supports multiple databases, while a DSN configures exactly one. If
-DBHub finds a TOML config *and* a DSN (`--dsn`, `DSN`, `DB_*` variables, or a DSN in
-a `.env` file), it exits with an error naming the conflicting DSN rather than
-silently ignoring one of them. Use one or the other.
+**TOML config is opt-in, and cannot be combined with a DSN.** TOML is loaded only
+when you pass `--config`; a `dbhub.toml` in the current directory is never picked up
+automatically. A TOML file defines database sources directly and supports multiple
+databases, while a DSN configures exactly one — so if you pass `--config` *and* a DSN
+(`--dsn`, `DSN`, `DB_*` variables, or a DSN in a `.env` file), DBHub exits with an
+error naming the conflict rather than silently ignoring one of them.
 </Note>
 
-**Choosing the database** — when no TOML config is present, the DSN is taken from the first of:
+**Choosing the database** — without `--config`, the DSN is taken from the first of:
 
 1. `--dsn` command-line argument (highest priority)
 2. `DSN` environment variable
@@ -285,10 +286,10 @@ This page covers command-line flags and environment variables. For TOML configur
 
 ### --config
 
-<ParamField path="--config" type="string" default="./dbhub.toml">
+<ParamField path="--config" type="string">
   Path to TOML configuration file for managing multiple database connections and advanced configurations.
 
-  Automatically loads `./dbhub.toml` if it exists in the current directory.
+  TOML configuration is loaded **only** when `--config` names it. A `dbhub.toml` in the current directory is not picked up automatically — pass `--config ./dbhub.toml` to use it.
 
   ```bash
   npx @bytebase/dbhub@latest --config ./dbhub.toml --transport http --port 8080

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -7,7 +7,9 @@ DBHub connects to your database in one of two ways:
 - **A DSN** — one connection string for a single database.
 - **A [TOML file](/config/toml)** — passed with `--config`, for one or more databases plus per-source and per-tool settings.
 
-Choose one. A TOML file defines its sources itself, so passing `--config` together with a DSN (`--dsn`, `DSN`, `DB_*` variables, or a DSN in a `.env` file) exits with an error naming the conflict.
+Choose one. A TOML file defines its sources itself, so `--config` and `--dsn` cannot be combined.
+
+Environment variables are a different matter: `DSN` and `DB_*` stay available to a TOML file through [`${VAR}` interpolation](/config/toml#environment-variable-interpolation), which is the recommended way to keep credentials out of the file.
 
 When you use a DSN, DBHub takes it from the first of:
 

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -2,30 +2,26 @@
 title: "Command-Line Options"
 ---
 
-DBHub is configured by command-line flags, environment variables, `.env` files, and an optional [TOML configuration file](/config/toml).
+DBHub connects to your database in one of two ways:
 
-<Note>
-**TOML config is opt-in, and cannot be combined with a DSN.** TOML is loaded only
-when you pass `--config`; a `dbhub.toml` in the current directory is never picked up
-automatically. A TOML file defines database sources directly and supports multiple
-databases, while a DSN configures exactly one — so if you pass `--config` *and* a DSN
-(`--dsn`, `DSN`, `DB_*` variables, or a DSN in a `.env` file), DBHub exits with an
-error naming the conflict rather than silently ignoring one of them.
-</Note>
+- **A DSN** — one connection string for a single database.
+- **A [TOML file](/config/toml)** — passed with `--config`, for one or more databases plus per-source and per-tool settings.
 
-**Choosing the database** — without `--config`, the DSN is taken from the first of:
+Choose one. A TOML file defines its sources itself, so passing `--config` together with a DSN (`--dsn`, `DSN`, `DB_*` variables, or a DSN in a `.env` file) exits with an error naming the conflict.
 
-1. `--dsn` command-line argument (highest priority)
+When you use a DSN, DBHub takes it from the first of:
+
+1. `--dsn` flag
 2. `DSN` environment variable
-3. Individual `DB_*` environment variables
-4. `.env` files (`.env.local` in development, `.env` in production)
+3. `DB_*` environment variables
+4. `.env` file (`.env.local` in development, `.env` in production)
 
-**Every other setting** (transport, port, host, and so on) cannot be set in TOML, and uses the conventional order:
+Every other option — transport, port, host, and so on — is set by flag or environment variable, in the same order:
 
-1. **Command-line arguments** (highest priority)
-2. **Environment variables**
-3. **`.env` files**
-4. Built-in defaults
+1. Command-line flag
+2. Environment variable
+3. `.env` file
+4. Built-in default
 
 This page covers command-line flags and environment variables. For TOML configuration, see [TOML Configuration](/config/toml).
 
@@ -287,22 +283,16 @@ This page covers command-line flags and environment variables. For TOML configur
 ### --config
 
 <ParamField path="--config" type="string">
-  Path to TOML configuration file for managing multiple database connections and advanced configurations.
-
-  TOML configuration is loaded **only** when `--config` names it. A `dbhub.toml` in the current directory is not picked up automatically — pass `--config ./dbhub.toml` to use it.
+  Path to a TOML configuration file, for managing multiple database connections and advanced configuration.
 
   ```bash
   npx @bytebase/dbhub@latest --config ./dbhub.toml --transport http --port 8080
   ```
 
-  See [TOML Configuration](/config/toml) for complete configuration reference including source options, tool options, SSH tunnels, and custom tools.
+  See [TOML Configuration](/config/toml) for the complete reference, including source options, tool options, SSH tunnels, and custom tools.
 
   <Warning>
-  **`--config` (TOML) is mutually exclusive with:**
-  - `--dsn` - TOML configuration defines database connections directly
-  - `--id` - TOML configuration defines source IDs directly in the file
-
-  If using TOML config, remove these flags. If you need `--id` or `--dsn`, use command-line/environment configuration instead.
+  A TOML file defines its own sources and source IDs, so `--config` is mutually exclusive with `--dsn` and `--id`. Use either a TOML file or command-line/environment configuration.
   </Warning>
 </ParamField>
 

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -285,7 +285,7 @@ This page covers command-line flags and environment variables. For TOML configur
 ### --config
 
 <ParamField path="--config" type="string">
-  Path to a TOML configuration file, for managing multiple database connections and advanced configuration.
+  Path to a TOML configuration file, for managing multiple database connections and advanced configurations.
 
   ```bash
   npx @bytebase/dbhub@latest --config ./dbhub.toml --transport http --port 8080

--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -2,16 +2,31 @@
 title: "Command-Line Options"
 ---
 
-DBHub supports three configuration methods with the following priority order:
+DBHub is configured by command-line flags, environment variables, `.env` files, and an optional [TOML configuration file](/config/toml).
+
+<Note>
+**TOML config and a DSN cannot be combined.** A TOML file defines database sources
+directly and supports multiple databases, while a DSN configures exactly one. If
+DBHub finds a TOML config *and* a DSN (`--dsn`, `DSN`, `DB_*` variables, or a DSN in
+a `.env` file), it exits with an error naming the conflicting DSN rather than
+silently ignoring one of them. Use one or the other.
+</Note>
+
+**Choosing the database** — when no TOML config is present, the DSN is taken from the first of:
+
+1. `--dsn` command-line argument (highest priority)
+2. `DSN` environment variable
+3. Individual `DB_*` environment variables
+4. `.env` files (`.env.local` in development, `.env` in production)
+
+**Every other setting** (transport, port, host, and so on) cannot be set in TOML, and uses the conventional order:
 
 1. **Command-line arguments** (highest priority)
-2. **TOML configuration file** (if `--config` is provided or `./dbhub.toml` exists)
-3. **Environment variables**
-4. **`.env` files** (`.env.local` in development, `.env` in production)
+2. **Environment variables**
+3. **`.env` files**
+4. Built-in defaults
 
 This page covers command-line flags and environment variables. For TOML configuration, see [TOML Configuration](/config/toml).
-
-Command-line flags are passed when starting DBHub. These have the highest priority and override all other configuration methods.
 
 ### --transport
 

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -4,6 +4,14 @@ title: "TOML Configuration"
 
 TOML configuration is the recommended way to configure DBHub for multi-database setups and advanced configurations. It provides more flexibility than command-line options or environment variables.
 
+<Note>
+TOML configuration replaces DSN configuration rather than layering on top of it.
+DBHub exits with an error if it finds a TOML config alongside a DSN (`--dsn`, `DSN`,
+`DB_*` variables, or a DSN in a `.env` file), since the two express conflicting
+intents: TOML defines sources for one or more databases, a DSN configures exactly
+one. Remove the DSN, or point `--config` elsewhere.
+</Note>
+
 ## Overview
 
 TOML configuration enables:

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -11,7 +11,7 @@ Load a TOML file with `--config`:
 npx @bytebase/dbhub@latest --config ./dbhub.toml
 ```
 
-A TOML file defines its own database sources, so it takes the place of DSN configuration. Passing `--config` alongside a DSN (`--dsn`, `DSN`, `DB_*` variables, or a DSN in a `.env` file) exits with an error naming the conflict.
+A TOML file defines its own database sources, so `--config` and `--dsn` cannot be combined. Environment variables such as `DSN` and `DB_*` remain available to the file through [`${VAR}` interpolation](#environment-variable-interpolation).
 </Note>
 
 ## Overview

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -5,13 +5,13 @@ title: "TOML Configuration"
 TOML configuration is the recommended way to configure DBHub for multi-database setups and advanced configurations. It provides more flexibility than command-line options or environment variables.
 
 <Note>
-**TOML configuration is loaded only via `--config`.** A `dbhub.toml` in the current
-directory is not auto-discovered — start DBHub with `--config ./dbhub.toml`.
+Load a TOML file with `--config`:
 
-It also replaces DSN configuration rather than layering on top of it. DBHub exits
-with an error if you pass `--config` alongside a DSN (`--dsn`, `DSN`, `DB_*`
-variables, or a DSN in a `.env` file), since the two express conflicting intents:
-TOML defines sources for one or more databases, a DSN configures exactly one.
+```bash
+npx @bytebase/dbhub@latest --config ./dbhub.toml
+```
+
+A TOML file defines its own database sources, so it takes the place of DSN configuration. Passing `--config` alongside a DSN (`--dsn`, `DSN`, `DB_*` variables, or a DSN in a `.env` file) exits with an error naming the conflict.
 </Note>
 
 ## Overview

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -5,11 +5,13 @@ title: "TOML Configuration"
 TOML configuration is the recommended way to configure DBHub for multi-database setups and advanced configurations. It provides more flexibility than command-line options or environment variables.
 
 <Note>
-TOML configuration replaces DSN configuration rather than layering on top of it.
-DBHub exits with an error if it finds a TOML config alongside a DSN (`--dsn`, `DSN`,
-`DB_*` variables, or a DSN in a `.env` file), since the two express conflicting
-intents: TOML defines sources for one or more databases, a DSN configures exactly
-one. Remove the DSN, or point `--config` elsewhere.
+**TOML configuration is loaded only via `--config`.** A `dbhub.toml` in the current
+directory is not auto-discovered — start DBHub with `--config ./dbhub.toml`.
+
+It also replaces DSN configuration rather than layering on top of it. DBHub exits
+with an error if you pass `--config` alongside a DSN (`--dsn`, `DSN`, `DB_*`
+variables, or a DSN in a `.env` file), since the two express conflicting intents:
+TOML defines sources for one or more databases, a DSN configures exactly one.
 </Note>
 
 ## Overview
@@ -86,7 +88,7 @@ A TOML configuration file has two main sections:
 1. **`[[sources]]`** - Database connection definitions
 2. **`[[tools]]`** - Tool configuration (execution settings, custom tools)
 
-Create `dbhub.toml` in your project directory:
+Create `dbhub.toml` in your project directory, then load it with `--config ./dbhub.toml`:
 
 ```toml dbhub.toml
 # Define database sources

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { buildDSNFromEnvParams, resolveDSN, resolveHost, resolveId } from '../env.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { buildDSNFromEnvParams, detectDSNConfig, resolveDSN, resolveHost, resolveId } from '../env.js';
+import { loadTomlConfig } from '../toml-loader.js';
 
 // Mock toml-loader to prevent it from loading dbhub.toml during tests
 vi.mock('../toml-loader.js', () => ({
@@ -612,6 +616,114 @@ describe('Environment Configuration Tests', () => {
       const result = resolveHost();
 
       expect(result).toEqual({ host: '127.0.0.1', source: 'command line argument' });
+    });
+  });
+
+  describe('detectDSNConfig', () => {
+    // envPath is passed explicitly throughout so these never depend on whether
+    // the developer running them happens to have a .env file.
+    const originalArgv = process.argv;
+
+    beforeEach(() => {
+      process.argv = ['node', 'script.js'];
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+    });
+
+    it('returns null when no DSN is configured anywhere', () => {
+      expect(detectDSNConfig(null)).toBeNull();
+    });
+
+    it('detects the --dsn flag', () => {
+      process.argv = ['node', 'script.js', '--dsn=sqlite://:memory:'];
+
+      expect(detectDSNConfig(null)).toEqual({ source: '--dsn command line argument' });
+    });
+
+    it('detects the DSN environment variable', () => {
+      process.env.DSN = 'sqlite://:memory:';
+
+      expect(detectDSNConfig(null)).toEqual({ source: 'DSN environment variable' });
+    });
+
+    it('detects individual DB_* environment variables', () => {
+      process.env.DB_TYPE = 'sqlite';
+      process.env.DB_NAME = 'test.db';
+
+      expect(detectDSNConfig(null)).toEqual({ source: 'DB_* environment variables' });
+    });
+
+    it('detects a DSN in a .env file without applying it to process.env', () => {
+      const envFile = path.join(os.tmpdir(), `detect_dsn_${Date.now()}.env`);
+      fs.writeFileSync(envFile, 'DSN=sqlite://from-env-file.db\nPORT=9999\n');
+
+      try {
+        expect(detectDSNConfig(envFile)).toEqual({
+          source: `DSN in ${path.basename(envFile)}`,
+        });
+        // The whole point of parsing rather than loading: checking for a
+        // conflict must not pull unrelated settings into the process.
+        expect(process.env.DSN).toBeUndefined();
+        expect(process.env.PORT).not.toBe('9999');
+      } finally {
+        fs.unlinkSync(envFile);
+      }
+    });
+
+    it('ignores a .env file that configures no database', () => {
+      const envFile = path.join(os.tmpdir(), `detect_nodsn_${Date.now()}.env`);
+      fs.writeFileSync(envFile, 'PORT=9999\nTRANSPORT=http\n');
+
+      try {
+        expect(detectDSNConfig(envFile)).toBeNull();
+      } finally {
+        fs.unlinkSync(envFile);
+      }
+    });
+  });
+
+  describe('resolveSourceConfigs TOML/DSN conflict', () => {
+    const originalArgv = process.argv;
+
+    beforeEach(() => {
+      process.argv = ['node', 'script.js'];
+      vi.mocked(loadTomlConfig).mockReturnValue({
+        sources: [{ id: 'db1', type: 'sqlite', dsn: 'sqlite://a.db' }],
+        source: 'dbhub.toml',
+      } as any);
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      vi.mocked(loadTomlConfig).mockReturnValue(null);
+    });
+
+    it('rejects a DSN env var supplied alongside TOML config', async () => {
+      process.env.DSN = 'sqlite://:memory:';
+      const { resolveSourceConfigs } = await import('../env.js');
+
+      await expect(resolveSourceConfigs()).rejects.toThrow(
+        /DSN configuration \(DSN environment variable\) cannot be used with TOML configuration/
+      );
+    });
+
+    it('rejects a --dsn flag supplied alongside TOML config', async () => {
+      process.argv = ['node', 'script.js', '--dsn=sqlite://:memory:'];
+      const { resolveSourceConfigs } = await import('../env.js');
+
+      await expect(resolveSourceConfigs()).rejects.toThrow(
+        /DSN configuration \(--dsn command line argument\) cannot be used with TOML configuration/
+      );
+    });
+
+    it('names the conflicting source so the user knows what to remove', async () => {
+      process.env.DB_TYPE = 'sqlite';
+      process.env.DB_NAME = 'test.db';
+      const { resolveSourceConfigs } = await import('../env.js');
+
+      await expect(resolveSourceConfigs()).rejects.toThrow(/DB_\* environment variables/);
     });
   });
 });

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import { buildDSNFromEnvParams, detectDSNConfig, resolveDSN, resolveHost, resolveId } from '../env.js';
+import { buildDSNFromEnvParams, resolveDSN, resolveHost, resolveId } from '../env.js';
 import { loadTomlConfig } from '../toml-loader.js';
 
 // Mock toml-loader to prevent it from loading dbhub.toml during tests
@@ -619,71 +616,6 @@ describe('Environment Configuration Tests', () => {
     });
   });
 
-  describe('detectDSNConfig', () => {
-    // envPath is passed explicitly throughout so these never depend on whether
-    // the developer running them happens to have a .env file.
-    const originalArgv = process.argv;
-
-    beforeEach(() => {
-      process.argv = ['node', 'script.js'];
-    });
-
-    afterEach(() => {
-      process.argv = originalArgv;
-    });
-
-    it('returns null when no DSN is configured anywhere', () => {
-      expect(detectDSNConfig(null)).toBeNull();
-    });
-
-    it('detects the --dsn flag', () => {
-      process.argv = ['node', 'script.js', '--dsn=sqlite://:memory:'];
-
-      expect(detectDSNConfig(null)).toEqual({ source: '--dsn command line argument' });
-    });
-
-    it('detects the DSN environment variable', () => {
-      process.env.DSN = 'sqlite://:memory:';
-
-      expect(detectDSNConfig(null)).toEqual({ source: 'DSN environment variable' });
-    });
-
-    it('detects individual DB_* environment variables', () => {
-      process.env.DB_TYPE = 'sqlite';
-      process.env.DB_NAME = 'test.db';
-
-      expect(detectDSNConfig(null)).toEqual({ source: 'DB_* environment variables' });
-    });
-
-    it('detects a DSN in a .env file without applying it to process.env', () => {
-      const envFile = path.join(os.tmpdir(), `detect_dsn_${Date.now()}.env`);
-      fs.writeFileSync(envFile, 'DSN=sqlite://from-env-file.db\nPORT=9999\n');
-
-      try {
-        expect(detectDSNConfig(envFile)).toEqual({
-          source: `DSN in ${path.basename(envFile)}`,
-        });
-        // The whole point of parsing rather than loading: checking for a
-        // conflict must not pull unrelated settings into the process.
-        expect(process.env.DSN).toBeUndefined();
-        expect(process.env.PORT).not.toBe('9999');
-      } finally {
-        fs.unlinkSync(envFile);
-      }
-    });
-
-    it('ignores a .env file that configures no database', () => {
-      const envFile = path.join(os.tmpdir(), `detect_nodsn_${Date.now()}.env`);
-      fs.writeFileSync(envFile, 'PORT=9999\nTRANSPORT=http\n');
-
-      try {
-        expect(detectDSNConfig(envFile)).toBeNull();
-      } finally {
-        fs.unlinkSync(envFile);
-      }
-    });
-  });
-
   describe('resolveSourceConfigs TOML/DSN conflict', () => {
     const originalArgv = process.argv;
 
@@ -700,30 +632,37 @@ describe('Environment Configuration Tests', () => {
       vi.mocked(loadTomlConfig).mockReturnValue(null);
     });
 
-    it('rejects a DSN env var supplied alongside TOML config', async () => {
-      process.env.DSN = 'sqlite://:memory:';
-      const { resolveSourceConfigs } = await import('../env.js');
-
-      await expect(resolveSourceConfigs()).rejects.toThrow(
-        /DSN configuration \(DSN environment variable\) cannot be used with TOML configuration/
-      );
-    });
-
     it('rejects a --dsn flag supplied alongside TOML config', async () => {
       process.argv = ['node', 'script.js', '--dsn=sqlite://:memory:'];
       const { resolveSourceConfigs } = await import('../env.js');
 
       await expect(resolveSourceConfigs()).rejects.toThrow(
-        /DSN configuration \(--dsn command line argument\) cannot be used with TOML configuration/
+        /The --dsn flag cannot be used with TOML configuration \(dbhub.toml\)/
       );
     });
 
-    it('names the conflicting source so the user knows what to remove', async () => {
+    it('allows a DSN env var alongside TOML config', async () => {
+      // TOML interpolation reads process.env, so `dsn = "${DSN}"` in the config
+      // file is a supported way to keep credentials out of it. An exported DSN
+      // is config material for TOML, not a competing single-database setup.
+      process.env.DSN = 'postgres://user:pass@localhost:5432/mydb';
+      const { resolveSourceConfigs } = await import('../env.js');
+
+      await expect(resolveSourceConfigs()).resolves.toMatchObject({
+        source: 'dbhub.toml',
+      });
+    });
+
+    it('allows DB_* env vars alongside TOML config', async () => {
+      // Same reasoning: these may exist purely to feed ${DB_PASSWORD}-style
+      // interpolation in the TOML file.
       process.env.DB_TYPE = 'sqlite';
       process.env.DB_NAME = 'test.db';
       const { resolveSourceConfigs } = await import('../env.js');
 
-      await expect(resolveSourceConfigs()).rejects.toThrow(/DB_\* environment variables/);
+      await expect(resolveSourceConfigs()).resolves.toMatchObject({
+        source: 'dbhub.toml',
+      });
     });
   });
 });

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { buildDSNFromEnvParams, resolveDSN, resolveHost, resolveId } from '../env.js';
 import { loadTomlConfig } from '../toml-loader.js';
 
@@ -651,6 +654,27 @@ describe('Environment Configuration Tests', () => {
       await expect(resolveSourceConfigs()).resolves.toMatchObject({
         source: 'dbhub.toml',
       });
+    });
+
+    it('loads .env before TOML config so ${VAR} interpolation can resolve', async () => {
+      // interpolateEnvVars() reads process.env, so the file has to be loaded
+      // before the TOML is parsed for `dsn = "${DSN}"` to resolve.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'env-before-toml-'));
+      const cwd = process.cwd();
+      fs.writeFileSync(path.join(dir, '.env'), 'DSN_FROM_ENV_FILE=sqlite://interpolated.db\n');
+      process.chdir(dir);
+      process.argv = ['node', 'script.js', '--config', path.join(dir, 'dbhub.toml')];
+
+      try {
+        const { resolveSourceConfigs } = await import('../env.js');
+        await resolveSourceConfigs();
+
+        expect(process.env.DSN_FROM_ENV_FILE).toBe('sqlite://interpolated.db');
+      } finally {
+        process.chdir(cwd);
+        delete process.env.DSN_FROM_ENV_FILE;
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('allows DB_* env vars alongside TOML config', async () => {

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -621,9 +621,19 @@ describe('Environment Configuration Tests', () => {
 
   describe('resolveSourceConfigs TOML/DSN conflict', () => {
     const originalArgv = process.argv;
+    const originalCwd = process.cwd();
+    let tempDir: string;
+    let configPath: string;
 
     beforeEach(() => {
-      process.argv = ['node', 'script.js'];
+      // Run from an empty directory so an ambient .env cannot reach the
+      // .env-before-TOML load that --config now triggers.
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'toml-dsn-conflict-'));
+      configPath = path.join(tempDir, 'dbhub.toml');
+      process.chdir(tempDir);
+      // --config is the only way TOML gets loaded, so it has to be present for
+      // the mocked loadTomlConfig() to stand for a state reachable at runtime.
+      process.argv = ['node', 'script.js', '--config', configPath];
       vi.mocked(loadTomlConfig).mockReturnValue({
         sources: [{ id: 'db1', type: 'sqlite', dsn: 'sqlite://a.db' }],
         source: 'dbhub.toml',
@@ -631,12 +641,14 @@ describe('Environment Configuration Tests', () => {
     });
 
     afterEach(() => {
+      process.chdir(originalCwd);
+      fs.rmSync(tempDir, { recursive: true, force: true });
       process.argv = originalArgv;
       vi.mocked(loadTomlConfig).mockReturnValue(null);
     });
 
     it('rejects a --dsn flag supplied alongside TOML config', async () => {
-      process.argv = ['node', 'script.js', '--dsn=sqlite://:memory:'];
+      process.argv = ['node', 'script.js', '--config', configPath, '--dsn=sqlite://:memory:'];
       const { resolveSourceConfigs } = await import('../env.js');
 
       await expect(resolveSourceConfigs()).rejects.toThrow(

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -14,9 +14,8 @@ describe('TOML Configuration Tests', () => {
     // Create a temporary directory for test config files
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dbhub-test-'));
     process.chdir(tempDir);
-    // TOML config is only loaded when --config names it explicitly (there is no
-    // cwd auto-discovery), so point --config at the file each test writes.
-    // Tests covering the absent/explicit-path cases override argv themselves.
+    // Only --config selects a config file, so point it at the file each test
+    // writes. Tests covering the absent/explicit-path cases override argv.
     process.argv = ['node', 'test', '--config', path.join(tempDir, 'dbhub.toml')];
   });
 
@@ -197,9 +196,9 @@ dsn = "mysql://user:pass@localhost:3306/db"
       expect(result).toBeNull();
     });
 
-    it('should NOT auto-discover dbhub.toml in the current directory', () => {
-      // Auto-discovery was removed: running from a directory that happens to
-      // contain a dbhub.toml must not silently repoint DBHub at that database.
+    it('should ignore a dbhub.toml in the current directory', () => {
+      // Only --config selects a config file, so running from a directory that
+      // happens to contain one must not repoint DBHub at that database.
       const tomlContent = `
 [[sources]]
 id = "ambient_db"

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -14,8 +14,10 @@ describe('TOML Configuration Tests', () => {
     // Create a temporary directory for test config files
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dbhub-test-'));
     process.chdir(tempDir);
-    // Clear command line arguments
-    process.argv = ['node', 'test'];
+    // TOML config is only loaded when --config names it explicitly (there is no
+    // cwd auto-discovery), so point --config at the file each test writes.
+    // Tests covering the absent/explicit-path cases override argv themselves.
+    process.argv = ['node', 'test', '--config', path.join(tempDir, 'dbhub.toml')];
   });
 
   afterEach(() => {
@@ -187,9 +189,26 @@ dsn = "mysql://user:pass@localhost:3306/db"
       expect(result?.source).toBe('custom.toml');
     });
 
-    it('should return null when no config file exists', () => {
+    it('should return null when --config is not supplied', () => {
+      process.argv = ['node', 'test'];
+
       const result = loadTomlConfig();
+
       expect(result).toBeNull();
+    });
+
+    it('should NOT auto-discover dbhub.toml in the current directory', () => {
+      // Auto-discovery was removed: running from a directory that happens to
+      // contain a dbhub.toml must not silently repoint DBHub at that database.
+      const tomlContent = `
+[[sources]]
+id = "ambient_db"
+dsn = "postgres://user:pass@localhost:5432/ambient"
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+      process.argv = ['node', 'test'];
+
+      expect(loadTomlConfig()).toBeNull();
     });
 
     it('should load multiple sources', () => {

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { loadTomlConfig, buildDSNFromSource, interpolateEnvVars } from '../toml-loader.js';
 import type { SourceConfig } from '../../types/config.js';
 import fs from 'fs';
@@ -194,6 +194,29 @@ dsn = "mysql://user:pass@localhost:3306/db"
       const result = loadTomlConfig();
 
       expect(result).toBeNull();
+    });
+
+    it.each([
+      ['bare flag', ['node', 'test', '--config']],
+      ['empty value', ['node', 'test', '--config=']],
+    ])('should reject --config with no value (%s)', (_label, argv) => {
+      // Without this, parseCommandLineArgs() resolves the flag to the sentinel
+      // "true" and the failure surfaces as `not found: true`.
+      process.argv = argv;
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        expect(() => loadTomlConfig()).toThrow('process.exit: 1');
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('--config requires a value')
+        );
+      } finally {
+        exitSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
     });
 
     it('should ignore a dbhub.toml in the current directory', () => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -242,18 +242,12 @@ export function buildDSNFromEnvParams(): { dsn: string; source: string } | null 
 }
 
 /**
- * Resolve DSN from command line args, environment variables, or .env files
- * Returns the DSN and its source, or null if not found
- */
-/**
  * Detect whether a single-database DSN is configured, and from where, without
  * applying anything to process.env.
  *
- * Used to reject the combination of TOML config and DSN config: TOML defines
- * sources for one or more databases, while a DSN configures exactly one, so
- * supplying both expresses two conflicting intents. Silently preferring one
- * (the previous behavior) meant a stray DSN looked ignored for no visible
- * reason.
+ * Backs the guard that keeps TOML config and DSN config mutually exclusive:
+ * TOML defines sources for one or more databases, while a DSN configures
+ * exactly one, so supplying both expresses two conflicting intents.
  *
  * The .env file is inspected via dotenv.parse rather than dotenv.config so that
  * merely checking for a conflict does not load unrelated settings.
@@ -298,6 +292,10 @@ export function detectDSNConfig(
   return null;
 }
 
+/**
+ * Resolve DSN from command line args, environment variables, or .env files
+ * Returns the DSN and its source, or null if not found
+ */
 export function resolveDSN(): { dsn: string; source: string; isDemo?: boolean } | null {
   // Get command line arguments
   const args = parseCommandLineArgs();
@@ -739,7 +737,7 @@ export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[];
       }
       // TOML config and DSN config are mutually exclusive: TOML defines sources
       // for one or more databases, a DSN configures exactly one. Supplying both
-      // is ambiguous, so reject it rather than silently ignoring the DSN.
+      // is ambiguous, so surface it instead of picking one.
       const dsnConfig = detectDSNConfig();
       if (dsnConfig) {
         throw new Error(

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -666,6 +666,18 @@ export function resolveSSHConfig(): { config: SSHTunnelConfig; source: string } 
  * Returns array of source configs and the source of the configuration
  */
 export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[]; tools?: import("../types/config.js").ToolConfig[]; source: string } | null> {
+  // Load .env before parsing TOML so `${VAR}` interpolation in the config file
+  // resolves against it — keeping credentials in .env and referencing them as
+  // `dsn = "${DSN}"` is the recommended pattern, and it only works if the file
+  // is loaded first.
+  //
+  // Scoped to TOML mode: on the DSN path resolveDSN() loads .env itself, and it
+  // has to do so after checking process.env in order to report whether a value
+  // came from the environment or from the file.
+  if (parseCommandLineArgs().config) {
+    loadEnvFiles();
+  }
+
   // 1. Try loading from TOML configuration file (skip if --demo flag is set)
   if (!isDemoMode()) {
     const tomlConfig = loadTomlConfig();

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -708,8 +708,6 @@ export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[];
         );
       }
 
-      // Note: --readonly flag is deprecated but no longer blocks TOML usage
-      // The warning is shown in isReadOnlyMode() function
       return tomlConfig;
     }
   }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -86,13 +86,14 @@ function findEnvFile(): string | null {
     ? [".env.local", ".env"] // In development, try .env.local first, then .env
     : [".env"]; // In production, only look for .env
 
-  // Build paths to check for environment files
+  // Build paths to check for environment files. The working directory is
+  // checked before the package root, so a project's own .env wins over one
+  // shipped alongside the install.
   const envPaths = [];
   for (const fileName of envFileNames) {
     envPaths.push(
-      fileName, // Current working directory
-      path.join(__dirname, "..", "..", fileName), // Two levels up (src/config -> src -> root)
-      path.join(process.cwd(), fileName) // Explicit current working directory
+      path.join(process.cwd(), fileName), // Current working directory
+      path.join(__dirname, "..", "..", fileName) // Two levels up (src/config -> src -> root)
     );
   }
 
@@ -357,7 +358,7 @@ export function resolvePort(): { port: number; source: string } {
  *
  * Returns the trimmed value, or undefined if the flag is absent.
  */
-function requireFlagValue(
+export function requireFlagValue(
   flag: string,
   args: Record<string, string>,
   example: string

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -75,10 +75,14 @@ export function parseCommandLineArgs() {
 }
 
 /**
- * Load environment files from various locations
- * Returns the name of the file that was loaded, or null if none was found
+ * Locate the env file that loadEnvFiles() would load, without loading it.
+ *
+ * Split out so the TOML/DSN conflict check can inspect a .env file's contents
+ * without the side effect of applying it to process.env — in TOML mode the
+ * .env file is otherwise never loaded, and loading it would silently change
+ * unrelated settings such as PORT and TRANSPORT.
  */
-export function loadEnvFiles(): string | null {
+export function findEnvFile(): string | null {
   // Determine if we're in development or production mode
   const isDevelopment = process.env.NODE_ENV === "development" || process.argv[1]?.includes("tsx");
 
@@ -97,44 +101,56 @@ export function loadEnvFiles(): string | null {
     );
   }
 
-  // Try to load the first env file found from the prioritized locations
   for (const envPath of envPaths) {
-    console.error(`Checking for env file: ${envPath}`);
     if (fs.existsSync(envPath)) {
-      dotenv.config({ path: envPath });
-
-      // Check for deprecated environment variables
-      if (process.env.READONLY !== undefined) {
-        console.error("\nERROR: READONLY environment variable is no longer supported.");
-        console.error("Use dbhub.toml with [[tools]] configuration instead:\n");
-        console.error("  [[sources]]");
-        console.error("  id = \"default\"");
-        console.error("  dsn = \"...\"\n");
-        console.error("  [[tools]]");
-        console.error("  name = \"execute_sql\"");
-        console.error("  source = \"default\"");
-        console.error("  readonly = true\n");
-        console.error("See https://dbhub.ai/tools/execute-sql#read-only-mode for details.\n");
-        process.exit(1);
-      }
-
-      if (process.env.MAX_ROWS !== undefined) {
-        console.error("\nERROR: MAX_ROWS environment variable is no longer supported.");
-        console.error("Use dbhub.toml with [[tools]] configuration instead:\n");
-        console.error("  [[sources]]");
-        console.error("  id = \"default\"");
-        console.error("  dsn = \"...\"\n");
-        console.error("  [[tools]]");
-        console.error("  name = \"execute_sql\"");
-        console.error("  source = \"default\"");
-        console.error("  max_rows = 1000\n");
-        console.error("See https://dbhub.ai/tools/execute-sql#row-limiting for details.\n");
-        process.exit(1);
-      }
-
-      // Return the name of the file that was loaded
-      return path.basename(envPath);
+      return envPath;
     }
+  }
+
+  return null;
+}
+
+/**
+ * Load environment files from various locations
+ * Returns the name of the file that was loaded, or null if none was found
+ */
+export function loadEnvFiles(): string | null {
+  const envPath = findEnvFile();
+
+  if (envPath) {
+    dotenv.config({ path: envPath });
+
+    // Check for deprecated environment variables
+    if (process.env.READONLY !== undefined) {
+      console.error("\nERROR: READONLY environment variable is no longer supported.");
+      console.error("Use dbhub.toml with [[tools]] configuration instead:\n");
+      console.error("  [[sources]]");
+      console.error("  id = \"default\"");
+      console.error("  dsn = \"...\"\n");
+      console.error("  [[tools]]");
+      console.error("  name = \"execute_sql\"");
+      console.error("  source = \"default\"");
+      console.error("  readonly = true\n");
+      console.error("See https://dbhub.ai/tools/execute-sql#read-only-mode for details.\n");
+      process.exit(1);
+    }
+
+    if (process.env.MAX_ROWS !== undefined) {
+      console.error("\nERROR: MAX_ROWS environment variable is no longer supported.");
+      console.error("Use dbhub.toml with [[tools]] configuration instead:\n");
+      console.error("  [[sources]]");
+      console.error("  id = \"default\"");
+      console.error("  dsn = \"...\"\n");
+      console.error("  [[tools]]");
+      console.error("  name = \"execute_sql\"");
+      console.error("  source = \"default\"");
+      console.error("  max_rows = 1000\n");
+      console.error("See https://dbhub.ai/tools/execute-sql#row-limiting for details.\n");
+      process.exit(1);
+    }
+
+    // Return the name of the file that was loaded
+    return path.basename(envPath);
   }
 
   return null;
@@ -229,6 +245,59 @@ export function buildDSNFromEnvParams(): { dsn: string; source: string } | null 
  * Resolve DSN from command line args, environment variables, or .env files
  * Returns the DSN and its source, or null if not found
  */
+/**
+ * Detect whether a single-database DSN is configured, and from where, without
+ * applying anything to process.env.
+ *
+ * Used to reject the combination of TOML config and DSN config: TOML defines
+ * sources for one or more databases, while a DSN configures exactly one, so
+ * supplying both expresses two conflicting intents. Silently preferring one
+ * (the previous behavior) meant a stray DSN looked ignored for no visible
+ * reason.
+ *
+ * The .env file is inspected via dotenv.parse rather than dotenv.config so that
+ * merely checking for a conflict does not load unrelated settings.
+ */
+export function detectDSNConfig(
+  // Injectable so tests do not depend on the developer's own .env file.
+  envPath: string | null = findEnvFile()
+): { source: string } | null {
+  const args = parseCommandLineArgs();
+
+  if (args.dsn) {
+    return { source: "--dsn command line argument" };
+  }
+
+  if (process.env.DSN) {
+    return { source: "DSN environment variable" };
+  }
+
+  if (buildDSNFromEnvParams()) {
+    return { source: "DB_* environment variables" };
+  }
+
+  // A .env file is not loaded in TOML mode, so inspect it read-only.
+  if (envPath) {
+    let parsed: Record<string, string>;
+    try {
+      parsed = dotenv.parse(fs.readFileSync(envPath));
+    } catch {
+      // An unreadable .env is not a conflict; leave it to the normal load path.
+      return null;
+    }
+
+    const envFileName = path.basename(envPath);
+    if (parsed.DSN) {
+      return { source: `DSN in ${envFileName}` };
+    }
+    if (parsed.DB_TYPE && parsed.DB_NAME) {
+      return { source: `DB_* parameters in ${envFileName}` };
+    }
+  }
+
+  return null;
+}
+
 export function resolveDSN(): { dsn: string; source: string; isDemo?: boolean } | null {
   // Get command line arguments
   const args = parseCommandLineArgs();
@@ -667,6 +736,20 @@ export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[];
           "Either remove the --id flag or use command-line DSN configuration instead."
         );
       }
+      // TOML config and DSN config are mutually exclusive: TOML defines sources
+      // for one or more databases, a DSN configures exactly one. Supplying both
+      // is ambiguous, so reject it rather than silently ignoring the DSN.
+      const dsnConfig = detectDSNConfig();
+      if (dsnConfig) {
+        throw new Error(
+          `DSN configuration (${dsnConfig.source}) cannot be used with TOML configuration. ` +
+          "TOML config defines database sources directly and supports multiple databases, " +
+          "while a DSN configures a single database. " +
+          "Either remove the DSN configuration, or remove the TOML config file " +
+          "(or point --config elsewhere)."
+        );
+      }
+
       // Note: --readonly flag is deprecated but no longer blocks TOML usage
       // The warning is shown in isReadOnlyMode() function
       return tomlConfig;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -719,7 +719,8 @@ export function resolveSSHConfig(): { config: SSHTunnelConfig; source: string } 
 
 /**
  * Resolve source configurations from TOML config or fallback to single DSN
- * Priority: TOML config (--config flag or ./dbhub.toml) > single DSN/env vars
+ * Sources come from either TOML config (--config flag only; no cwd auto-discovery)
+ * or a single DSN/env vars — never both. Supplying both throws.
  * Returns array of source configs and the source of the configuration
  */
 export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[]; tools?: import("../types/config.js").ToolConfig[]; source: string } | null> {
@@ -742,11 +743,11 @@ export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[];
       const dsnConfig = detectDSNConfig();
       if (dsnConfig) {
         throw new Error(
-          `DSN configuration (${dsnConfig.source}) cannot be used with TOML configuration. ` +
+          `DSN configuration (${dsnConfig.source}) cannot be used with TOML configuration ` +
+          `(${tomlConfig.source}). ` +
           "TOML config defines database sources directly and supports multiple databases, " +
           "while a DSN configures a single database. " +
-          "Either remove the DSN configuration, or remove the TOML config file " +
-          "(or point --config elsewhere)."
+          "Either remove the DSN configuration, or drop the --config flag."
         );
       }
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -76,13 +76,8 @@ export function parseCommandLineArgs() {
 
 /**
  * Locate the env file that loadEnvFiles() would load, without loading it.
- *
- * Split out so the TOML/DSN conflict check can inspect a .env file's contents
- * without the side effect of applying it to process.env — in TOML mode the
- * .env file is otherwise never loaded, and loading it would silently change
- * unrelated settings such as PORT and TRANSPORT.
  */
-export function findEnvFile(): string | null {
+function findEnvFile(): string | null {
   // Determine if we're in development or production mode
   const isDevelopment = process.env.NODE_ENV === "development" || process.argv[1]?.includes("tsx");
 
@@ -239,57 +234,6 @@ export function buildDSNFromEnvParams(): { dsn: string; source: string } | null 
     dsn,
     source: 'individual environment variables'
   };
-}
-
-/**
- * Detect whether a single-database DSN is configured, and from where, without
- * applying anything to process.env.
- *
- * Backs the guard that keeps TOML config and DSN config mutually exclusive:
- * TOML defines sources for one or more databases, while a DSN configures
- * exactly one, so supplying both expresses two conflicting intents.
- *
- * The .env file is inspected via dotenv.parse rather than dotenv.config so that
- * merely checking for a conflict does not load unrelated settings.
- */
-export function detectDSNConfig(
-  // Injectable so tests do not depend on the developer's own .env file.
-  envPath: string | null = findEnvFile()
-): { source: string } | null {
-  const args = parseCommandLineArgs();
-
-  if (args.dsn) {
-    return { source: "--dsn command line argument" };
-  }
-
-  if (process.env.DSN) {
-    return { source: "DSN environment variable" };
-  }
-
-  if (buildDSNFromEnvParams()) {
-    return { source: "DB_* environment variables" };
-  }
-
-  // A .env file is not loaded in TOML mode, so inspect it read-only.
-  if (envPath) {
-    let parsed: Record<string, string>;
-    try {
-      parsed = dotenv.parse(fs.readFileSync(envPath));
-    } catch {
-      // An unreadable .env is not a conflict; leave it to the normal load path.
-      return null;
-    }
-
-    const envFileName = path.basename(envPath);
-    if (parsed.DSN) {
-      return { source: `DSN in ${envFileName}` };
-    }
-    if (parsed.DB_TYPE && parsed.DB_NAME) {
-      return { source: `DB_* parameters in ${envFileName}` };
-    }
-  }
-
-  return null;
 }
 
 /**
@@ -735,17 +679,20 @@ export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[];
           "Either remove the --id flag or use command-line DSN configuration instead."
         );
       }
-      // TOML config and DSN config are mutually exclusive: TOML defines sources
-      // for one or more databases, a DSN configures exactly one. Supplying both
-      // is ambiguous, so surface it instead of picking one.
-      const dsnConfig = detectDSNConfig();
-      if (dsnConfig) {
+      // TOML config and a --dsn flag are mutually exclusive: TOML defines
+      // sources for one or more databases, a DSN configures exactly one, so
+      // passing both flags is ambiguous.
+      //
+      // Only the flag counts. DSN environment variables — whether exported or
+      // read from a .env file — are left alone, because TOML interpolation
+      // legitimately reads them: `dsn = "${DSN}"` is a supported way to keep
+      // credentials out of the config file.
+      if (parseCommandLineArgs().dsn) {
         throw new Error(
-          `DSN configuration (${dsnConfig.source}) cannot be used with TOML configuration ` +
-          `(${tomlConfig.source}). ` +
+          `The --dsn flag cannot be used with TOML configuration (${tomlConfig.source}). ` +
           "TOML config defines database sources directly and supports multiple databases, " +
           "while a DSN configures a single database. " +
-          "Either remove the DSN configuration, or drop the --config flag."
+          "Either remove the --dsn flag or drop the --config flag."
         );
       }
 

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { homedir } from "os";
 import toml from "@iarna/toml";
 import type { SourceConfig, TomlConfig, ToolConfig } from "../types/config.js";
-import { parseCommandLineArgs } from "./env.js";
+import { parseCommandLineArgs, requireFlagValue } from "./env.js";
 import { parseConnectionInfoFromDSN, getDefaultPortForType } from "../utils/dsn-obfuscate.js";
 import { SafeURL } from "../utils/safe-url.js";
 import { BUILTIN_TOOLS, BUILTIN_TOOL_EXECUTE_SQL, BUILTIN_TOOL_SEARCH_OBJECTS } from "../tools/builtin-tools.js";
@@ -64,8 +64,12 @@ export function loadTomlConfig(): { sources: SourceConfig[]; tools?: TomlConfig[
 export function resolveTomlConfigPath(): string | null {
   const args = parseCommandLineArgs();
 
-  if (args.config) {
-    const configPath = expandHomeDir(args.config);
+  // A bare `--config`, or `--config=`, otherwise resolves to the sentinel
+  // "true" and surfaces as `not found: true`.
+  const configValue = requireFlagValue("config", args, "./dbhub.toml");
+
+  if (configValue) {
+    const configPath = expandHomeDir(configValue);
     if (!fs.existsSync(configPath)) {
       throw new Error(
         `Configuration file specified by --config flag not found: ${configPath}`

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -53,13 +53,18 @@ export function loadTomlConfig(): { sources: SourceConfig[]; tools?: TomlConfig[
 }
 
 /**
- * Resolve the path to the TOML configuration file
- * Priority: --config flag > ./dbhub.toml
+ * Resolve the path to the TOML configuration file.
+ *
+ * TOML config is loaded only when --config names it explicitly. A dbhub.toml
+ * sitting in the current directory is deliberately NOT auto-discovered: TOML
+ * config selects the database and cannot be combined with a DSN, so implicit
+ * discovery meant merely running DBHub from the wrong directory could silently
+ * repoint it at a different database, or make an explicitly supplied DSN
+ * appear to be ignored for no visible reason.
  */
 export function resolveTomlConfigPath(): string | null {
   const args = parseCommandLineArgs();
 
-  // 1. Check for --config flag (highest priority)
   if (args.config) {
     const configPath = expandHomeDir(args.config);
     if (!fs.existsSync(configPath)) {
@@ -68,12 +73,6 @@ export function resolveTomlConfigPath(): string | null {
       );
     }
     return configPath;
-  }
-
-  // 2. Check for dbhub.toml in current directory
-  const defaultConfigPath = path.join(process.cwd(), "dbhub.toml");
-  if (fs.existsSync(defaultConfigPath)) {
-    return defaultConfigPath;
   }
 
   return null;

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -55,12 +55,11 @@ export function loadTomlConfig(): { sources: SourceConfig[]; tools?: TomlConfig[
 /**
  * Resolve the path to the TOML configuration file.
  *
- * TOML config is loaded only when --config names it explicitly. A dbhub.toml
- * sitting in the current directory is deliberately NOT auto-discovered: TOML
- * config selects the database and cannot be combined with a DSN, so implicit
- * discovery meant merely running DBHub from the wrong directory could silently
- * repoint it at a different database, or make an explicitly supplied DSN
- * appear to be ignored for no visible reason.
+ * TOML config is loaded only when --config names it. Keep it that way: TOML
+ * selects the database outright and cannot be combined with a DSN, so
+ * discovering a file implicitly (from the working directory, say) would let
+ * DBHub silently connect somewhere the user never named, and make an
+ * explicitly supplied DSN look ignored for no visible reason.
  */
 export function resolveTomlConfigPath(): string | null {
   const args = parseCommandLineArgs();


### PR DESCRIPTION
Three related fixes to how database sources are configured. Two are breaking. Follow-up to #367, where investigating a test failure surfaced the first.

## 1. TOML config is loaded only via `--config`

`resolveTomlConfigPath()` fell back to `./dbhub.toml` in the current working directory when `--config` was absent. Since TOML config selects the database outright, that meant **running DBHub from the wrong directory could silently repoint it at a different database** — or make an explicitly supplied DSN look ignored for no reason:

```
$ npx tsx src/index.ts --dsn="sqlite://:memory:"     # in a dir with dbhub.toml
Configuration source: dbhub.toml
Fatal error: error: database "employee" does not exist
```

The user asked for SQLite and got a Postgres error, never having mentioned TOML.

Nothing shipped depends on the old fallback: the MCPB bundle already passes `--config ${__dirname}/dbhub.toml` (`mcpb/manifest.json`), and every documented invocation passes `--config` explicitly.

## 2. `--config` and `--dsn` cannot be combined

`resolveSourceConfigs()` returned the TOML config before `resolveDSN()` was ever consulted, so `--dsn` was silently ignored. The documented priority order said the opposite — CLAUDE.md and `docs/config/command-line.mdx` both claimed "command-line arguments (highest priority)" over TOML.

TOML wins, and the docs were wrong. The two are conflicting rather than layered: TOML is multi-database, a DSN is single-database. Passing both flags now errors, mirroring the existing `--id` guard:

```
Error: The --dsn flag cannot be used with TOML configuration (dbhub.toml). ...
```

**The guard is deliberately limited to the flag.** `DSN` and `DB_*` environment variables are *not* conflicts, whether exported or read from `.env` — see below.

## 3. `.env` is loaded before TOML, so `${VAR}` interpolation resolves

`interpolateEnvVars()` reads `process.env`, but `.env` was only loaded inside `resolveDSN()` — the fallback path that never runs when `--config` is given. So the recommended pattern of keeping credentials out of the config file did not work:

```bash
# .env
DSN=postgres://user:pass@localhost:5432/mydb
```
```toml
# dbhub.toml
[[sources]]
id = "prod"
dsn = "${DSN}"
```

```
Configuration source: dbhub.toml
  - prod: ${DSN}
Fatal error: No connector found for DSN: ${DSN}
```

This is the same fix as **#358 by @kevinke**, narrowed in scope and with a regression test — that PR can be closed once this merges.

The narrowing matters: #358 calls `loadEnvFiles()` unconditionally. On the DSN path `resolveDSN()` already loads `.env` itself, and it does so *after* checking `process.env` so it can report whether a value came from the environment or from the file. Preloading unconditionally relabels every `.env`-sourced DSN as `environment variable` in the startup log. Scoping the load to TOML mode avoids that; verified the DSN path still reports `Configuration source: .env file`.

### Why fixes 2 and 3 belong together

They pull in opposite directions, and getting one right requires the other. An earlier revision of this PR rejected *any* DSN-shaped environment variable as a conflict — which would have broken the interpolation pattern above outright. Only `--dsn` expresses unambiguous intent; environment variables are config material for TOML, not a competing setup.

## ⚠️ Breaking changes

1. **`dbhub.toml` in the current directory is no longer loaded.** Pass `--config ./dbhub.toml`.
2. **`--config` together with `--dsn` now fails to start** instead of silently using TOML.

Both warrant a release note. The second was chosen over a warning because silent-ignore is what produced the confusing failure above, and a stderr warning is easy to miss in stdio mode.

## Docs

Both docs described a single priority ladder. The accurate model is two independent rules, since TOML only defines `sources` and `tools` and cannot express transport/port/host:

- **Source selection**: TOML (via `--config`) *or* a DSN. Within DSN mode: `--dsn` > `DSN` > `DB_*` > `.env`.
- **Everything else**: CLI > env > `.env` > defaults (unchanged, always correct).

Rewritten to describe the model directly rather than contrast against previous behavior. Updated `CLAUDE.md`, `docs/config/command-line.mdx`, `docs/config/toml.mdx`.

## Verification

- **1107 tests passing.** New coverage: `--dsn` + `--config` rejected; `DSN` env var + `--config` allowed; `DB_*` + `--config` allowed; `.env` loaded before TOML parsing; a cwd `dbhub.toml` ignored.
- The `.env`-before-TOML test was confirmed to **fail** without the fix, not merely pass alongside it.
- The 106 `toml-loader` tests that wrote `dbhub.toml` into a temp cwd now point `--config` at it via one line in `beforeEach`, rather than 106 edits.
- Manually verified against real configs: `dsn = "${DSN}"` resolves from both an exported variable and a `.env` file; the DSN path still reports `.env file` as its source; `--dsn` + `--config` errors; cwd `dbhub.toml` ignored; missing `--config` path still errors.
- Only failure is `sqlserver.integration.test.ts` (container won't boot on arm64) — fails identically on clean `main`.

Rebased onto `main` after #367 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)