### PR TITLE
fix: stop logging SQL statements and parameters on execution errors

### DIFF
--- a/src/connectors/__tests__/shared/integration-test-base.ts
+++ b/src/connectors/__tests__/shared/integration-test-base.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import type { Connector } from '../../interface.js';
 
 export interface DatabaseTestConfig {
@@ -320,6 +320,29 @@ export abstract class IntegrationTestBase<TContainer extends TestContainer> {
         const result = await this.connector.getTableSchema('nonexistent_table');
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBe(0);
+      });
+
+      it('should keep the failing statement and its parameters out of stderr', async () => {
+        // A failing statement carries whatever the caller put in it, and stderr
+        // is retained and read more widely than the database itself — on the
+        // stdio transport it is the MCP client that collects it. The error is
+        // re-thrown to the caller, so nothing needs to be logged here.
+        // Parameters are passed because the connectors only reached their
+        // logging on the parameterized path.
+        const marker = 'dbhub_stderr_marker_value';
+        const stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        try {
+          await expect(
+            this.connector.executeSQL('SELECT * FROM nonexistent_table', {}, [marker])
+          ).rejects.toThrow();
+
+          const logged = stderr.mock.calls.map((args) => args.join(' ')).join('\n');
+          expect(logged).not.toContain(marker);
+          expect(logged).not.toContain('nonexistent_table');
+        } finally {
+          stderr.mockRestore();
+        }
       });
     });
   }

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -659,14 +659,7 @@ export class MariaDBConnector implements Connector {
           // Pass parameters if provided
           let results: any;
           if (parameters && parameters.length > 0) {
-            try {
-              results = await conn.query(processedSQL, parameters);
-            } catch (error) {
-              console.error(`[MariaDB executeSQL] ERROR: ${(error as Error).message}`);
-              console.error(`[MariaDB executeSQL] SQL: ${processedSQL}`);
-              console.error(`[MariaDB executeSQL] Parameters: ${JSON.stringify(parameters)}`);
-              throw error;
-            }
+            results = await conn.query(processedSQL, parameters);
           } else {
             results = await conn.query(processedSQL);
           }
@@ -678,9 +671,6 @@ export class MariaDBConnector implements Connector {
           return { rows, rowCount };
         }
       );
-    } catch (error) {
-      console.error("Error executing query:", error);
-      throw error;
     } finally {
       // Always release the connection back to the pool
       conn.release();

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -677,14 +677,7 @@ export class MySQLConnector implements Connector {
           // Pass parameters if provided, with optional query timeout
           let results: any;
           if (parameters && parameters.length > 0) {
-            try {
-              results = await conn.query({ sql: processedSQL, timeout: this.queryTimeoutMs }, parameters);
-            } catch (error) {
-              console.error(`[MySQL executeSQL] ERROR: ${(error as Error).message}`);
-              console.error(`[MySQL executeSQL] SQL: ${processedSQL}`);
-              console.error(`[MySQL executeSQL] Parameters: ${JSON.stringify(parameters)}`);
-              throw error;
-            }
+            results = await conn.query({ sql: processedSQL, timeout: this.queryTimeoutMs }, parameters);
           } else {
             results = await conn.query({ sql: processedSQL, timeout: this.queryTimeoutMs });
           }
@@ -700,9 +693,6 @@ export class MySQLConnector implements Connector {
           return { rows, rowCount };
         }
       );
-    } catch (error) {
-      console.error("Error executing query:", error);
-      throw error;
     } finally {
       // Always release the connection back to the pool
       conn.release();

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -636,11 +636,6 @@ export class PostgresConnector implements Connector {
             } catch {
               // ignore; the original error is more useful
             }
-            console.error(`[PostgreSQL executeSQL] ERROR: ${(error as Error).message}`);
-            console.error(`[PostgreSQL executeSQL] SQL: ${processedStatement}`);
-            if (parameters && parameters.length > 0) {
-              console.error(`[PostgreSQL executeSQL] Parameters: ${JSON.stringify(parameters)}`);
-            }
             throw error;
           }
         }
@@ -648,14 +643,7 @@ export class PostgresConnector implements Connector {
         // Use parameters if provided
         let result;
         if (parameters && parameters.length > 0) {
-          try {
-            result = await client.query(processedStatement, parameters);
-          } catch (error) {
-            console.error(`[PostgreSQL executeSQL] ERROR: ${(error as Error).message}`);
-            console.error(`[PostgreSQL executeSQL] SQL: ${processedStatement}`);
-            console.error(`[PostgreSQL executeSQL] Parameters: ${JSON.stringify(parameters)}`);
-            throw error;
-          }
+          result = await client.query(processedStatement, parameters);
         } else {
           result = await client.query(processedStatement);
         }

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -496,15 +496,8 @@ export class SQLiteConnector implements Connector {
         if (isReadStatement) {
           // Pass parameters if provided
           if (parameters && parameters.length > 0) {
-            try {
-              const rows = this.prepare(processedStatement).all(...parameters);
-              return { rows, rowCount: rows.length };
-            } catch (error) {
-              console.error(`[SQLite executeSQL] ERROR: ${(error as Error).message}`);
-              console.error(`[SQLite executeSQL] SQL: ${processedStatement}`);
-              console.error(`[SQLite executeSQL] Parameters: ${JSON.stringify(parameters)}`);
-              throw error;
-            }
+            const rows = this.prepare(processedStatement).all(...parameters);
+            return { rows, rowCount: rows.length };
           } else {
             const rows = this.prepare(processedStatement).all();
             return { rows, rowCount: rows.length };
@@ -513,14 +506,7 @@ export class SQLiteConnector implements Connector {
           // Use run() for statements that don't return data
           let result;
           if (parameters && parameters.length > 0) {
-            try {
-              result = this.prepare(processedStatement).run(...parameters);
-            } catch (error) {
-              console.error(`[SQLite executeSQL] ERROR: ${(error as Error).message}`);
-              console.error(`[SQLite executeSQL] SQL: ${processedStatement}`);
-              console.error(`[SQLite executeSQL] Parameters: ${JSON.stringify(parameters)}`);
-              throw error;
-            }
+            result = this.prepare(processedStatement).run(...parameters);
           } else {
             result = this.prepare(processedStatement).run();
           }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -695,17 +695,7 @@ export class SQLServerConnector implements Connector {
 
       SQLServerConnector.bindParameters(request, parameters);
 
-      let result;
-      try {
-        result = await request.query(processedSQL);
-      } catch (error) {
-        if (parameters && parameters.length > 0) {
-          console.error(`[SQL Server executeSQL] ERROR: ${(error as Error).message}`);
-          console.error(`[SQL Server executeSQL] SQL: ${processedSQL}`);
-          console.error(`[SQL Server executeSQL] Parameters: ${JSON.stringify(parameters)}`);
-        }
-        throw error;
-      }
+      const result = await request.query(processedSQL);
 
       return {
         rows: result.recordset || [],
@@ -842,11 +832,6 @@ export class SQLServerConnector implements Connector {
       result = await request.query(processedSQL);
     } catch (error) {
       queryFailed = true;
-      console.error(`[SQL Server executeReadOnly] ERROR: ${(error as Error).message}`);
-      console.error(`[SQL Server executeReadOnly] SQL: ${processedSQL}`);
-      if (parameters && parameters.length > 0) {
-        console.error(`[SQL Server executeReadOnly] Parameters: ${JSON.stringify(parameters)}`);
-      }
       throw error;
     } finally {
       try {


### PR DESCRIPTION
Fixes #373.

Every connector echoed the failing statement to stderr before re-throwing, and the parameterized paths also echoed `JSON.stringify(parameters)`. Whatever the caller put in the statement — tokens, personal data, business values — was written to logs that are typically retained longer and read more widely than the database itself.

One exposure path worth naming beyond the report: over the stdio transport the server's stderr is consumed by the MCP client, not by the server's own log pipeline. So a stdio deployment writes the statement text into the client's logs, which is usually a different retention and access boundary than the operator was reasoning about.

## Removal rather than redaction

Every one of these sites re-throws immediately after logging, and the message reaches the caller through `executeSQL`'s outer wrapper. The log added exactly one thing the caller did not already have: the statement text — which the caller is the one that sent.

So there is no diagnostic signal to preserve. A fingerprinting or redaction scheme would have to be designed, then kept correct in eight places, to protect data that does not need to be there at all.

## Sites removed

Statement and parameter echoes, eight sites:

| File | Path |
| --- | --- |
| `postgres/index.ts` | multi-statement (**unconditional**) and parameterized |
| `mysql/index.ts` | parameterized |
| `mariadb/index.ts` | parameterized |
| `sqlite/index.ts` | `.all()` and `.run()` |
| `sqlserver/index.ts` | `executeSQL` parameterized, and `executeReadOnly` (**unconditional**) |

The two unconditional ones are worth calling out. PostgreSQL's multi-statement path is what the report reproduces. SQL Server's `executeReadOnly` is reached exactly when a tool is configured `readonly = true` — so the setting chosen for safety was the one logging every failing statement regardless of parameters.

MariaDB has its own connector and the same pattern; it is not mentioned in the issue.

Two more sites, found by the test rather than by reading:

| File | Line | Statement |
| --- | --- | --- |
| `mysql/index.ts` | 697 | `console.error("Error executing query:", error)` |
| `mariadb/index.ts` | 675 | same |

These log the error rather than the statement, so the leak is narrower — but the database puts data in its messages. A duplicate-key error quotes the offending value, and the test caught this one with `Table 'testdb.nonexistent_table' doesn't exist`. Same shape as the rest: log, then re-throw the very error that was logged. Removing the log left `catch (error) { throw error; }` wrapping a `finally`, so the catch went too and the `try`/`finally` stayed.

Where a `catch` block existed only to log and re-throw, it is removed with the logging. `executeReadOnly` keeps its `catch` because `queryFailed` is set there and the rollback handling below depends on it.

## Testing

Adds one test to the shared integration base, so it runs for all five connectors: a failing parameterized statement must leave neither the parameter value nor the table name in stderr. Parameters are passed because the connectors only reached their logging on the parameterized path.

Verified to fail against the previous code — restoring the SQL Server logging makes it fail with `expected '[SQL Server executeSQL] ERROR: …' not to contain 'dbhub_stderr_marker_value'`, i.e. the assertion catches the exact leak.

The test is also what surfaced the two `Error executing query:` sites, which reading the code had not.

Run locally against real containers for all five connectors: 244 passed, 1 failed. The failure is `SQLite > SDK-Level Readonly Mode Tests > should open file-based database in readonly mode`, which fails the same way on an unmodified checkout of `main` — unrelated to this change. No new TypeScript errors.