### PR TITLE
feat: support the GO batch separator on SQL Server

### DIFF
--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -929,9 +929,176 @@ describe('SQL Server Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id',
         {}
       );
-      
+
       // Should return all users (at least the original 3 plus any added in previous tests)
       expect(result.rows.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('GO batch separator', () => {
+    it('runs batches on one session, so state carries across GO', async () => {
+      // A temp table proves the session is pinned: on a fresh connection the
+      // INSERT would fail with "Invalid object name '#go_state'".
+      const result = await sqlServerTest.connector.executeSQL(
+        [
+          'CREATE TABLE #go_state (id INT)',
+          'GO',
+          'INSERT INTO #go_state VALUES (1),(2)',
+          'GO',
+          'SELECT COUNT(*) AS n FROM #go_state',
+          'GO',
+        ].join('\n'),
+        {}
+      );
+
+      expect(result.rows).toEqual([{ n: 2 }]);
+    });
+
+    it('creates several procedures in one call', async () => {
+      // Each CREATE PROCEDURE must open its own batch, so without GO support
+      // this whole script is rejected outright.
+      await sqlServerTest.connector.executeSQL(
+        [
+          'CREATE PROCEDURE dbo.go_probe_a AS SELECT 1 AS v;',
+          'GO',
+          'CREATE PROCEDURE dbo.go_probe_b AS SELECT 2 AS v;',
+          'GO',
+        ].join('\n'),
+        {}
+      );
+
+      const created = await sqlServerTest.connector.executeSQL(
+        "SELECT name FROM sys.procedures WHERE name IN ('go_probe_a', 'go_probe_b') ORDER BY name",
+        {}
+      );
+
+      expect(created.rows.map((r: any) => r.name)).toEqual(['go_probe_a', 'go_probe_b']);
+    });
+
+    it('leaves PARSEONLY applying to the statements rather than to itself', async () => {
+      // The trap this feature exists to remove: in a single batch, the closing
+      // SET PARSEONLY OFF is read at parse time and the INSERT really runs.
+      // Split across GO, each SET lands in its own batch and nothing executes.
+      const before = await sqlServerTest.connector.executeSQL(
+        'SELECT COUNT(*) AS n FROM users',
+        {}
+      );
+
+      await sqlServerTest.connector.executeSQL(
+        [
+          'SET PARSEONLY ON',
+          'GO',
+          "INSERT INTO users (name, email, age) VALUES ('parseonly', 'parseonly@example.com', 1)",
+          'GO',
+          'SET PARSEONLY OFF',
+          'GO',
+        ].join('\n'),
+        {}
+      );
+
+      const after = await sqlServerTest.connector.executeSQL(
+        'SELECT COUNT(*) AS n FROM users',
+        {}
+      );
+
+      expect(after.rows[0].n).toBe(before.rows[0].n);
+    });
+
+    it('still surfaces a syntax error under PARSEONLY', async () => {
+      // Name the offending keyword: an unsplit script errors on `GO` itself,
+      // which would satisfy a looser match without PARSEONLY ever applying.
+      await expect(
+        sqlServerTest.connector.executeSQL(
+          'SET PARSEONLY ON\nGO\nSELECT FROM WHERE\nGO',
+          {}
+        )
+      ).rejects.toThrow(/Incorrect syntax near the keyword 'FROM'/);
+    });
+
+    it('does not let session state outlive the call', async () => {
+      // NOEXEC crossing the GO is the feature; the per-call pool is what stops
+      // it from swallowing every query that follows.
+      const swallowed = await sqlServerTest.connector.executeSQL(
+        'SET NOEXEC ON\nGO\nSELECT 1 AS a\nGO',
+        {}
+      );
+      expect(swallowed.rows).toEqual([]);
+
+      const after = await sqlServerTest.connector.executeSQL('SELECT 1 AS a', {});
+      expect(after.rows).toEqual([{ a: 1 }]);
+    });
+
+    it('repeats a batch GO <n> times', async () => {
+      const result = await sqlServerTest.connector.executeSQL(
+        [
+          'CREATE TABLE #go_repeat (id INT)',
+          'GO',
+          'INSERT INTO #go_repeat VALUES (1)',
+          'GO 3',
+          'SELECT COUNT(*) AS n FROM #go_repeat',
+          'GO',
+        ].join('\n'),
+        {}
+      );
+
+      expect(result.rows).toEqual([{ n: 3 }]);
+    });
+
+    it('returns every result set the script produced', async () => {
+      const result = await sqlServerTest.connector.executeSQL(
+        'SELECT 1 AS a\nGO\nSELECT 2 AS b\nGO',
+        {}
+      );
+
+      expect(result.rows).toEqual([{ a: 1 }]);
+      expect(result.resultSets).toEqual([[{ a: 1 }], [{ b: 2 }]]);
+    });
+
+    it('names the batch that failed', async () => {
+      // Line numbers the server reports are relative to the batch, so the batch
+      // has to be identified for them to mean anything.
+      await expect(
+        sqlServerTest.connector.executeSQL(
+          'SELECT 1\nGO\nSELECT * FROM no_such_table_xyz\nGO',
+          {}
+        )
+      ).rejects.toThrow(/batch 2 of 2/);
+    });
+
+    it('refuses GO in read-only mode', async () => {
+      await expect(
+        sqlServerTest.connector.executeSQL('SELECT 1\nGO\nSELECT 2\nGO', { readonly: true })
+      ).rejects.toThrow(/GO batch separator/);
+    });
+
+    it('keeps the single-batch path for a script with a lone trailing GO', async () => {
+      // The splitter strips it; the server would reject it as syntax.
+      const result = await sqlServerTest.connector.executeSQL('SELECT 1 AS a\nGO', {});
+      expect(result.rows).toEqual([{ a: 1 }]);
+    });
+
+    it('treats a script of only separators as a no-op', async () => {
+      // The splitter yields no batches, so there is nothing to run. Falling
+      // through to the single-batch path would hand the raw `GO` to the
+      // server, which reads it as a procedure name.
+      const result = await sqlServerTest.connector.executeSQL('GO\nGO\n', {});
+      expect(result.rows).toEqual([]);
+      expect(result.rowCount).toBe(0);
+    });
+
+    it('does not split on GO inside a string literal', async () => {
+      const result = await sqlServerTest.connector.executeSQL(
+        "SELECT '\nGO\n' AS s",
+        {}
+      );
+      expect(result.rows).toEqual([{ s: '\nGO\n' }]);
+    });
+
+    it('returns both result sets from a multi-statement single batch', async () => {
+      // recordset is only the first; without recordsets the second vanished.
+      const result = await sqlServerTest.connector.executeSQL('SELECT 1 AS a; SELECT 2 AS b;', {});
+      expect(result.rows).toEqual([{ a: 1 }]);
+      expect(result.resultSets).toEqual([[{ a: 1 }], [{ b: 2 }]]);
     });
   });
 });

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -27,6 +27,13 @@ export interface DatabaseMessage {
 export interface SQLResult {
   rows: any[];
   rowCount: number;
+  /**
+   * Every result set the SQL produced, in order, when it produced more than one
+   * (e.g. `SELECT 1; SELECT 2`). `rows` stays the first of them, so a caller
+   * that only ever expects one result set sees no change. Absent when the SQL
+   * produced a single result set or none.
+   */
+  resultSets?: any[][];
   /** Informational messages from the database (e.g. SQL Server STATISTICS TIME/IO, PRINT output) */
   messages?: DatabaseMessage[];
 }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -16,7 +16,11 @@ import { isDriverNotInstalled } from "../../utils/module-loader.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
-import { stripCommentsAndStrings } from "../../utils/sql-parser.js";
+import {
+  stripCommentsAndStrings,
+  splitSQLServerBatches,
+  type SQLServerBatch,
+} from "../../utils/sql-parser.js";
 import {
   sqlServerDynamicSqlKeywords,
   sqlServerDynamicSqlPattern,
@@ -662,11 +666,27 @@ export class SQLServerConnector implements Connector {
         : this.explainQuery(query, options.readonly, parameters);
     }
 
+    // `GO` is a client directive the server never sees, so a script carrying one
+    // has to be cut up and sent batch by batch. Scripts without a separator —
+    // the overwhelming majority — stay on the single round trip below.
+    const batches = splitSQLServerBatches(sqlQuery);
+    if (batches.length === 0) {
+      // Nothing but separators (or nothing at all): no statement to run. SSMS
+      // treats that as a no-op, and falling through would hand the raw `GO`
+      // to the server, which has no idea what it is.
+      return { rows: [], rowCount: 0 };
+    }
+    if (batches.length > 1 || batches.some((batch) => batch.count > 1)) {
+      return this.executeBatches(batches, options, parameters);
+    }
+
     try {
-      // Apply maxRows limit to SELECT queries if specified
-      let processedSQL = sqlQuery;
+      // Exactly one batch here, so at most a trailing `GO`, which the splitter
+      // has already removed; send its text rather than the original, or the
+      // server would reject the separator.
+      let processedSQL = batches[0].sql;
       if (options.maxRows) {
-        processedSQL = SQLRowLimiter.applyMaxRowsForSQLServer(sqlQuery, options.maxRows);
+        processedSQL = SQLRowLimiter.applyMaxRowsForSQLServer(processedSQL, options.maxRows);
       }
 
       // Engine-level read-only enforcement: SQL Server has no
@@ -680,26 +700,19 @@ export class SQLServerConnector implements Connector {
       // Create request and collect informational messages (e.g. SET STATISTICS TIME/IO, PRINT)
       const request = this.connection.request();
       const messages: DatabaseMessage[] = [];
-      request.on(
-        'info',
-        (info: { message: string; number?: number; class?: number; lineNumber?: number }) => {
-          messages.push({
-            text: info.message,
-            // SQL Server reports severity as a numeric class; info messages are < 10.
-            severity: info.class !== undefined ? String(info.class) : undefined,
-            code: info.number,
-            line: info.lineNumber,
-          });
-        }
-      );
+      SQLServerConnector.collectInfoMessages(request, messages);
 
       SQLServerConnector.bindParameters(request, parameters);
 
       const result = await request.query(processedSQL);
 
+      // `recordset` is only the first result set, so `SELECT 1; SELECT 2` would
+      // otherwise drop the second without saying so.
+      const resultSets = (result.recordsets ?? []) as unknown as any[][];
       return {
         rows: result.recordset || [],
         rowCount: result.rowsAffected[0] || 0,
+        ...(resultSets.length > 1 ? { resultSets } : {}),
         ...(messages.length > 0 ? { messages } : {}),
       };
     } catch (error) {
@@ -793,6 +806,124 @@ export class SQLServerConnector implements Connector {
   }
 
   /**
+   * Route a request's informational messages — SET STATISTICS IO/TIME output,
+   * PRINT — into `messages`. SQL Server delivers them as events rather than as
+   * result sets, so they are invisible to the driver's normal return value.
+   */
+  private static collectInfoMessages(request: sql.Request, messages: DatabaseMessage[]): void {
+    request.on(
+      'info',
+      (info: { message: string; number?: number; class?: number; lineNumber?: number }) => {
+        messages.push({
+          text: info.message,
+          // SQL Server reports severity as a numeric class; info messages are < 10.
+          severity: info.class !== undefined ? String(info.class) : undefined,
+          code: info.number,
+          line: info.lineNumber,
+        });
+      }
+    );
+  }
+
+  /**
+   * Run a `GO`-separated script one batch per round trip.
+   *
+   * The single-batch path sends SQL through node-mssql's `request.query`, which
+   * is an sp_executesql RPC: one batch, inside a nested scope. Neither suits a
+   * script. CREATE PROCEDURE must be alone in its batch, and a session-scoped
+   * SET has to outlive the statement that set it — sp_executesql reverts it on
+   * scope exit. So batches go through `request.batch` instead.
+   *
+   * That costs the isolation sp_executesql was providing: `request.batch` runs
+   * at nest level 0 and leaves SET options on the session, and the shared pool
+   * hands that same session to the next caller — one stray `SET NOEXEC ON`
+   * would silently swallow every later query. Hence a private pool per call,
+   * pinned to one connection and closed at the end: the session dies with it and
+   * takes any leaked state along. The price is a connect per call, paid only by
+   * scripts that actually carry a separator.
+   */
+  private async executeBatches(
+    batches: SQLServerBatch[],
+    options: ExecuteOptions,
+    parameters?: any[]
+  ): Promise<SQLResult> {
+    if (!this.config) {
+      throw new Error("Not connected to SQL Server database");
+    }
+
+    // A rollback guard cannot span batches: each `GO` ends the batch a
+    // transaction would have to live in, and DDL like CREATE PROCEDURE is
+    // exactly what such scripts carry. Refuse rather than half-enforce.
+    if (options.readonly) {
+      throw new Error(
+        "Read-only mode does not support the GO batch separator: a rollback guard cannot span batches"
+      );
+    }
+
+    // A batch can carry parameters — node-mssql prepends the DECLARE/SET, which
+    // is how the EXPLAIN paths bind them. What has no obvious answer is which
+    // batch of a multi-batch script they belong to: binding them to every batch
+    // would redeclare them per batch, binding them to one would need the caller
+    // to say which. Refuse until there is a use case that settles it.
+    if (parameters && parameters.length > 0) {
+      throw new Error("Parameters are not supported alongside the GO batch separator");
+    }
+
+    const batchPool = new sql.ConnectionPool({
+      ...this.config,
+      pool: { ...this.config.pool, max: 1, min: 1 },
+    });
+
+    const messages: DatabaseMessage[] = [];
+    const resultSets: any[][] = [];
+    let rowCount = 0;
+
+    try {
+      await batchPool.connect();
+
+      for (const [index, batch] of batches.entries()) {
+        const batchSQL = options.maxRows
+          ? SQLRowLimiter.applyMaxRowsForSQLServer(batch.sql, options.maxRows)
+          : batch.sql;
+
+        // max:1 + sequential awaits guarantee every batch hits the same session,
+        // which is the whole point: state has to carry from one to the next.
+        for (let run = 0; run < batch.count; run++) {
+          const request = batchPool.request();
+          SQLServerConnector.collectInfoMessages(request, messages);
+
+          let result: sql.IResult<any>;
+          try {
+            result = await request.batch(batchSQL);
+          } catch (error) {
+            // Name the batch: in a long script the server's line numbers are
+            // relative to the batch, which is useless without knowing which.
+            throw new Error(`batch ${index + 1} of ${batches.length}: ${(error as Error).message}`);
+          }
+
+          for (const recordset of (result.recordsets ?? []) as unknown as any[][]) {
+            resultSets.push(recordset);
+          }
+          rowCount += result.rowsAffected.reduce((sum, affected) => sum + affected, 0);
+        }
+      }
+    } catch (error) {
+      throw new Error(`Failed to execute query: ${(error as Error).message}`);
+    } finally {
+      await batchPool.close();
+    }
+
+    return {
+      rows: resultSets[0] ?? [],
+      // Summed across batches: a script's writes are one logical unit, and no
+      // single batch's count would describe it.
+      rowCount,
+      ...(resultSets.length > 1 ? { resultSets } : {}),
+      ...(messages.length > 0 ? { messages } : {}),
+    };
+  }
+
+  /**
    * Execute a query inside a transaction that always rolls back, preventing
    * any modifications from persisting. SQL Server has no native READ ONLY
    * transaction mode, so this is the defense-in-depth backstop behind the
@@ -812,17 +943,7 @@ export class SQLServerConnector implements Connector {
 
     const request = new sql.Request(transaction);
     const messages: DatabaseMessage[] = [];
-    request.on(
-      'info',
-      (info: { message: string; number?: number; class?: number; lineNumber?: number }) => {
-        messages.push({
-          text: info.message,
-          severity: info.class !== undefined ? String(info.class) : undefined,
-          code: info.number,
-          line: info.lineNumber,
-        });
-      },
-    );
+    SQLServerConnector.collectInfoMessages(request, messages);
 
     SQLServerConnector.bindParameters(request, parameters);
 

--- a/src/tools/execute-sql.ts
+++ b/src/tools/execute-sql.ts
@@ -75,6 +75,9 @@ export function createExecuteSqlToolHandler(sourceId?: string) {
         rows: result.rows,
         count: result.rowCount,
         source_id: effectiveSourceId,
+        // Only present when the SQL produced more than one result set; `rows`
+        // stays the first, so a single-result response is unchanged.
+        ...(result.resultSets ? { result_sets: result.resultSets } : {}),
         ...(result.messages && result.messages.length > 0 ? { messages: result.messages } : {}),
       };
 

--- a/src/utils/__tests__/sql-parser.test.ts
+++ b/src/utils/__tests__/sql-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { stripCommentsAndStrings, splitSQLStatements } from "../sql-parser.js";
+import { stripCommentsAndStrings, splitSQLStatements, splitSQLServerBatches } from "../sql-parser.js";
 
 describe("stripCommentsAndStrings", () => {
   describe("single-line comments (--)", () => {
@@ -619,4 +619,120 @@ describe("splitSQLStatements", () => {
     });
   });
 
+});
+
+describe("splitSQLServerBatches", () => {
+  const texts = (sql: string) => splitSQLServerBatches(sql).map((b) => b.sql.trim());
+
+  describe("basic splitting", () => {
+    it("returns the whole script as one batch when there is no GO", () => {
+      expect(splitSQLServerBatches("SELECT 1; SELECT 2;")).toEqual([
+        { sql: "SELECT 1; SELECT 2;", count: 1 },
+      ]);
+    });
+
+    it("splits on a GO line", () => {
+      expect(texts("SELECT 1\nGO\nSELECT 2")).toEqual(["SELECT 1", "SELECT 2"]);
+    });
+
+    it("strips a trailing GO that has no newline after it", () => {
+      expect(texts("SELECT 1\nGO")).toEqual(["SELECT 1"]);
+    });
+
+    it("accepts CRLF line endings", () => {
+      expect(texts("SELECT 1\r\nGO\r\nSELECT 2")).toEqual(["SELECT 1", "SELECT 2"]);
+    });
+
+    it("is case-insensitive and tolerates surrounding whitespace", () => {
+      expect(texts("SELECT 1\n   Go  \nSELECT 2")).toEqual(["SELECT 1", "SELECT 2"]);
+    });
+
+    it("drops empty batches from consecutive or leading separators", () => {
+      expect(texts("GO\nSELECT 1\nGO\nGO\nSELECT 2\n")).toEqual(["SELECT 1", "SELECT 2"]);
+    });
+
+    it("returns nothing for a script that is only separators", () => {
+      expect(splitSQLServerBatches("GO\nGO\n")).toEqual([]);
+    });
+
+    it("allows a line comment after the separator", () => {
+      expect(texts("SELECT 1\nGO -- next up\nSELECT 2")).toEqual(["SELECT 1", "SELECT 2"]);
+    });
+  });
+
+  describe("repeat count", () => {
+    it("reads the count from GO <n>", () => {
+      expect(splitSQLServerBatches("SELECT 1\nGO 3\n")).toEqual([{ sql: "SELECT 1\n", count: 3 }]);
+    });
+
+    it("defaults the count to 1", () => {
+      expect(splitSQLServerBatches("SELECT 1\nGO\n")).toEqual([{ sql: "SELECT 1\n", count: 1 }]);
+    });
+
+    it("reads a count that carries a trailing comment", () => {
+      expect(splitSQLServerBatches("SELECT 1\nGO 2 -- twice\n")[0].count).toBe(2);
+    });
+
+    it("leaves GO 0 alone rather than silently dropping the batch", () => {
+      // SSMS rejects GO 0; passing it through surfaces that error instead of
+      // quietly running the batch zero times.
+      expect(texts("SELECT 1\nGO 0\n")).toEqual(["SELECT 1\nGO 0"]);
+    });
+  });
+
+  describe("GO that is not a separator", () => {
+    it("does not split on GOTO", () => {
+      expect(texts("SELECT 1\nGOTO done\nSELECT 2")).toEqual(["SELECT 1\nGOTO done\nSELECT 2"]);
+    });
+
+    it("does not split on GO with trailing tokens", () => {
+      expect(texts("SELECT 1\nGO SELECT 2")).toEqual(["SELECT 1\nGO SELECT 2"]);
+    });
+
+    it("does not split on GO inside a string literal", () => {
+      expect(texts("SELECT '\nGO\n' AS s")).toEqual(["SELECT '\nGO\n' AS s"]);
+    });
+
+    it("does not split on GO inside a block comment", () => {
+      expect(texts("SELECT 1\n/*\nGO\n*/\nSELECT 2")).toEqual(["SELECT 1\n/*\nGO\n*/\nSELECT 2"]);
+    });
+
+    it("does not split on GO inside a bracket-quoted identifier", () => {
+      expect(texts("SELECT 1 AS [\nGO\n]")).toEqual(["SELECT 1 AS [\nGO\n]"]);
+    });
+
+    it("still splits after a block comment closes", () => {
+      expect(texts("/* header\nGO\n*/\nSELECT 1\nGO\nSELECT 2")).toEqual([
+        "/* header\nGO\n*/\nSELECT 1",
+        "SELECT 2",
+      ]);
+    });
+
+    it("splits on the line after a line comment", () => {
+      expect(texts("SELECT 1 -- note\nGO\nSELECT 2")).toEqual(["SELECT 1 -- note", "SELECT 2"]);
+    });
+  });
+
+  describe("realistic scripts", () => {
+    it("separates procedures that each must start their own batch", () => {
+      const script = [
+        "CREATE PROCEDURE dbo.a AS SELECT 1;",
+        "GO",
+        "CREATE PROCEDURE dbo.b AS SELECT 2;",
+        "GO",
+      ].join("\n");
+      expect(texts(script)).toEqual([
+        "CREATE PROCEDURE dbo.a AS SELECT 1;",
+        "CREATE PROCEDURE dbo.b AS SELECT 2;",
+      ]);
+    });
+
+    it("keeps a parse-time SET in a batch of its own", () => {
+      expect(texts("SET PARSEONLY ON\nGO\nSELECT 1\nGO\nSET PARSEONLY OFF\nGO")).toEqual([
+        "SET PARSEONLY ON",
+        "SELECT 1",
+        "SET PARSEONLY OFF",
+      ]);
+    });
+  });
 });

--- a/src/utils/sql-parser.ts
+++ b/src/utils/sql-parser.ts
@@ -258,3 +258,78 @@ export function splitSQLStatements(sql: string, dialect?: ConnectorType): string
 
   return statements;
 }
+
+/** One T-SQL batch, as cut from a script by the `GO` separator. */
+export interface SQLServerBatch {
+  /** Batch text, with the terminating `GO` line removed. */
+  sql: string;
+  /** Repeat count from `GO <n>`; 1 when the separator carried no count. */
+  count: number;
+}
+
+/**
+ * A line separates batches when it holds nothing but `GO`, an optional repeat
+ * count, and an optional trailing line comment. `GOTO label` therefore stays a
+ * statement, and so does `GO 0`, which SSMS rejects rather than running zero
+ * times — letting it through as a separator would silently drop a batch.
+ */
+const GO_SEPARATOR_LINE = /^[^\S\n]*go(?:[^\S\n]+([1-9]\d*))?[^\S\n]*(?:--[^\n]*)?$/i;
+
+/**
+ * Split T-SQL on the `GO` batch separator the way SSMS and sqlcmd do.
+ *
+ * `GO` is a client directive, not T-SQL — the server never sees it. A caller
+ * that needs CREATE PROCEDURE (which must be alone in its batch), or a
+ * parse-time SET such as PARSEONLY to apply to statements rather than to
+ * itself, has to cut the script here and send each batch separately.
+ *
+ * Only a `GO` alone on its own line separates, so `GOTO`, `SELECT 'GO'` and a
+ * `GO` inside a comment are left alone. Returns one batch for a script with no
+ * separator at all, which lets the caller keep using its single-batch path.
+ */
+export function splitSQLServerBatches(sql: string): SQLServerBatch[] {
+  const scanToken = getScanner("sqlserver");
+  const batches: SQLServerBatch[] = [];
+  let batchStart = 0;
+  let lineStart = 0;
+  let i = 0;
+
+  const separatorCount = (lineEnd: number): number | null => {
+    const match = GO_SEPARATOR_LINE.exec(sql.substring(lineStart, lineEnd));
+    if (!match) { return null; }
+    return match[1] ? Number(match[1]) : 1;
+  };
+
+  const pushBatch = (end: number, count: number) => {
+    const text = sql.substring(batchStart, end);
+    if (text.trim().length > 0) { batches.push({ sql: text, count }); }
+  };
+
+  while (i < sql.length) {
+    const token = scanToken(sql, i);
+
+    // Only a newline the scanner calls plain ends a line: newlines inside a
+    // block comment or a string literal belong to that token, so a `GO` sitting
+    // on its own line *within* them must not separate anything.
+    if (token.type === TokenType.Plain && sql[i] === "\n") {
+      const count = separatorCount(i);
+      if (count !== null) {
+        pushBatch(lineStart, count);
+        batchStart = i + 1;
+      }
+      lineStart = i + 1;
+    }
+
+    i = token.end;
+  }
+
+  // A trailing `GO` needs no newline after it to close the batch it follows.
+  const trailingCount = separatorCount(sql.length);
+  if (trailingCount !== null) {
+    pushBatch(lineStart, trailingCount);
+    batchStart = sql.length;
+  }
+
+  pushBatch(sql.length, 1);
+  return batches;
+}


### PR DESCRIPTION
`GO` is a client directive, not T-SQL — SSMS and sqlcmd split on it and send each batch separately, and the server never sees the word. DBHub passed it through unchanged, so SQL Server answered `Incorrect syntax near 'GO'`.

That blocked two things outright:

- **`CREATE PROCEDURE`**, which must be the only statement in its batch, so a migration script with several procedures could not be sent at all;
- **any session-scoped `SET`**, because `request.query` sends SQL as an `sp_executesql` RPC whose nested scope reverts SET options on exit.

## Why this matters beyond convenience: the PARSEONLY trap

The second failure has a sharp edge. The usual SSMS idiom for validating a script without running it is:

```sql
SET PARSEONLY ON
<script>
SET PARSEONLY OFF
```

Without `GO` that is one batch, and `PARSEONLY` applies at **parse** time. The parser reaches the closing `SET PARSEONLY OFF` and clears the flag before anything executes — so by the end of parsing the batch runs for real. A script the caller meant only to validate executes instead:

```
SET PARSEONLY ON; SELECT TOP 1 name FROM sys.objects; SET PARSEONLY OFF;
→ returns a row
```

Split across `GO`, each `SET` lands in its own batch and `PARSEONLY` applies to the statements rather than to itself. With DML in that script, the difference is not academic.

## How it works

A script carrying a separator goes through `request.batch` on a `ConnectionPool` pinned to a single connection, private to the call and closed at the end.

The private pool is the point, not an optimization. `request.batch` runs at nest level 0 and leaves SET options on the session, and the shared pool would hand that same session to the next caller — one stray `SET NOEXEC ON` would silently swallow every later query. A per-call pool means the session dies with it and takes any leaked state along. This mirrors what `explainQuery` and `explainAnalyzeQuery` already do for their session toggles.

The connect is only paid by scripts that actually carry a separator. A script without one — the overwhelming majority — keeps the existing single round trip, and a lone trailing `GO` is stripped and stays on that fast path.

## What the splitter will not do

`splitSQLServerBatches` walks the existing SQL Server tokenizer from `sql-parser.ts`, so `GO` separates only when it stands alone on its own line:

| Input | Behaviour |
| --- | --- |
| `GOTO done` | not a separator |
| `SELECT 'GO'` | not a separator (string literal) |
| `GO` inside `/* ... */` | not a separator (comment) |
| `SELECT 1 AS [GO]` | not a separator (bracket-quoted identifier) |
| `GO 3` | repeats the batch three times |
| `GO 0` | passed through — SSMS rejects it, and treating it as a separator would silently drop the batch |

## Deliberate refusals

**Read-only mode refuses `GO`** rather than half-enforcing it: the rollback guard cannot span batches, and DDL is exactly what such scripts carry.

**Parameters are refused alongside a separator**, but not because a batch cannot carry them — it can, node-mssql prepends the DECLARE/SET, which is how the EXPLAIN paths bind them since #361. What has no obvious answer is which batch of a multi-batch script they belong to: binding to every batch redeclares them per batch, binding to one needs the caller to say which. Refusing leaves that decision open rather than guessing wrong.

## Also in this change

`SQLResult.resultSets` surfaces every result set a statement produced, present only when there is more than one. `recordset` is just the first, so `SELECT 1; SELECT 2` silently dropped the second — the tool response gains `result_sets` alongside the unchanged `rows`.

## Testing

- 21 unit tests for the splitter covering the separator/non-separator table above, repeat counts, CRLF, and consecutive or leading separators
- 12 integration tests against a real SQL Server container: state carrying across `GO`, several `CREATE PROCEDURE` in one call, the PARSEONLY trap being gone, a syntax error still surfacing under PARSEONLY, no session state outliving the call, `GO <n>`, batch naming in errors, read-only refusal, and the single-batch fast path
- Falsified: with the batch routing disabled, 9 of the 12 integration tests fail, so they exercise the new path rather than passing vacuously
- Full suite green on top of this branch: 81/81 SQL Server integration tests (69 existing + 12 new), unit suite unchanged, and no new TypeScript errors

Builds on #361, which merged earlier today; this branch is rebased directly onto main.