### PR TITLE
fix: block SELECT-invocable escape-hatch functions in readonly mode (#377)

### DIFF
--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -454,4 +454,40 @@ describe("isReadOnlySQL", () => {
       expect(areAllStatementsReadOnly("SELECT 1--1;DROP TABLE victim", "postgres")).toBe(true);
     });
   });
+
+  describe("escape-hatch function bypass prevention (issue #377)", () => {
+    // Functions callable from a plain SELECT that read the server filesystem or
+    // take server-wide locks — a read-only transaction does not contain them.
+    it.each([
+      ["mysql", "SELECT LOAD_FILE('/etc/passwd')"],
+      ["mysql", "SELECT get_lock('x', 10)"],
+      ["mysql", "SELECT RELEASE_LOCK('x')"],
+      ["mysql", "SELECT RELEASE_ALL_LOCKS()"],
+      ["mariadb", "SELECT LOAD_FILE('/etc/passwd')"],
+      ["mariadb", "SELECT get_lock('x', 10)"],
+      ["postgres", "SELECT pg_read_file('/etc/passwd')"],
+      ["postgres", "SELECT pg_read_binary_file('server.key')"],
+      ["postgres", "SELECT pg_ls_dir('/var/lib/postgresql')"],
+    ] as const)("rejects %s escape-hatch call: %s", (dialect, sql) => {
+      expect(isReadOnlySQL(sql, dialect)).toBe(false);
+    });
+
+    it("rejects an escape-hatch call buried in a subquery / FROM clause", () => {
+      expect(isReadOnlySQL("SELECT * FROM (SELECT LOAD_FILE('/etc/passwd') AS x) t", "mysql")).toBe(false);
+      expect(isReadOnlySQL("WITH t AS (SELECT pg_read_file('x')) SELECT * FROM t", "postgres")).toBe(false);
+    });
+
+    it("still allows a column or alias named like an escape-hatch function (call position only)", () => {
+      expect(isReadOnlySQL("SELECT load_file FROM documents", "mysql")).toBe(true);
+      expect(isReadOnlySQL("SELECT count(*) AS get_lock FROM t", "mysql")).toBe(true);
+      expect(isReadOnlySQL("SELECT pg_read_file FROM audit", "postgres")).toBe(true);
+    });
+
+    it("does not apply another dialect's escape-hatch list", () => {
+      // pg_read_file is a Postgres function; a mysql column of that name is fine.
+      expect(isReadOnlySQL("SELECT pg_read_file FROM t", "mysql")).toBe(true);
+      // load_file is MySQL's; a postgres column of that name is fine.
+      expect(isReadOnlySQL("SELECT load_file FROM t", "postgres")).toBe(true);
+    });
+  });
 });

--- a/src/utils/__tests__/allowed-keywords.test.ts
+++ b/src/utils/__tests__/allowed-keywords.test.ts
@@ -468,6 +468,9 @@ describe("isReadOnlySQL", () => {
       ["postgres", "SELECT pg_read_file('/etc/passwd')"],
       ["postgres", "SELECT pg_read_binary_file('server.key')"],
       ["postgres", "SELECT pg_ls_dir('/var/lib/postgresql')"],
+      // SQL Server pass-through sources share the same call-position guard.
+      ["sqlserver", "SELECT * FROM OPENQUERY(lnk, 'SELECT 1')"],
+      ["sqlserver", "SELECT * FROM OPENROWSET('SQLNCLI', 'x', 'SELECT 1')"],
     ] as const)("rejects %s escape-hatch call: %s", (dialect, sql) => {
       expect(isReadOnlySQL(sql, dialect)).toBe(false);
     });

--- a/src/utils/__tests__/sql-access-policy.test.ts
+++ b/src/utils/__tests__/sql-access-policy.test.ts
@@ -42,6 +42,15 @@ describe("classifyStatement", () => {
     expect(classifyStatement("SELECT * FROM OPENQUERY(lnk, 'SELECT 1')", "sqlserver")).toBe("admin");
   });
 
+  it("classifies SELECT-invocable escape-hatch functions as admin (issue #377)", () => {
+    // File/lock functions that a read-only transaction does not contain.
+    expect(classifyStatement("SELECT LOAD_FILE('/etc/passwd')", "mysql")).toBe("admin");
+    expect(classifyStatement("SELECT get_lock('x', 10)", "mariadb")).toBe("admin");
+    expect(classifyStatement("SELECT pg_read_file('/etc/passwd')", "postgres")).toBe("admin");
+    // Call position only: a column of the same name stays read.
+    expect(classifyStatement("SELECT load_file FROM t", "mysql")).toBe("read");
+  });
+
   it("keeps a column named openquery read-only on SQL Server", () => {
     expect(classifyStatement("SELECT openquery FROM t", "sqlserver")).toBe("read");
   });

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -110,6 +110,47 @@ export const sqlServerPassThroughPattern = new RegExp(
 );
 
 /**
+ * Functions callable from a plain SELECT that reach beyond ordinary data
+ * access and are NOT contained by a read-only transaction:
+ * - MySQL/MariaDB: LOAD_FILE reads server-side files (gated by the FILE
+ *   privilege, not transaction mode); GET_LOCK / RELEASE_LOCK /
+ *   RELEASE_ALL_LOCKS take or release server-wide advisory locks (a session
+ *   side effect a read-only transaction does not prevent).
+ * - PostgreSQL: pg_read_file / pg_read_binary_file / pg_ls_dir read the
+ *   server filesystem (gated by the pg_read_server_files role;
+ *   default_transaction_read_only does not apply).
+ *
+ * Matched in call position only (trailing `(`), so a column or table named
+ * `load_file` still classifies as read-only. Like the SQL Server pass-through
+ * patterns above, this is a best-effort guardrail: least-privilege database
+ * accounts remain the security boundary. See issue #377.
+ */
+export const escapeHatchFunctionKeywords: Partial<Record<ConnectorType, readonly string[]>> = {
+  mysql: ["load_file", "get_lock", "release_lock", "release_all_locks"],
+  mariadb: ["load_file", "get_lock", "release_lock", "release_all_locks"],
+  postgres: ["pg_read_file", "pg_read_binary_file", "pg_ls_dir"],
+};
+
+const escapeHatchFunctionPatterns: Partial<Record<ConnectorType, RegExp>> = Object.fromEntries(
+  Object.entries(escapeHatchFunctionKeywords).map(([type, keywords]) => [
+    type,
+    new RegExp(`\\b(?:${keywords.join("|")})\\s*\\(`, "i"),
+  ])
+);
+
+/**
+ * Whether (comment/string-stripped) SQL invokes one of the dialect's
+ * escape-hatch functions in call position.
+ */
+export function hasEscapeHatchFunction(
+  strippedSQL: string,
+  connectorType: ConnectorType | string
+): boolean {
+  const pattern = escapeHatchFunctionPatterns[connectorType as ConnectorType];
+  return pattern !== undefined && pattern.test(strippedSQL);
+}
+
+/**
  * Extended pattern for SQL Server: base mutating keywords plus the dynamic SQL
  * primitives above.
  */
@@ -183,6 +224,13 @@ function checkReadOnly(cleanedSQL: string, connectorType: ConnectorType | string
   // are rejected wherever they appear — not just under WITH, since the common
   // form is a plain `SELECT ... FROM OPENQUERY(...)`.
   if (connectorType === "sqlserver" && sqlServerPassThroughPattern.test(cleanedSQL)) {
+    return false;
+  }
+
+  // Same class of escape for the other dialects: functions callable from a
+  // plain SELECT that read the server filesystem or take server-wide locks,
+  // which a read-only transaction does not contain (issue #377).
+  if (hasEscapeHatchFunction(cleanedSQL, connectorType)) {
     return false;
   }
 

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -111,24 +111,34 @@ export const sqlServerPassThroughPattern = new RegExp(
 
 /**
  * Functions callable from a plain SELECT that reach beyond ordinary data
- * access and are NOT contained by a read-only transaction:
- * - MySQL/MariaDB: LOAD_FILE reads server-side files (gated by the FILE
- *   privilege, not transaction mode); GET_LOCK / RELEASE_LOCK /
- *   RELEASE_ALL_LOCKS take or release server-wide advisory locks (a session
- *   side effect a read-only transaction does not prevent).
+ * access and are NOT contained by a read-only transaction, because they are
+ * gated by privilege rather than transaction mode. Matched in call position
+ * (trailing `(`) on the comment/string-stripped SQL, so a column or table
+ * named `load_file` still classifies as read-only. Per dialect:
+ * - MySQL/MariaDB: LOAD_FILE reads server-side files (FILE privilege);
+ *   GET_LOCK / RELEASE_LOCK / RELEASE_ALL_LOCKS take or release server-wide
+ *   advisory locks (a session side effect).
  * - PostgreSQL: pg_read_file / pg_read_binary_file / pg_ls_dir read the
- *   server filesystem (gated by the pg_read_server_files role;
- *   default_transaction_read_only does not apply).
+ *   server filesystem (pg_read_server_files role; default_transaction_read_only
+ *   does not apply).
+ * - SQL Server: OPENQUERY / OPENROWSET / OPENDATASOURCE run on a
+ *   remote/ad-hoc source outside the local read-only transaction
+ *   (sqlServerPassThroughKeywords, reused here as the single source of truth).
  *
- * Matched in call position only (trailing `(`), so a column or table named
- * `load_file` still classifies as read-only. Like the SQL Server pass-through
- * patterns above, this is a best-effort guardrail: least-privilege database
+ * This is a best-effort guardrail: name matching is bypassable (quoted
+ * identifiers, executable version comments), so least-privilege database
  * accounts remain the security boundary. See issue #377.
+ *
+ * NOTE: SQL Server's dynamic-SQL primitives (EXEC / sp_executesql /
+ * xp_cmdshell) are NOT here — they are statement-leading forms, not
+ * call-position functions, and already fail the first-keyword allow-list in
+ * isReadOnlySQL. They classify as admin via sqlServerDynamicSqlPattern.
  */
 export const escapeHatchFunctionKeywords: Partial<Record<ConnectorType, readonly string[]>> = {
   mysql: ["load_file", "get_lock", "release_lock", "release_all_locks"],
   mariadb: ["load_file", "get_lock", "release_lock", "release_all_locks"],
   postgres: ["pg_read_file", "pg_read_binary_file", "pg_ls_dir"],
+  sqlserver: sqlServerPassThroughKeywords,
 };
 
 const escapeHatchFunctionPatterns: Partial<Record<ConnectorType, RegExp>> = Object.fromEntries(
@@ -220,16 +230,11 @@ function checkReadOnly(cleanedSQL: string, connectorType: ConnectorType | string
     return false;
   }
 
-  // SQL Server pass-through data sources escape both read-only layers, so they
-  // are rejected wherever they appear — not just under WITH, since the common
-  // form is a plain `SELECT ... FROM OPENQUERY(...)`.
-  if (connectorType === "sqlserver" && sqlServerPassThroughPattern.test(cleanedSQL)) {
-    return false;
-  }
-
-  // Same class of escape for the other dialects: functions callable from a
-  // plain SELECT that read the server filesystem or take server-wide locks,
-  // which a read-only transaction does not contain (issue #377).
+  // Escape-hatch functions callable from a plain SELECT that a read-only
+  // transaction does not contain — SQL Server pass-through sources
+  // (OPENQUERY & co.), MySQL/MariaDB file/lock functions, PostgreSQL
+  // filesystem reads. Rejected wherever they appear, since the common form is
+  // e.g. `SELECT ... FROM OPENQUERY(...)`. See escapeHatchFunctionKeywords.
   if (hasEscapeHatchFunction(cleanedSQL, connectorType)) {
     return false;
   }

--- a/src/utils/sql-access-policy.ts
+++ b/src/utils/sql-access-policy.ts
@@ -20,7 +20,6 @@ import {
   isReadOnlySQL,
   hasEscapeHatchFunction,
   sqlServerDynamicSqlPattern,
-  sqlServerPassThroughPattern,
 } from "./allowed-keywords.js";
 import { splitSQLStatements, stripCommentsAndStrings } from "./sql-parser.js";
 
@@ -58,13 +57,12 @@ const grantRevokePattern = /\b(?:grant|revoke)\b/i;
 
 function isAdminStatement(stripped: string, connectorType: ConnectorType): boolean {
   if (grantRevokePattern.test(stripped)) return true;
-  // Dialect escape hatches: T-SQL dynamic SQL / pass-through sources, and the
-  // SELECT-invocable file/lock functions of the other dialects.
+  // Call-position escape-hatch functions (SQL Server OPENQUERY & co., the
+  // MySQL/MariaDB file/lock functions, PostgreSQL filesystem reads).
   if (hasEscapeHatchFunction(stripped, connectorType)) return true;
-  return (
-    connectorType === "sqlserver" &&
-    (sqlServerDynamicSqlPattern.test(stripped) || sqlServerPassThroughPattern.test(stripped))
-  );
+  // SQL Server dynamic-SQL primitives are statement-leading forms (not
+  // call-position), so they need their own whole-word pattern.
+  return connectorType === "sqlserver" && sqlServerDynamicSqlPattern.test(stripped);
 }
 
 /**

--- a/src/utils/sql-access-policy.ts
+++ b/src/utils/sql-access-policy.ts
@@ -18,6 +18,7 @@
 import { ConnectorType } from "../connectors/interface.js";
 import {
   isReadOnlySQL,
+  hasEscapeHatchFunction,
   sqlServerDynamicSqlPattern,
   sqlServerPassThroughPattern,
 } from "./allowed-keywords.js";
@@ -28,8 +29,10 @@ import { splitSQLStatements, stripCommentsAndStrings } from "./sql-parser.js";
  * - read: allowed by the read-only classifier (select/with/explain/show/...)
  * - dml: data modification (insert/update/delete/merge, REPLACE INTO)
  * - ddl: schema modification (create/alter/drop/truncate/rename)
- * - admin: privilege changes and dynamic-SQL escape hatches
- *   (grant/revoke, T-SQL EXEC/sp_executesql/xp_cmdshell, OPENQUERY & co.)
+ * - admin: privilege changes plus privilege-gated and server-side-effect
+ *   escape hatches (grant/revoke; T-SQL EXEC/sp_executesql/xp_cmdshell and
+ *   OPENQUERY & co.; MySQL/MariaDB LOAD_FILE and the GET_LOCK family;
+ *   PostgreSQL pg_read_file & co.)
  * - unknown: not classifiable (vacuum, set, call, ...) — ranked above the
  *   named classes because an unclassifiable statement must be treated at
  *   least as cautiously as any known one
@@ -53,9 +56,11 @@ const ddlPattern = /\b(?:create|alter|drop|truncate|rename)\b/i;
 const dmlPattern = /\b(?:insert|update|delete|merge|replace\s+(?:(?:low_priority|delayed)\s+)?into)\b/i;
 const grantRevokePattern = /\b(?:grant|revoke)\b/i;
 
-/** The dynamic-SQL / pass-through escape hatches are T-SQL-only. */
 function isAdminStatement(stripped: string, connectorType: ConnectorType): boolean {
   if (grantRevokePattern.test(stripped)) return true;
+  // Dialect escape hatches: T-SQL dynamic SQL / pass-through sources, and the
+  // SELECT-invocable file/lock functions of the other dialects.
+  if (hasEscapeHatchFunction(stripped, connectorType)) return true;
   return (
     connectorType === "sqlserver" &&
     (sqlServerDynamicSqlPattern.test(stripped) || sqlServerPassThroughPattern.test(stripped))


### PR DESCRIPTION
Closes #377. A focused alternative to the guardrail machinery in #376.

## Problem

`readonly = true` accepts any statement that passes the read-only classifier and relies on a read-only transaction as an engine-level backstop. But some functions are callable from a plain `SELECT` while reaching beyond ordinary data access, and a read-only transaction does **not** contain them because they are gated by *privilege*, not transaction mode:

- **MySQL / MariaDB** — `LOAD_FILE()` reads server-side files (FILE privilege); `GET_LOCK` / `RELEASE_LOCK` / `RELEASE_ALL_LOCKS` take/release server-wide advisory locks (a session side effect).
- **PostgreSQL** — `pg_read_file` / `pg_read_binary_file` / `pg_ls_dir` read the server filesystem (`pg_read_server_files` role); `default_transaction_read_only` does not apply. (This is the case originally raised in #315.)

These are valid SELECTs with no mutating keyword, so `isReadOnlySQL` returns `true` and `readonly = true` lets them through.

## Approach

DBHub already has this exact guard for SQL Server: `OPENQUERY(` / `OPENROWSET(` / `OPENDATASOURCE(` are rejected in call position even inside a plain SELECT. This change applies the **same treatment** to the other dialects, and routes the result through the existing statement-class pipeline (`src/utils/sql-access-policy.ts`):

- New per-dialect escape-hatch function list + `hasEscapeHatchFunction()` in `allowed-keywords.ts`, matched in **call position only** (trailing `(`), on comment/string-stripped SQL — so a column or alias named `load_file` still classifies as read-only.
- `isReadOnlySQL` rejects a statement invoking one; `classifyStatement` puts it in the existing **`admin`** class.

No new statement class, no new config key, no new call site. `readonly = true` denies these, `readonly = false` allows them, and tool annotations stay accurate — all derived from the one policy.

### Deliberately scoped out (see #377 discussion)

- `SLEEP` / `BENCHMARK` — resource consumption is `query_timeout`'s job; any cross join DoSes equally, so blocking two names is theater.
- `SYS_EXEC` / `SYS_EVAL` — nonstandard UDF plugins; if installed *and* granted to the MCP account, that's an operator decision, and the space of dangerous UDFs is unbounded.
- Flavor detection / `sql_mode` inspection — these functions exist across the mysql/mariadb family; a false rejection on an exotic flavor is a cheap, clear error, not worth a probing subsystem.

## Security posture

Best-effort guardrail. Name matching is bypassable (quoted identifiers, executable version comments) — the same acknowledged limitation the SQL Server pass-through pattern already carries. **Least-privilege database accounts remain the documented security boundary**, unchanged.

## Tests

- `allowed-keywords.test.ts`: rejection per dialect/function, subquery/CTE placement, call-position-only (column named `load_file` allowed), and cross-dialect isolation (a Postgres function name is a fine column in MySQL).
- `sql-access-policy.test.ts`: the same statements classify as `admin`.
- Full suite green (1211 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)