### PR TITLE
feat(connectors): add SAP HANA 2.0 connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@
 # DSN=sqlite::memory:
 # DSN=sqlserver://user:password@localhost:1433/dbname
 # DSN=mysql://user:password@localhost:3306/dbname
+# DSN=hana://user:password@localhost:30015?encrypt=true&sslmode=verify-full
 DSN=
 
 # Method 2: Individual Database Parameters
@@ -19,7 +20,7 @@ DSN=
 # DB_PASSWORD=my@password:with/special#chars
 # DB_NAME=mydatabase
 
-# Supported DB_TYPE values: postgres, mysql, mariadb, sqlserver, sqlite
+# Supported DB_TYPE values: postgres, mysql, mariadb, sqlserver, sqlite, hana
 # DB_PORT is optional - defaults to standard port for each database type
 # For SQLite: only DB_TYPE and DB_NAME are required (DB_NAME is the file path)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ src/
 │   ├── mysql/           # MySQL connector
 │   ├── mariadb/         # MariaDB connector
 │   ├── sqlserver/       # SQL Server connector
-│   └── sqlite/          # SQLite connector
+│   ├── sqlite/          # SQLite connector
+│   └── hana/            # SAP HANA connector
 ├── tools/               # MCP tool handlers
 │   ├── execute-sql.ts   # SQL execution handler
 │   └── search-objects.ts  # Unified search/list with progressive disclosure
@@ -167,7 +168,9 @@ outside TOML and follow the same order:
   - SQL Server (named instance): `sqlserver://user:password@localhost:1433/dbname?instanceName=ENV1`
   - SQL Server (NTLM): `sqlserver://user:password@localhost:1433/dbname?authentication=ntlm&domain=MYDOMAIN`
   - SQLite: `sqlite:///path/to/database.db` or `sqlite:///:memory:`
-- SSL modes: `sslmode=disable` (no SSL), `sslmode=require` (SSL without cert verification), `sslmode=verify-ca` (PostgreSQL only, CA verification), `sslmode=verify-full` (PostgreSQL only, CA + hostname verification). Use `sslrootcert` to specify CA certificate path for verify modes.
+  - SAP HANA: `hana://user:password@localhost:30015?encrypt=true&sslmode=verify-full`
+  - SAP HANA (multitenant/HANA Cloud, tenant in path): `hana://user:password@host:443/TENANT?encrypt=true`
+- SSL modes: `sslmode=disable` (no SSL), `sslmode=require` (SSL without cert verification), `sslmode=verify-ca` (PostgreSQL only, CA verification), `sslmode=verify-full` (PostgreSQL only, CA + hostname verification). Use `sslrootcert` to specify CA certificate path for verify modes. For SAP HANA, `sslmode` maps to the driver's `encrypt`/`sslValidateCertificate` options.
 
 ## Testing Approach
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
             |                  |    |              |    |                  |
             |  Copilot CLI     +--->+              +--->+    MariaDB       |
             |                  |    |              |    |                  |
-            |                  |    |              |    |                  |
+            |                  |    |              +--->+    SAP HANA      |
             +------------------+    +--------------+    +------------------+
                  MCP Clients           MCP Server             Databases
 ```
@@ -33,14 +33,18 @@
 DBHub is a zero-dependency, token efficient MCP server implementing the Model Context Protocol (MCP) server interface. This lightweight gateway allows MCP-compatible clients to connect to and explore different databases:
 
 - **Local Development First**: Zero dependency, token efficient with just two MCP tools to maximize context window
-- **Multi-Database**: PostgreSQL, MySQL, MariaDB, SQL Server, and SQLite through a single interface
+- **Multi-Database**: PostgreSQL, MySQL, MariaDB, SQL Server, SQLite, and SAP HANA through a single interface
 - **Multi-Connection**: Connect to multiple databases simultaneously with TOML configuration
 - **Guardrails**: Read-only mode, row limiting, and query timeout to prevent runaway operations
 - **Secure Access**: SSH tunneling and SSL/TLS encryption
 
 ## Supported Databases
 
-PostgreSQL, MySQL, SQL Server, MariaDB, and SQLite.
+PostgreSQL, MySQL, SQL Server, MariaDB, SQLite, and SAP HANA (2.0 and HANA Cloud).
+
+> SAP HANA requires the optional native driver `@sap/hana-client`, which ships
+> platform-specific binaries (glibc — not Alpine/musl). DSN format:
+> `hana://user:password@host:30015?encrypt=true&sslmode=verify-full`.
 
 ## MCP Tools
 

--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -217,6 +217,33 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # dsn = "sqlite:///:memory:"
 
 # ============================================================================
+# SAP HANA (2.0 and HANA Cloud)
+# ============================================================================
+# Requires the optional native driver: pnpm add @sap/hana-client
+# (ships glibc binaries — not available on Alpine/musl images).
+
+# HANA - DSN format (single-container instance; default SQL port 3<inst>15)
+# [[sources]]
+# id = "local_hana"
+# dsn = "hana://SYSTEM:password@hana-host:30015?encrypt=true&sslmode=verify-full"
+
+# HANA - Individual parameters (database = tenant name on a multitenant system)
+# [[sources]]
+# id = "hana_tenant"
+# type = "hana"
+# host = "hana-host"
+# port = 30041
+# database = "TENANT1"
+# user = "APP_USER"
+# password = "secret"
+# sslmode = "verify-full"
+
+# SAP HANA Cloud (TLS is mandatory; typically port 443)
+# [[sources]]
+# id = "hana_cloud"
+# dsn = "hana://APP_USER:password@xxxxx.hana.prod-region.hanacloud.ondemand.com:443?encrypt=true&sslmode=verify-full"
+
+# ============================================================================
 # TOOL CONFIGURATION (Optional)
 # ============================================================================
 #

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dbhub",
   "version": "0.24.0",
   "mcpName": "io.github.bytebase/dbhub",
-  "description": "Minimal, token-efficient Database MCP Server for PostgreSQL, MySQL, SQL Server, SQLite, MariaDB",
+  "description": "Minimal, token-efficient Database MCP Server for PostgreSQL, MySQL, SQL Server, SQLite, MariaDB, SAP HANA",
   "repository": {
     "type": "git",
     "url": "https://github.com/bytebase/dbhub.git"
@@ -54,6 +54,7 @@
   "optionalDependencies": {
     "@aws-sdk/rds-signer": "^3.1001.0",
     "@azure/identity": "^4.8.0",
+    "@sap/hana-client": "^2.20.0",
     "mariadb": "^3.4.0",
     "mssql": "^11.0.1",
     "mysql2": "^3.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@azure/identity':
         specifier: ^4.8.0
         version: 4.10.1
+      '@sap/hana-client':
+        specifier: ^2.20.0
+        version: 2.29.25
       mariadb:
         specifier: ^3.4.0
         version: 3.4.2
@@ -973,6 +976,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sap/hana-client@2.29.25':
+    resolution: {integrity: sha512-yX8N9hE5S7vDkCTxEoD33JRRbHv0aa3Kqhd5FVlaqv+xNKMtZDgtZmXPe29KLo3Y5GjZhpoqixr/1mt0C2Ahjw==}
+    engines: {node: '>=4.0.0'}
+
   '@smithy/abort-controller@4.2.10':
     resolution: {integrity: sha512-qocxM/X4XGATqQtUkbE9SPUB6wekBi+FyJOMbPj0AhvyvFGYEmOlz6VB22iMePCQsFmMIvFSeViDvA7mZJG47g==}
     engines: {node: '>=18.0.0'}
@@ -1786,6 +1793,14 @@ packages:
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@3.1.0:
+    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -4546,6 +4561,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.43.0':
     optional: true
 
+  '@sap/hana-client@2.29.25':
+    dependencies:
+      debug: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@smithy/abort-controller@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -5552,6 +5574,11 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@3.1.0:
+    dependencies:
+      ms: 2.0.0
+    optional: true
+
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -5588,7 +5615,7 @@ snapshots:
 
   docker-modem@5.0.6:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3(supports-color@10.2.2)
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.16.0
@@ -5940,7 +5967,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 

--- a/src/api/openapi.d.ts
+++ b/src/api/openapi.d.ts
@@ -64,7 +64,7 @@ export interface components {
              * @example postgres
              * @enum {string}
              */
-            type: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite";
+            type: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite" | "hana";
             /**
              * @description Database host (not present for SQLite)
              * @example localhost

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -102,7 +102,7 @@ components:
           example: Production read replica for analytics queries
         type:
           type: string
-          enum: [postgres, mysql, mariadb, sqlserver, sqlite]
+          enum: [postgres, mysql, mariadb, sqlserver, sqlite, hana]
           description: Database type
           example: postgres
         host:

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -188,7 +188,7 @@ export function buildDSNFromEnvParams(): { dsn: string; source: string } | null 
   }
 
   // Validate supported database types
-  const supportedTypes = ['postgres', 'postgresql', 'mysql', 'mariadb', 'sqlserver', 'sqlite'];
+  const supportedTypes = ['postgres', 'postgresql', 'mysql', 'mariadb', 'sqlserver', 'sqlite', 'hana'];
   if (!supportedTypes.includes(dbType.toLowerCase())) {
     throw new Error(`Unsupported DB_TYPE: ${dbType}. Supported types: ${supportedTypes.join(', ')}`);
   }
@@ -207,6 +207,9 @@ export function buildDSNFromEnvParams(): { dsn: string; source: string } | null 
         break;
       case 'sqlserver':
         port = '1433';
+        break;
+      case 'hana':
+        port = '30015';
         break;
       case 'sqlite':
         // SQLite doesn't use host/port, handle differently
@@ -729,7 +732,7 @@ export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[];
     const protocol = dsnUrl.protocol.replace(':', '');
 
     // Map protocol to database type
-    let dbType: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite";
+    let dbType: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite" | "hana";
     if (protocol === 'postgresql' || protocol === 'postgres') {
       dbType = 'postgres';
     } else if (protocol === 'mysql') {
@@ -740,6 +743,8 @@ export async function resolveSourceConfigs(): Promise<{ sources: SourceConfig[];
       dbType = 'sqlserver';
     } else if (protocol === 'sqlite') {
       dbType = 'sqlite';
+    } else if (protocol === 'hana') {
+      dbType = 'hana';
     } else {
       throw new Error(`Unsupported database type in DSN: ${protocol}`);
     }

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -396,7 +396,7 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
 
   // Validate type if provided
   if (source.type) {
-    const validTypes = ["postgres", "mysql", "mariadb", "sqlserver", "sqlite"];
+    const validTypes = ["postgres", "mysql", "mariadb", "sqlserver", "sqlite", "hana"];
     if (!validTypes.includes(source.type)) {
       throw new Error(
         `Configuration file ${configPath}: source '${source.id}' has invalid type '${source.type}'. ` +
@@ -498,10 +498,11 @@ function validateSourceConfig(source: SourceConfig, configPath: string): void {
 
     if (
       (source.sslmode === "verify-ca" || source.sslmode === "verify-full") &&
-      source.type !== "postgres"
+      source.type !== "postgres" &&
+      source.type !== "hana"
     ) {
       throw new Error(
-        `Configuration file ${configPath}: source '${source.id}' has sslmode '${source.sslmode}' which is only supported for PostgreSQL. ` +
+        `Configuration file ${configPath}: source '${source.id}' has sslmode '${source.sslmode}' which is only supported for PostgreSQL and SAP HANA. ` +
           `Valid values for ${source.type}: disable, require`
       );
     }
@@ -910,10 +911,12 @@ export function buildDSNFromSource(source: SourceConfig): string {
   const passwordRequired =
     source.authentication !== "azure-active-directory-access-token" &&
     !isAwsIamPasswordless;
-  if (!source.host || !source.user || !source.database) {
+  // HANA connects by host:port; the tenant/database is optional.
+  const databaseRequired = source.type !== "hana";
+  if (!source.host || !source.user || (databaseRequired && !source.database)) {
     throw new Error(
       `Source '${source.id}': missing required connection parameters. ` +
-        `Required: type, host, user, database`
+        `Required: type, host, user${databaseRequired ? ", database" : ""}`
     );
   }
   if (passwordRequired && !source.password) {
@@ -934,10 +937,11 @@ export function buildDSNFromSource(source: SourceConfig): string {
   // Encode credentials
   const encodedUser = encodeURIComponent(source.user);
   const encodedPassword = source.password ? encodeURIComponent(source.password) : "";
-  const encodedDatabase = encodeURIComponent(source.database);
+  const encodedDatabase = source.database ? encodeURIComponent(source.database) : "";
 
-  // Build base DSN
-  let dsn = `${source.type}://${encodedUser}:${encodedPassword}@${source.host}:${port}/${encodedDatabase}`;
+  // Build base DSN. The database path is omitted when absent (HANA without a tenant).
+  const databasePath = encodedDatabase ? `/${encodedDatabase}` : "";
+  let dsn = `${source.type}://${encodedUser}:${encodedPassword}@${source.host}:${port}${databasePath}`;
 
   // Collect query parameters
   const queryParams: string[] = [];

--- a/src/connectors/__tests__/dsn-parser.test.ts
+++ b/src/connectors/__tests__/dsn-parser.test.ts
@@ -6,6 +6,7 @@ import { PostgresConnector } from '../postgres/index.js';
 import { MySQLConnector } from '../mysql/index.js';
 import { MariaDBConnector } from '../mariadb/index.js';
 import { SQLServerConnector } from '../sqlserver/index.js';
+import { HanaConnector } from '../hana/index.js';
 
 describe('DSN Parser - PostgreSQL SSL Modes', () => {
   const connector = new PostgresConnector();
@@ -258,5 +259,100 @@ describe('DSN Parser - missing database component', () => {
       const config = await parser.parse(`${scheme}://user:pass@localhost:3306/mydb`);
       expect(config.database).toBe('mydb');
     });
+  });
+});
+
+describe('DSN Parser - SAP HANA', () => {
+  const parser = new HanaConnector().dsnParser;
+
+  it('parses host, port, user and password', async () => {
+    const config = await parser.parse('hana://user:pass@hana.example.com:30015');
+    expect(config.host).toBe('hana.example.com');
+    expect(config.port).toBe(30015);
+    expect(config.uid).toBe('user');
+    expect(config.pwd).toBe('pass');
+  });
+
+  it('defaults the port to 30015 when omitted', async () => {
+    const config = await parser.parse('hana://user:pass@hana.example.com');
+    expect(config.port).toBe(30015);
+  });
+
+  it('reads the tenant database from the path segment', async () => {
+    const config = await parser.parse('hana://user:pass@host:30015/H00');
+    expect(config.databaseName).toBe('H00');
+  });
+
+  it('reads the tenant database from the databaseName query param', async () => {
+    const config = await parser.parse('hana://user:pass@host:30041?databaseName=TENANT1');
+    expect(config.databaseName).toBe('TENANT1');
+  });
+
+  it('maps sslmode=disable to encrypt=false', async () => {
+    const config = await parser.parse('hana://user:pass@host:30015?sslmode=disable');
+    expect(config.encrypt).toBe(false);
+  });
+
+  it('maps sslmode=require to encrypt=true without certificate validation', async () => {
+    const config = await parser.parse('hana://user:pass@host:30015?sslmode=require');
+    expect(config.encrypt).toBe(true);
+    expect(config.sslValidateCertificate).toBe(false);
+  });
+
+  it('maps sslmode=verify-full to encrypt=true with certificate validation', async () => {
+    const config = await parser.parse('hana://user:pass@host:30015?sslmode=verify-full');
+    expect(config.encrypt).toBe(true);
+    expect(config.sslValidateCertificate).toBe(true);
+  });
+
+  it('rejects contradictory TLS config (verify-full with encrypt=false)', async () => {
+    await expect(
+      parser.parse('hana://user:pass@host:30015?sslmode=verify-full&encrypt=false')
+    ).rejects.toThrow(/Contradictory TLS config/);
+  });
+
+  it('parses encrypt case-insensitively', async () => {
+    const config = await parser.parse('hana://user:pass@host:30015?encrypt=TRUE');
+    expect(config.encrypt).toBe(true);
+  });
+
+  it('rejects an invalid boolean for encrypt', async () => {
+    await expect(
+      parser.parse('hana://user:pass@host:30015?encrypt=yes')
+    ).rejects.toThrow(/Invalid boolean/);
+  });
+
+  it('rejects an unknown sslmode', async () => {
+    await expect(
+      parser.parse('hana://user:pass@host:30015?sslmode=bogus')
+    ).rejects.toThrow(/Invalid sslmode/);
+  });
+
+  it('maps connectionTimeoutSeconds to connectTimeout in milliseconds', async () => {
+    const config = await parser.parse('hana://user:pass@host:30015', {
+      connectionTimeoutSeconds: 15,
+    });
+    expect(config.connectTimeout).toBe(15000);
+  });
+
+  it('accepts its own sample DSN as valid', () => {
+    expect(parser.isValidDSN(parser.getSampleDSN())).toBe(true);
+  });
+
+  it('only accepts the hana:// scheme', () => {
+    expect(parser.isValidDSN('hana://u:p@h:30015')).toBe(true);
+    expect(parser.isValidDSN('hdb://u:p@h:30015')).toBe(false);
+  });
+
+  it('rejects a non-HANA DSN', async () => {
+    await expect(parser.parse('mysql://user:pass@host:3306/db')).rejects.toThrow(
+      'Invalid SAP HANA DSN format'
+    );
+  });
+
+  it('does not leak the password in the error message', async () => {
+    await expect(parser.parse('postgres://user:hunter2@host:5432/db')).rejects.toThrow(
+      expect.objectContaining({ message: expect.not.stringContaining('hunter2') })
+    );
   });
 });

--- a/src/connectors/__tests__/hana-connector.test.ts
+++ b/src/connectors/__tests__/hana-connector.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Inject a fake @sap/hana-client so the connector's lazy `import()` resolves to
+// a controllable mock (no native driver required).
+const hoisted = vi.hoisted(() => ({ current: null as unknown as MockConn }));
+vi.mock("@sap/hana-client", () => ({
+  // The connector reads `mod.default ?? mod`, so provide both a default and a
+  // named export (vitest throws on accessing an undefined `default`).
+  default: { createConnection: () => hoisted.current },
+  createConnection: () => hoisted.current,
+}));
+
+import { HanaConnector } from "../hana/index.js";
+
+/** Records every driver interaction so tests can assert the exact sequence. */
+class MockConn {
+  execLog: string[] = [];
+  autoCommitLog: boolean[] = [];
+  rollbackCount = 0;
+  disconnectCount = 0;
+  connectShouldFail: Error | null = null;
+
+  connect(_params: unknown, cb: (e: Error | null) => void): void {
+    cb(this.connectShouldFail);
+  }
+  exec(sql: string, _params: unknown[], cb: (e: Error | null, rows: unknown) => void): void {
+    this.execLog.push(sql.replace(/\s+/g, " ").trim());
+    cb(null, []);
+  }
+  prepare(sql: string, cb: (e: Error | null, stmt: unknown) => void): void {
+    cb(null, {
+      setTimeout: () => {},
+      exec: (_p: unknown[], c: (e: Error | null, rows: unknown) => void) => {
+        this.execLog.push(sql.replace(/\s+/g, " ").trim());
+        c(null, []);
+      },
+      drop: (c?: (e: Error | null) => void) => c?.(null),
+    });
+  }
+  disconnect(cb?: (e: Error | null) => void): void {
+    this.disconnectCount++;
+    cb?.(null);
+  }
+  setAutoCommit(b: boolean): void {
+    this.autoCommitLog.push(b);
+  }
+  rollback(cb: (e: Error | null) => void): void {
+    this.rollbackCount++;
+    cb(null);
+  }
+}
+
+async function connected(mock: MockConn): Promise<HanaConnector> {
+  hoisted.current = mock;
+  const connector = new HanaConnector();
+  await connector.connect("hana://u:p@h:30015");
+  return connector;
+}
+
+describe("HanaConnector (mocked driver)", () => {
+  it("read-only execution restores READ WRITE + autocommit afterwards", async () => {
+    const mock = new MockConn();
+    const connector = await connected(mock);
+
+    await connector.executeSQL("SELECT 1 AS N FROM DUMMY", { readonly: true });
+
+    expect(mock.execLog).toEqual([
+      "SET TRANSACTION READ ONLY",
+      "SELECT 1 AS N FROM DUMMY",
+      "SET TRANSACTION READ WRITE",
+    ]);
+    expect(mock.autoCommitLog).toEqual([false, true]);
+    expect(mock.rollbackCount).toBe(2);
+  });
+
+  it("rejects parameters combined with multiple statements", async () => {
+    const mock = new MockConn();
+    const connector = await connected(mock);
+    await expect(connector.executeSQL("SELECT ?; SELECT ?", {}, [1, 2])).rejects.toThrow(
+      /multiple statements/
+    );
+  });
+
+  it("does not split procedural DDL on internal semicolons", async () => {
+    const mock = new MockConn();
+    const connector = await connected(mock);
+    const ddl = "CREATE OR REPLACE PROCEDURE FOO AS BEGIN DELETE FROM t1; DELETE FROM t2; END;";
+
+    await connector.executeSQL(ddl, {});
+
+    expect(mock.execLog).toHaveLength(1);
+    expect(mock.execLog[0]).toContain("CREATE OR REPLACE PROCEDURE");
+    expect(mock.execLog[0]).toContain("DELETE FROM t2");
+  });
+
+  it("still splits ordinary multi-statement scripts", async () => {
+    const mock = new MockConn();
+    const connector = await connected(mock);
+    await connector.executeSQL("SELECT 1 FROM DUMMY; SELECT 2 FROM DUMMY", {});
+    expect(mock.execLog).toEqual(["SELECT 1 FROM DUMMY", "SELECT 2 FROM DUMMY"]);
+  });
+
+  it("cleans up (disconnects) when connect fails", async () => {
+    const mock = new MockConn();
+    mock.connectShouldFail = new Error("connect boom");
+    hoisted.current = mock;
+    const connector = new HanaConnector();
+
+    await expect(connector.connect("hana://u:p@h:30015")).rejects.toThrow("connect boom");
+    expect(mock.disconnectCount).toBe(1);
+    // The connection field is cleared, so later calls report "not connected".
+    await expect(connector.executeSQL("SELECT 1 FROM DUMMY", {})).rejects.toThrow(/Not connected/);
+  });
+
+  it("caps rows for a CTE (WITH … SELECT) that the plain limiter would miss", async () => {
+    const mock = new MockConn();
+    const connector = await connected(mock);
+    await connector.executeSQL("WITH c AS (SELECT 1 AS N FROM DUMMY) SELECT * FROM c", {
+      maxRows: 5,
+    });
+    expect(mock.execLog).toHaveLength(1);
+    expect(mock.execLog[0]).toMatch(/LIMIT 5/);
+  });
+});

--- a/src/connectors/__tests__/hana.integration.test.ts
+++ b/src/connectors/__tests__/hana.integration.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { HanaConnector } from "../hana/index.js";
+
+/**
+ * SAP HANA integration tests.
+ *
+ * SAP HANA 2.0 cannot run in a local container the way the other connectors'
+ * Testcontainers-based suites do (HANA Express is x86_64-only and heavyweight),
+ * so this suite runs against a REAL, reachable HANA instance and is skipped
+ * unless a DSN is supplied:
+ *
+ *   HANA_DSN="hana://user:pass@host:30015?encrypt=true&sslmode=verify-full" \
+ *     pnpm test:integration src/connectors/__tests__/hana.integration.test.ts
+ *
+ * All assertions read only from the SYS catalog, so no write privileges or test
+ * fixtures are required — any HANA login can run them.
+ */
+const HANA_DSN = process.env.HANA_DSN;
+
+describe.skipIf(!HANA_DSN)("SAP HANA (integration)", () => {
+  const connector = new HanaConnector();
+
+  beforeAll(async () => {
+    await connector.connect(HANA_DSN as string);
+  });
+
+  afterAll(async () => {
+    await connector.disconnect();
+  });
+
+  it("executes a simple SELECT", async () => {
+    const result = await connector.executeSQL("SELECT 1 AS N FROM SYS.DUMMY", {});
+    expect(result.rows).toEqual([{ N: 1 }]);
+    expect(result.rowCount).toBe(1);
+  });
+
+  it("returns the default (current) schema", async () => {
+    const schema = await connector.getDefaultSchema();
+    expect(typeof schema).toBe("string");
+    expect(schema).toBeTruthy();
+  });
+
+  it("lists schemas including SYS", async () => {
+    const schemas = await connector.getSchemas();
+    expect(Array.isArray(schemas)).toBe(true);
+    expect(schemas).toContain("SYS");
+  });
+
+  it("lists views in the SYS schema", async () => {
+    const views = await connector.getViews("SYS");
+    expect(views.length).toBeGreaterThan(0);
+    expect(views).toContain("SCHEMAS");
+  });
+
+  it("reports that the SYS.SCHEMAS view exists", async () => {
+    expect(await connector.tableExists("SCHEMAS", "SYS")).toBe(true);
+    expect(await connector.tableExists("DEFINITELY_NOT_A_REAL_OBJECT", "SYS")).toBe(false);
+  });
+
+  it("describes columns of a SYS view", async () => {
+    const columns = await connector.getTableSchema("SCHEMAS", "SYS");
+    const names = columns.map((c) => c.column_name);
+    expect(names).toContain("SCHEMA_NAME");
+    // Every column carries the normalized nullability string.
+    for (const col of columns) {
+      expect(["YES", "NO"]).toContain(col.is_nullable);
+    }
+  });
+
+  it("applies maxRows to SELECT queries", async () => {
+    const result = await connector.executeSQL("SELECT SCHEMA_NAME FROM SYS.SCHEMAS", {
+      maxRows: 1,
+    });
+    expect(result.rows.length).toBeLessThanOrEqual(1);
+  });
+
+  it("executes SELECT in read-only mode", async () => {
+    const result = await connector.executeSQL("SELECT 1 AS N FROM SYS.DUMMY", { readonly: true });
+    expect(result.rows).toEqual([{ N: 1 }]);
+  });
+
+  it("rejects writes in read-only mode", async () => {
+    await expect(
+      connector.executeSQL("CREATE TABLE dbhub_hana_readonly_probe (id INT)", { readonly: true })
+    ).rejects.toBeTruthy();
+  });
+
+  it("restores a writable session after a read-only call", async () => {
+    // Regression for the read-only session-state leak: a read-only execution
+    // must not leave the shared connection stuck read-only. Verify with a
+    // LOCAL TEMPORARY table — session-scoped, invisible to others, auto-dropped.
+    await connector.executeSQL("SELECT 1 FROM DUMMY", { readonly: true });
+    await connector.executeSQL("CREATE LOCAL TEMPORARY TABLE #DBHUB_RW_PROBE (ID INT)", {});
+    await connector.executeSQL("DROP TABLE #DBHUB_RW_PROBE", {});
+  });
+});

--- a/src/connectors/hana/index.ts
+++ b/src/connectors/hana/index.ts
@@ -1,0 +1,668 @@
+import {
+  Connector,
+  ConnectorType,
+  ConnectorRegistry,
+  DSNParser,
+  SQLResult,
+  TableColumn,
+  TableIndex,
+  StoredProcedure,
+  ExecuteOptions,
+  ConnectorConfig,
+} from "../interface.js";
+import { isDriverNotInstalled } from "../../utils/module-loader.js";
+import { SafeURL } from "../../utils/safe-url.js";
+import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
+import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
+import { splitSQLStatements, stripCommentsAndStrings } from "../../utils/sql-parser.js";
+
+// Minimal typings for the parts of the @sap/hana-client callback API we use. The
+// driver is an optional native dependency imported lazily in connect(), so these
+// let the DSN parser and its unit tests load without the package installed.
+interface HanaStatementResult {
+  [column: string]: unknown;
+}
+type HanaExecResult = HanaStatementResult[] | number;
+interface HanaStatement {
+  setTimeout(seconds: number): void;
+  exec(params: unknown[], cb: (err: Error | null, rows: HanaExecResult) => void): void;
+  drop?(cb?: (err: Error | null) => void): void;
+}
+interface HanaConnection {
+  connect(params: HanaConnectionConfig, cb: (err: Error | null) => void): void;
+  exec(sql: string, params: unknown[], cb: (err: Error | null, rows: HanaExecResult) => void): void;
+  prepare(sql: string, cb: (err: Error | null, statement: HanaStatement) => void): void;
+  disconnect(cb: (err: Error | null) => void): void;
+  setAutoCommit(autoCommit: boolean): void;
+  rollback(cb: (err: Error | null) => void): void;
+}
+interface HanaClientModule {
+  createConnection(): HanaConnection;
+}
+
+function parseBoolParam(key: string, value: string): boolean {
+  const v = value.trim().toLowerCase();
+  if (v === "true" || v === "1") return true;
+  if (v === "false" || v === "0") return false;
+  throw new Error(`Invalid boolean for '${key}': '${value}'. Use true or false.`);
+}
+
+/** Connection properties passed to @sap/hana-client's connect(). */
+export interface HanaConnectionConfig {
+  host: string;
+  port: number;
+  uid: string;
+  pwd: string;
+  encrypt?: boolean;
+  sslValidateCertificate?: boolean;
+  /** Tenant/database name for a multitenant (MDC) system. */
+  databaseName?: string;
+  /** Connection timeout in milliseconds. */
+  connectTimeout?: number;
+}
+
+/**
+ * SAP HANA DSN parser.
+ *
+ * Format: hana://username:password@host:port[/databaseName][?params]
+ *   - default port 30015 (tenant SQL port); for MDC name-based routing use the
+ *     SYSTEMDB port with the tenant name in the path.
+ *   - sslmode maps to encrypt/sslValidateCertificate: disable→off,
+ *     require→encrypt, verify-ca/verify-full→encrypt+validate. Explicit
+ *     encrypt/sslValidateCertificate params override; verify modes imply encryption.
+ */
+export class HanaDSNParser implements DSNParser {
+  async parse(dsn: string, config?: ConnectorConfig): Promise<HanaConnectionConfig> {
+    if (!this.isValidDSN(dsn)) {
+      throw new Error(
+        `Invalid SAP HANA DSN format.\nProvided: ${obfuscateDSNPassword(dsn)}\nExpected: ${this.getSampleDSN()}`
+      );
+    }
+
+    try {
+      const url = new SafeURL(dsn);
+      if (!url.hostname) {
+        throw new Error("SAP HANA DSN must include a host");
+      }
+
+      let sslmode: string | undefined;
+      let encryptParam: boolean | undefined;
+      let sslValidateParam: boolean | undefined;
+      let databaseNameParam: string | undefined;
+
+      url.forEachSearchParam((value, key) => {
+        switch (key) {
+          case "sslmode":
+            sslmode = value.trim().toLowerCase();
+            break;
+          case "encrypt":
+            encryptParam = parseBoolParam("encrypt", value);
+            break;
+          case "sslValidateCertificate":
+            sslValidateParam = parseBoolParam("sslValidateCertificate", value);
+            break;
+          case "databaseName":
+            databaseNameParam = value;
+            break;
+        }
+      });
+
+      let encrypt = encryptParam;
+      let sslValidateCertificate = sslValidateParam;
+      let sslmodeRequiresEncrypt = false;
+      if (sslmode !== undefined) {
+        switch (sslmode) {
+          case "disable":
+            encrypt = encryptParam ?? false;
+            break;
+          case "require":
+            encrypt = encryptParam ?? true;
+            sslValidateCertificate = sslValidateParam ?? false;
+            break;
+          case "verify-ca":
+          case "verify-full":
+            encrypt = encryptParam ?? true;
+            sslValidateCertificate = sslValidateParam ?? true;
+            sslmodeRequiresEncrypt = true;
+            break;
+          default:
+            throw new Error(
+              `Invalid sslmode '${sslmode}'. Valid values: disable, require, verify-ca, verify-full.`
+            );
+        }
+      }
+
+      // Reject config that would silently disable TLS despite a verify mode.
+      if (sslmodeRequiresEncrypt && encrypt === false) {
+        throw new Error(
+          `Contradictory TLS config: sslmode=${sslmode} requires encryption but encrypt=false was given.`
+        );
+      }
+      if (sslValidateCertificate === true && encrypt === false) {
+        throw new Error(
+          "Contradictory TLS config: sslValidateCertificate=true requires encrypt=true."
+        );
+      }
+      if (sslValidateCertificate === true) {
+        encrypt = true;
+      }
+
+      const pathDatabase =
+        url.pathname && url.pathname.length > 1 ? url.pathname.substring(1) : undefined;
+      const databaseName = pathDatabase ?? databaseNameParam;
+
+      const hanaConfig: HanaConnectionConfig = {
+        host: url.hostname,
+        port: url.port ? parseInt(url.port, 10) : 30015,
+        uid: url.username,
+        pwd: url.password,
+      };
+      if (encrypt !== undefined) hanaConfig.encrypt = encrypt;
+      if (sslValidateCertificate !== undefined)
+        hanaConfig.sslValidateCertificate = sslValidateCertificate;
+      if (databaseName) hanaConfig.databaseName = databaseName;
+      if (config?.connectionTimeoutSeconds !== undefined) {
+        hanaConfig.connectTimeout = config.connectionTimeoutSeconds * 1000;
+      }
+
+      return hanaConfig;
+    } catch (error) {
+      throw new Error(
+        `Failed to parse SAP HANA DSN: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  getSampleDSN(): string {
+    return "hana://username:password@localhost:30015?encrypt=true&sslmode=verify-full";
+  }
+
+  isValidDSN(dsn: string): boolean {
+    return dsn.startsWith("hana://");
+  }
+}
+
+/**
+ * SAP HANA connector (HANA 2.0 and HANA Cloud) on @sap/hana-client.
+ *
+ * A single connection per source is not safe for concurrent use, and read-only
+ * execution mutates transaction state, so every operation is serialized through
+ * runExclusive.
+ */
+export class HanaConnector implements Connector {
+  id: ConnectorType = "hana";
+  name = "SAP HANA";
+  dsnParser = new HanaDSNParser();
+
+  private connection?: HanaConnection;
+  private queryTimeoutSeconds?: number;
+  private sourceId = "default";
+  private opLock: Promise<unknown> = Promise.resolve();
+
+  // Procedural DDL / anonymous blocks whose bodies contain semicolons that are
+  // not statement separators.
+  private static readonly PROCEDURAL_RE =
+    /^\s*(?:create(?:\s+or\s+replace)?|alter)\b[\s\S]*?\b(?:procedure|function|trigger)\b|^\s*do\b/i;
+
+  getId(): string {
+    return this.sourceId;
+  }
+
+  clone(): Connector {
+    return new HanaConnector();
+  }
+
+  private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.opLock.then(fn, fn);
+    this.opLock = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  async connect(dsn: string, _initScript?: string, config?: ConnectorConfig): Promise<void> {
+    const params = await this.dsnParser.parse(dsn, config);
+    this.queryTimeoutSeconds =
+      config?.queryTimeoutSeconds && config.queryTimeoutSeconds > 0
+        ? config.queryTimeoutSeconds
+        : undefined;
+
+    // Lazy import: the native driver ships a platform-specific binary (glibc, not
+    // Alpine/musl), so keep it out of module scope. Mirrors the SQL Server
+    // connector's lazy @azure/identity import.
+    let hana: HanaClientModule;
+    try {
+      const mod = await import("@sap/hana-client");
+      hana = ((mod as { default?: HanaClientModule }).default ?? mod) as unknown as HanaClientModule;
+    } catch (importError) {
+      if (isDriverNotInstalled(importError, "@sap/hana-client")) {
+        throw new Error(
+          'SAP HANA support requires the "@sap/hana-client" package. Install it with: pnpm add @sap/hana-client'
+        );
+      }
+      throw importError;
+    }
+
+    const connection = hana.createConnection();
+    // Assign before connecting so a failed connect is still reachable for teardown.
+    this.connection = connection;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        connection.connect(params, (err) => (err ? reject(err) : resolve()));
+      });
+    } catch (err) {
+      this.connection = undefined;
+      await new Promise<void>((resolve) => {
+        try {
+          connection.disconnect(() => resolve());
+        } catch {
+          resolve();
+        }
+      });
+      throw err;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    const connection = this.connection;
+    if (!connection) return;
+    this.connection = undefined;
+    await new Promise<void>((resolve, reject) => {
+      connection.disconnect((err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  // Low-level driver call; callers hold the mutex. A configured query timeout
+  // needs a prepared statement, otherwise exec() directly.
+  private execRaw(sql: string, params: unknown[] = []): Promise<HanaExecResult> {
+    const connection = this.connection;
+    if (!connection) {
+      return Promise.reject(new Error("Not connected to SAP HANA database"));
+    }
+    const timeout = this.queryTimeoutSeconds;
+    if (!timeout) {
+      return new Promise<HanaExecResult>((resolve, reject) => {
+        connection.exec(sql, params, (err, rows) => (err ? reject(err) : resolve(rows)));
+      });
+    }
+    return new Promise<HanaExecResult>((resolve, reject) => {
+      connection.prepare(sql, (prepErr, statement) => {
+        if (prepErr) return reject(prepErr);
+        try {
+          statement.setTimeout(timeout);
+        } catch {
+          /* older drivers may lack setTimeout */
+        }
+        statement.exec(params, (execErr, rows) => {
+          try {
+            statement.drop?.(() => {});
+          } catch {
+            /* best effort */
+          }
+          if (execErr) reject(execErr);
+          else resolve(rows);
+        });
+      });
+    });
+  }
+
+  private async queryOne(sql: string, params: unknown[] = []): Promise<HanaStatementResult | undefined> {
+    const result = await this.execRaw(sql, params);
+    return Array.isArray(result) ? result[0] : undefined;
+  }
+
+  private async queryAll(sql: string, params: unknown[] = []): Promise<HanaStatementResult[]> {
+    const result = await this.execRaw(sql, params);
+    return Array.isArray(result) ? result : [];
+  }
+
+  private async getCurrentSchema(): Promise<string> {
+    const row = await this.queryOne("SELECT CURRENT_SCHEMA AS SCHEMA_NAME FROM SYS.DUMMY");
+    return (row?.SCHEMA_NAME as string) ?? "PUBLIC";
+  }
+
+  private async resolveSchema(schema?: string): Promise<string> {
+    return schema ?? (await this.getCurrentSchema());
+  }
+
+  async getSchemas(): Promise<string[]> {
+    return this.runExclusive(async () => {
+      const rows = await this.queryAll("SELECT SCHEMA_NAME FROM SYS.SCHEMAS ORDER BY SCHEMA_NAME");
+      return rows.map((row) => row.SCHEMA_NAME as string);
+    });
+  }
+
+  async getDefaultSchema(): Promise<string | null> {
+    return this.runExclusive(() => this.getCurrentSchema());
+  }
+
+  async getTables(schema?: string): Promise<string[]> {
+    return this.runExclusive(async () => {
+      const schemaToUse = await this.resolveSchema(schema);
+      const rows = await this.queryAll(
+        "SELECT TABLE_NAME FROM SYS.TABLES WHERE SCHEMA_NAME = ? ORDER BY TABLE_NAME",
+        [schemaToUse]
+      );
+      return rows.map((row) => row.TABLE_NAME as string);
+    });
+  }
+
+  async getViews(schema?: string): Promise<string[]> {
+    return this.runExclusive(async () => {
+      const schemaToUse = await this.resolveSchema(schema);
+      const rows = await this.queryAll(
+        "SELECT VIEW_NAME FROM SYS.VIEWS WHERE SCHEMA_NAME = ? ORDER BY VIEW_NAME",
+        [schemaToUse]
+      );
+      return rows.map((row) => row.VIEW_NAME as string);
+    });
+  }
+
+  async tableExists(tableName: string, schema?: string): Promise<boolean> {
+    return this.runExclusive(async () => {
+      const schemaToUse = await this.resolveSchema(schema);
+      const row = await this.queryOne(
+        `SELECT
+           (SELECT COUNT(*) FROM SYS.TABLES WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?)
+         + (SELECT COUNT(*) FROM SYS.VIEWS  WHERE SCHEMA_NAME = ? AND VIEW_NAME  = ?) AS CNT
+         FROM SYS.DUMMY`,
+        [schemaToUse, tableName, schemaToUse, tableName]
+      );
+      return Number(row?.CNT ?? 0) > 0;
+    });
+  }
+
+  async getTableSchema(tableName: string, schema?: string): Promise<TableColumn[]> {
+    return this.runExclusive(async () => {
+      const schemaToUse = await this.resolveSchema(schema);
+      // Union table and view columns so the call works for either. HANA returns
+      // uppercase result keys, so read them as such.
+      const rows = await this.queryAll(
+        `SELECT COLUMN_NAME, DATA_TYPE_NAME AS DATA_TYPE,
+                CASE WHEN IS_NULLABLE = 'TRUE' THEN 'YES' ELSE 'NO' END AS IS_NULLABLE,
+                DEFAULT_VALUE AS COLUMN_DEFAULT, COMMENTS AS DESCRIPTION, POSITION
+         FROM SYS.TABLE_COLUMNS WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?
+         UNION ALL
+         SELECT COLUMN_NAME, DATA_TYPE_NAME,
+                CASE WHEN IS_NULLABLE = 'TRUE' THEN 'YES' ELSE 'NO' END,
+                DEFAULT_VALUE, COMMENTS, POSITION
+         FROM SYS.VIEW_COLUMNS WHERE SCHEMA_NAME = ? AND VIEW_NAME = ?
+         ORDER BY POSITION`,
+        [schemaToUse, tableName, schemaToUse, tableName]
+      );
+      return rows.map((row) => ({
+        column_name: row.COLUMN_NAME as string,
+        data_type: row.DATA_TYPE as string,
+        is_nullable: row.IS_NULLABLE as string,
+        column_default: (row.COLUMN_DEFAULT as string | null) ?? null,
+        description: (row.DESCRIPTION as string | null) || null,
+      }));
+    });
+  }
+
+  async getTableIndexes(tableName: string, schema?: string): Promise<TableIndex[]> {
+    return this.runExclusive(async () => {
+      const schemaToUse = await this.resolveSchema(schema);
+      // CONSTRAINT is reserved, so quote it; its value is e.g. 'PRIMARY KEY', 'UNIQUE'.
+      const rows = await this.queryAll(
+        `SELECT INDEX_NAME, COLUMN_NAME, "CONSTRAINT" AS CONSTRAINT_TYPE, POSITION
+         FROM SYS.INDEX_COLUMNS
+         WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?
+         ORDER BY INDEX_NAME, POSITION`,
+        [schemaToUse, tableName]
+      );
+
+      const indexMap = new Map<string, { columns: string[]; is_unique: boolean; is_primary: boolean }>();
+      for (const row of rows) {
+        const indexName = row.INDEX_NAME as string;
+        const constraint = ((row.CONSTRAINT_TYPE as string | null) ?? "").toUpperCase();
+        const isPrimary = constraint.startsWith("PRIMARY");
+        const isUnique = isPrimary || constraint.includes("UNIQUE");
+
+        let info = indexMap.get(indexName);
+        if (!info) {
+          info = { columns: [], is_unique: isUnique, is_primary: isPrimary };
+          indexMap.set(indexName, info);
+        }
+        info.columns.push(row.COLUMN_NAME as string);
+      }
+
+      return Array.from(indexMap.entries()).map(([index_name, info]) => ({
+        index_name,
+        column_names: info.columns,
+        is_unique: info.is_unique,
+        is_primary: info.is_primary,
+      }));
+    });
+  }
+
+  async getTableComment(tableName: string, schema?: string): Promise<string | null> {
+    return this.runExclusive(async () => {
+      try {
+        const schemaToUse = await this.resolveSchema(schema);
+        const row = await this.queryOne(
+          `SELECT COMMENTS FROM (
+             SELECT SCHEMA_NAME, TABLE_NAME AS OBJECT_NAME, COMMENTS FROM SYS.TABLES
+             UNION ALL
+             SELECT SCHEMA_NAME, VIEW_NAME, COMMENTS FROM SYS.VIEWS
+           )
+           WHERE SCHEMA_NAME = ? AND OBJECT_NAME = ?`,
+          [schemaToUse, tableName]
+        );
+        return (row?.COMMENTS as string | null) || null;
+      } catch {
+        return null;
+      }
+    });
+  }
+
+  async getTableRowCount(tableName: string, schema?: string): Promise<number | null> {
+    return this.runExclusive(async () => {
+      try {
+        const schemaToUse = await this.resolveSchema(schema);
+        // Runtime statistics avoid a full COUNT(*).
+        const row = await this.queryOne(
+          "SELECT RECORD_COUNT FROM SYS.M_TABLES WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?",
+          [schemaToUse, tableName]
+        );
+        if (row?.RECORD_COUNT === undefined || row?.RECORD_COUNT === null) return null;
+        return Number(row.RECORD_COUNT);
+      } catch {
+        return null;
+      }
+    });
+  }
+
+  async getStoredProcedures(
+    schema?: string,
+    routineType?: "procedure" | "function"
+  ): Promise<string[]> {
+    return this.runExclusive(async () => {
+      const schemaToUse = await this.resolveSchema(schema);
+      const parts: string[] = [];
+      if (routineType !== "function") {
+        parts.push("SELECT PROCEDURE_NAME AS ROUTINE_NAME FROM SYS.PROCEDURES WHERE SCHEMA_NAME = ?");
+      }
+      if (routineType !== "procedure") {
+        parts.push("SELECT FUNCTION_NAME AS ROUTINE_NAME FROM SYS.FUNCTIONS WHERE SCHEMA_NAME = ?");
+      }
+      const params = new Array(parts.length).fill(schemaToUse);
+      const rows = await this.queryAll(`${parts.join(" UNION ALL ")} ORDER BY ROUTINE_NAME`, params);
+      return rows.map((row) => row.ROUTINE_NAME as string);
+    });
+  }
+
+  async getStoredProcedureDetail(procedureName: string, schema?: string): Promise<StoredProcedure> {
+    return this.runExclusive(async () => {
+      const schemaToUse = await this.resolveSchema(schema);
+
+      const procRow = await this.queryOne(
+        "SELECT PROCEDURE_NAME, DEFINITION FROM SYS.PROCEDURES WHERE SCHEMA_NAME = ? AND PROCEDURE_NAME = ?",
+        [schemaToUse, procedureName]
+      );
+
+      if (procRow) {
+        const paramRows = await this.queryAll(
+          `SELECT PARAMETER_NAME, DATA_TYPE_NAME, PARAMETER_TYPE
+           FROM SYS.PROCEDURE_PARAMETERS
+           WHERE SCHEMA_NAME = ? AND PROCEDURE_NAME = ?
+           ORDER BY POSITION`,
+          [schemaToUse, procedureName]
+        );
+        return {
+          procedure_name: procRow.PROCEDURE_NAME as string,
+          procedure_type: "procedure",
+          language: "SQLSCRIPT",
+          parameter_list: this.formatParameters(paramRows),
+          definition: (procRow.DEFINITION as string | undefined) ?? undefined,
+        };
+      }
+
+      const funcRow = await this.queryOne(
+        "SELECT FUNCTION_NAME, DEFINITION FROM SYS.FUNCTIONS WHERE SCHEMA_NAME = ? AND FUNCTION_NAME = ?",
+        [schemaToUse, procedureName]
+      );
+
+      if (funcRow) {
+        const paramRows = await this.queryAll(
+          `SELECT PARAMETER_NAME, DATA_TYPE_NAME, PARAMETER_TYPE
+           FROM SYS.FUNCTION_PARAMETERS
+           WHERE SCHEMA_NAME = ? AND FUNCTION_NAME = ?
+           ORDER BY POSITION`,
+          [schemaToUse, procedureName]
+        );
+        // HANA function params are IN/OUT/INOUT; the OUT ones are the return values.
+        const mode = (row: HanaStatementResult) => ((row.PARAMETER_TYPE as string) ?? "IN").toUpperCase();
+        const inputs = paramRows.filter((r) => mode(r) !== "OUT");
+        const outputs = paramRows.filter((r) => mode(r) === "OUT");
+        return {
+          procedure_name: funcRow.FUNCTION_NAME as string,
+          procedure_type: "function",
+          language: "SQLSCRIPT",
+          parameter_list: this.formatParameters(inputs),
+          return_type: outputs.map((r) => r.DATA_TYPE_NAME as string).join(", ") || undefined,
+          definition: (funcRow.DEFINITION as string | undefined) ?? undefined,
+        };
+      }
+
+      throw new Error(`Stored procedure '${procedureName}' not found in schema '${schemaToUse}'`);
+    });
+  }
+
+  private formatParameters(paramRows: HanaStatementResult[]): string {
+    return paramRows
+      .map((row) => {
+        const mode = ((row.PARAMETER_TYPE as string) ?? "IN").toUpperCase();
+        return `${row.PARAMETER_NAME} ${mode} ${row.DATA_TYPE_NAME}`;
+      })
+      .join(", ");
+  }
+
+  // SQLScript procedural DDL and anonymous DO blocks carry semicolons inside their
+  // bodies, so submit them as one statement; split everything else on ';'.
+  private splitStatements(sqlQuery: string): string[] {
+    const stripped = stripCommentsAndStrings(sqlQuery, "hana");
+    if (/\bbegin\b/i.test(stripped) || HanaConnector.PROCEDURAL_RE.test(stripped)) {
+      const trimmed = sqlQuery.trim();
+      return trimmed ? [trimmed] : [];
+    }
+    const parts = splitSQLStatements(sqlQuery, "hana");
+    if (parts.length > 0) return parts;
+    const trimmed = sqlQuery.trim();
+    return trimmed ? [trimmed] : [];
+  }
+
+  // Cap rows for a read query, including CTEs and comment-prefixed SELECTs that
+  // SQLRowLimiter (leading SELECT only) would miss.
+  private capRows(sql: string, maxRows?: number): string {
+    if (!maxRows) return sql;
+    const firstKeyword = stripCommentsAndStrings(sql, "hana")
+      .trimStart()
+      .match(/^([a-z]+)/i)?.[1]
+      ?.toLowerCase();
+    if (firstKeyword === "select" && sql.trimStart().toLowerCase().startsWith("select")) {
+      return SQLRowLimiter.applyMaxRows(sql, maxRows);
+    }
+    if (firstKeyword === "select" || firstKeyword === "with") {
+      const inner = sql.trim().replace(/;\s*$/, "");
+      return `SELECT * FROM (\n${inner}\n) AS DBHUB_LIMITED LIMIT ${maxRows}`;
+    }
+    return sql;
+  }
+
+  async executeSQL(sqlQuery: string, options: ExecuteOptions, parameters?: any[]): Promise<SQLResult> {
+    const statements = this.splitStatements(sqlQuery);
+
+    // Positional parameters can't be spread across statements.
+    if (parameters && parameters.length > 0 && statements.length > 1) {
+      throw new Error(
+        "Parameters are not supported with multiple statements; run parameterized statements one at a time."
+      );
+    }
+
+    const processed = statements.map((stmt) => this.capRows(stmt, options.maxRows));
+
+    return this.runExclusive(async () => {
+      if (!this.connection) {
+        throw new Error("Not connected to SAP HANA database");
+      }
+      if (options.readonly) {
+        return this.executeReadOnly(processed, parameters);
+      }
+      return this.runStatements(processed, parameters);
+    });
+  }
+
+  private async runStatements(statements: string[], parameters?: any[]): Promise<SQLResult> {
+    const rows: any[] = [];
+    let rowCount = 0;
+    for (const statement of statements) {
+      const result = await this.execRaw(statement, parameters ?? []);
+      if (Array.isArray(result)) {
+        rows.push(...result);
+        rowCount += result.length;
+      } else if (typeof result === "number") {
+        rowCount += result;
+      }
+    }
+    return { rows, rowCount };
+  }
+
+  // Engine-level read-only enforcement behind the keyword classifier. Marks the
+  // transaction read-only, then always rolls back and restores READ WRITE +
+  // autocommit so the shared connection stays usable; discards it if that fails.
+  private async executeReadOnly(statements: string[], parameters?: any[]): Promise<SQLResult> {
+    const connection = this.connection!;
+    connection.setAutoCommit(false);
+    try {
+      await this.execRaw("SET TRANSACTION READ ONLY");
+      return await this.runStatements(statements, parameters);
+    } finally {
+      await this.restoreReadWrite(connection);
+    }
+  }
+
+  private async restoreReadWrite(connection: HanaConnection): Promise<void> {
+    const rollback = () =>
+      new Promise<void>((resolve, reject) => connection.rollback((e) => (e ? reject(e) : resolve())));
+    try {
+      await rollback();
+      await this.execRaw("SET TRANSACTION READ WRITE");
+      await rollback();
+      connection.setAutoCommit(true);
+    } catch {
+      if (this.connection === connection) this.connection = undefined;
+      await new Promise<void>((resolve) => {
+        try {
+          connection.disconnect(() => resolve());
+        } catch {
+          resolve();
+        }
+      });
+    }
+  }
+}
+
+const hanaConnector = new HanaConnector();
+ConnectorRegistry.register(hanaConnector);

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -1,7 +1,7 @@
 /**
  * Type definition for supported database connector types
  */
-export type ConnectorType = "postgres" | "mysql" | "mariadb" | "sqlite" | "sqlserver";
+export type ConnectorType = "postgres" | "mysql" | "mariadb" | "sqlite" | "sqlserver" | "hana";
 
 /**
  * Database Connector Interface

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ const connectorModules = [
   { load: () => import("./connectors/sqlite/index.js"), name: "SQLite", driver: "node:sqlite" },
   { load: () => import("./connectors/mysql/index.js"), name: "MySQL", driver: "mysql2" },
   { load: () => import("./connectors/mariadb/index.js"), name: "MariaDB", driver: "mariadb" },
+  { load: () => import("./connectors/hana/index.js"), name: "SAP HANA", driver: "@sap/hana-client" },
 ];
 
 loadConnectors(connectorModules)

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -27,7 +27,7 @@ export interface SSHConfig {
  * Database connection parameters (alternative to DSN)
  */
 export interface ConnectionParams {
-  type: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite";
+  type: "postgres" | "mysql" | "mariadb" | "sqlserver" | "sqlite" | "hana";
   host?: string;
   port?: number;
   database?: string;

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -14,6 +14,8 @@ export const allowedKeywords: Record<ConnectorType, string[]> = {
   // SQL Server has no native EXPLAIN statement; the connector translates a
   // leading `EXPLAIN` into a SET SHOWPLAN_XML request (see SQLServerConnector).
   sqlserver: ["select", "with", "explain"],
+  // HANA's EXPLAIN PLAN writes to a plan table rather than returning rows.
+  hana: ["select", "with"],
 };
 
 /**
@@ -125,6 +127,7 @@ const mutatingPatterns: Record<ConnectorType, RegExp> = {
   mariadb: mutatingPatternWithReplace,
   sqlite: mutatingPatternWithReplace,
   sqlserver: mutatingPatternSqlServer,
+  hana: mutatingPattern,
 };
 
 const selectIntoPattern = /\bselect\b[\s\S]+\binto\b/i;

--- a/src/utils/dsn-obfuscate.ts
+++ b/src/utils/dsn-obfuscate.ts
@@ -191,7 +191,8 @@ function protocolToConnectorType(protocol: string): ConnectorType | undefined {
     'mysql': 'mysql',
     'mariadb': 'mariadb',
     'sqlserver': 'sqlserver',
-    'sqlite': 'sqlite'
+    'sqlite': 'sqlite',
+    'hana': 'hana'
   };
   return mapping[protocol];
 }
@@ -208,6 +209,7 @@ export function getDefaultPortForType(type: ConnectorType): number | undefined {
     'mariadb': 3306,
     'sqlserver': 1433,
     'sqlite': undefined,
+    'hana': 30015,
   };
   return ports[type];
 }

--- a/src/utils/error-classifier.ts
+++ b/src/utils/error-classifier.ts
@@ -34,6 +34,8 @@ const AUTH_CODES: Record<ConnectorType, ReadonlyArray<string | number>> = {
   mariadb: ["ER_ACCESS_DENIED_ERROR", 1045, 1698],
   sqlserver: ["ELOGIN"],
   sqlite: [], // no network/auth layer
+  // HANA: SQL error 10 = "authentication failed" (SQLSTATE 28000).
+  hana: [10, "28000"],
 };
 
 function unreachableMessage(sourceId: string): string {
@@ -79,9 +81,13 @@ export function classifyConnectionError(
 
   const authCodes = AUTH_CODES[connectorType];
   const errno = err.errno;
+  const sqlState = err.sqlState;
   if (
     (typeof code === "string" && authCodes.includes(code)) ||
-    (typeof errno === "number" && authCodes.includes(errno))
+    // @sap/hana-client reports a numeric code and a sqlState.
+    (typeof code === "number" && authCodes.includes(code)) ||
+    (typeof errno === "number" && authCodes.includes(errno)) ||
+    (typeof sqlState === "string" && authCodes.includes(sqlState))
   ) {
     return { code: "AUTH_FAILED", message: authMessage(sourceId) };
   }

--- a/src/utils/identifier-quoter.ts
+++ b/src/utils/identifier-quoter.ts
@@ -34,7 +34,8 @@ export function quoteIdentifier(identifier: string, dbType: ConnectorType): stri
   switch (dbType) {
     case "postgres":
     case "sqlite":
-      // PostgreSQL and SQLite use double quotes
+    case "hana":
+      // PostgreSQL, SQLite and SAP HANA use double quotes
       // Escape existing double quotes by doubling them
       return `"${identifier.replace(/"/g, '""')}"`;
 

--- a/src/utils/parameter-mapper.ts
+++ b/src/utils/parameter-mapper.ts
@@ -16,6 +16,7 @@ export const PARAMETER_STYLES = {
   mariadb: "positional", // ?, ?, ?
   sqlserver: "named", // @p1, @p2, @p3
   sqlite: "positional", // ?, ?, ?
+  hana: "positional", // ?, ?, ?
 } as const;
 
 /**

--- a/src/utils/sql-parser.ts
+++ b/src/utils/sql-parser.ts
@@ -191,6 +191,9 @@ const dialectScanners: Record<ConnectorType, TokenScanner> = {
   mariadb: scanTokenMySQL,
   sqlite: scanTokenSQLite,
   sqlserver: scanTokenSQLServer,
+  // HANA uses ANSI comments (-- and /* */), single-quoted strings and
+  // double-quoted identifiers — exactly the ANSI scanner.
+  hana: scanTokenAnsi,
 };
 
 function getScanner(dialect?: ConnectorType): TokenScanner {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   // CJS code into ESM chunks (which causes "Dynamic require of X is not
   // supported"). Cloud auth packages are externalized to keep their large
   // dependency trees out of the bundle.
-  external: ['pg', 'mysql2', 'mariadb', 'mssql', '@aws-sdk/rds-signer', '@azure/identity'],
+  external: ['pg', 'mysql2', 'mariadb', 'mssql', '@sap/hana-client', '@aws-sdk/rds-signer', '@azure/identity'],
   // Copy the employee-sqlite demo data to dist
   async onSuccess() {
     // Create target directory


### PR DESCRIPTION
Add a SAP HANA connector (HANA 2.0 and HANA Cloud) built on the optional native @sap/hana-client driver, wired through every config path (DSN, DB_* env params, and TOML sources).

- src/connectors/hana/index.ts: Connector + DSNParser. DSN hana://user:pass@host:30015[/tenant][?encrypt&sslmode]. Metadata via SYS views; LIMIT-based maxRows including CTEs; engine-level read-only enforcement via SET TRANSACTION READ ONLY with a READ WRITE restore; a single connection serialized by a mutex; prepared-statement query timeout.
- Driver imported lazily and externalized in tsup so the CJS native module is not bundled into the ESM output.
- HANA-aware statement splitting: procedure/function/trigger DDL and DO blocks are run whole instead of split on their internal semicolons.
- Register "hana" across ConnectorType and the exhaustive maps: allowed-keywords, sql-parser, dsn-obfuscate, error-classifier, parameter-mapper, identifier-quoter.
- Config paths: DSN protocol, DB_TYPE=hana, TOML type="hana" (database optional, verify-* sslmode allowed), and the OpenAPI source-type enum.
- Tests: DSN-parser unit tests, driver-mocked connector unit tests, and a gated integration suite (HANA_DSN).
- Docs: README, CLAUDE.md, .env.example, dbhub.toml.example, package.json.