### PR TITLE
feat: add opt-in explain_sql tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ src/
 │   └── sqlite/          # SQLite connector
 ├── tools/               # MCP tool handlers
 │   ├── execute-sql.ts   # SQL execution handler
-│   └── search-objects.ts  # Unified search/list with progressive disclosure
+│   ├── search-objects.ts  # Unified search/list with progressive disclosure
+│   └── explain-sql.ts   # Opt-in EXPLAIN plan tool (never executes the target statement)
 ├── utils/               # Shared utilities
 │   ├── dsn-obfuscator.ts# DSN security
 │   ├── response-formatter.ts # Output formatting

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 DBHub is a zero-dependency, token efficient MCP server implementing the Model Context Protocol (MCP) server interface. This lightweight gateway allows MCP-compatible clients to connect to and explore different databases:
 
-- **Local Development First**: Zero dependency, token efficient with just two MCP tools to maximize context window
+- **Local Development First**: Zero dependency, token efficient with a minimal set of MCP tools to maximize context window
 - **Multi-Database**: PostgreSQL, MySQL, MariaDB, SQL Server, and SQLite through a single interface
 - **Multi-Connection**: Connect to multiple databases simultaneously with TOML configuration
 - **Guardrails**: Read-only mode, row limiting, and query timeout to prevent runaway operations

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ DBHub implements MCP tools for database operations:
 
 - **[execute_sql](https://dbhub.ai/tools/execute-sql)**: Execute SQL queries with transaction support and safety controls
 - **[search_objects](https://dbhub.ai/tools/search-objects)**: Search and explore database schemas, tables, columns, indexes, and procedures with progressive disclosure
+- **[explain_sql](https://dbhub.ai/tools/explain-sql)** (opt-in): Show a query's execution plan without running it
 - **[Custom Tools](https://dbhub.ai/tools/custom-tools)**: Define reusable, parameterized SQL operations in your `dbhub.toml` configuration file
 
 ## Workbench

--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -233,6 +233,15 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # name = "search_objects"
 # source = "local_pg"
 
+# 'explain_sql' is opt-in only (not part of the default pair above) - add it
+# explicitly to expose an EXPLAIN tool for a source. It only ever shows the
+# query plan and never executes the statement, so it's safe to enable
+# regardless of the source's own readonly setting; it takes no readonly/
+# max_rows options of its own.
+# [[tools]]
+# name = "explain_sql"
+# source = "local_pg"
+
 # ============================================================================
 # CUSTOM TOOLS (Optional)
 # ============================================================================
@@ -366,6 +375,7 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # Tool Options:
 #   readonly = true    # Restrict to SELECT, SHOW, DESCRIBE, EXPLAIN (works for execute_sql and custom tools)
 #   max_rows = 1000    # Limit result set size (works for execute_sql and custom tools)
+#   explain_sql        # Opt-in tool (name = "explain_sql"); no readonly/max_rows options - always safe
 #
 # Parameter Placeholders by Database:
 #   PostgreSQL:     $1, $2, $3

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -530,7 +530,7 @@ Tools define MCP tools (like `execute_sql`) with specific execution settings. To
 ### name
 
 <ParamField path="name" type="string" required>
-  **Required.** Tool name. Currently, the primary tool is `execute_sql`.
+  **Required.** Tool name. Built-in tools are `execute_sql`, `search_objects`, and the opt-in `explain_sql` (see [explain_sql](/tools/explain-sql)); any other name defines a [custom tool](/tools/custom-tools).
 
   ```toml
   [[tools]]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,6 +26,7 @@
               "tools/overview",
               "tools/execute-sql",
               "tools/search-objects",
+              "tools/explain-sql",
               "tools/custom-tools"
             ]
           },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -41,7 +41,7 @@ PostgreSQL, MySQL, SQL Server, MariaDB, and SQLite.
 
 DBHub brings powerful database capabilities to AI coding assistants:
 
-- **Local Development First**: Zero dependency, token efficient with just two MCP tools to maximize context window
+- **Local Development First**: Zero dependency, token efficient with a minimal set of MCP tools to maximize context window
 - **Multi-Database**: PostgreSQL, MySQL, MariaDB, SQL Server, and SQLite through a single interface
 - **Multi-Connection**: Connect to multiple databases simultaneously with TOML configuration
 - **Guardrails**: Read-only mode, row limiting, and query timeout to prevent runaway operations
@@ -51,9 +51,10 @@ DBHub brings powerful database capabilities to AI coding assistants:
 
 ### MCP Tools
 
-DBHub provides AI assistants with direct database access through three core tools:
+DBHub provides AI assistants with direct database access through these tools:
 - **[execute_sql](/tools/execute-sql)**: Run queries with transaction support and safety controls
 - **[search_objects](/tools/search-objects)**: Explore schemas, tables, columns, indexes, and procedures
+- **[explain_sql](/tools/explain-sql)** (opt-in): Show a query's execution plan without running it
 - **[Custom Tools](/tools/custom-tools)**: Define reusable, parameterized SQL operations
 
 ### Workbench
@@ -84,6 +85,7 @@ flowchart TB
         subgraph Tools["MCP Tools"]
             ES["execute_sql"]
             SO["search_objects"]
+            EX["explain_sql (opt-in)"]
             CT["custom tools"]
         end
     end

--- a/docs/tools/custom-tools.mdx
+++ b/docs/tools/custom-tools.mdx
@@ -275,7 +275,7 @@ Tools are validated when the server starts:
 
 - All required fields must be present
 - The specified source must exist
-- Tool names must be unique and cannot conflict with built-in tools (`execute_sql`, `search_objects`)
+- Tool names must be unique and cannot conflict with built-in tools (`execute_sql`, `search_objects`, `explain_sql`)
 - Parameter count must match SQL placeholders
 - Parameter types must be valid
 
@@ -327,3 +327,4 @@ Custom tools return the same response format as `execute_sql`:
 - [TOML Configuration](/config/toml) - Complete configuration reference
 - [execute_sql](/tools/execute-sql) - Direct SQL execution tool
 - [search_objects](/tools/search-objects) - Database schema exploration tool
+- [explain_sql](/tools/explain-sql) - Query execution plan tool (opt-in)

--- a/docs/tools/execute-sql.mdx
+++ b/docs/tools/execute-sql.mdx
@@ -211,3 +211,9 @@ source = "production"
 <Note>
 If no `[[tools]]` entries are defined for a source, both `execute_sql` and `search_objects` are enabled by default for backward compatibility.
 </Note>
+
+## See Also
+
+- [search_objects](/tools/search-objects) - Database schema exploration tool
+- [explain_sql](/tools/explain-sql) - Query execution plan tool (opt-in)
+- [Custom Tools](/tools/custom-tools) - Reusable, parameterized SQL operations

--- a/docs/tools/explain-sql.mdx
+++ b/docs/tools/explain-sql.mdx
@@ -1,0 +1,60 @@
+---
+title: "explain_sql"
+---
+
+Show the execution plan for a SQL statement without running it.
+
+## Features
+
+- **Never executes**: Only ever compiles/plans the statement — safe to enable regardless of the source's `readonly` setting
+- **Per-dialect output**: Uses `EXPLAIN` on PostgreSQL, MySQL, MariaDB, and SQL Server, and `EXPLAIN QUERY PLAN` on SQLite (bare `EXPLAIN` on SQLite returns low-level bytecode, not a readable plan)
+- **Opt-in only**: Not part of the default tool pair — must be explicitly enabled per source
+
+<Note>
+`explain_sql` is **opt-in**. Unlike `execute_sql` and `search_objects`, it is not enabled automatically when a source has no `[[tools]]` entries — add it explicitly (see [Enabling explain_sql](#enabling-explain-sql) below).
+</Note>
+
+## Usage
+
+Pass a single SQL statement to explain. The tool adds the `EXPLAIN` prefix itself — do not include it in the input.
+
+<CodeGroup>
+```text Input
+SELECT * FROM users WHERE status = 'active'
+```
+
+```text Sent to the database
+EXPLAIN SELECT * FROM users WHERE status = 'active'
+```
+</CodeGroup>
+
+Only a single statement is accepted (no `;`-separated batches), and the input must not itself begin with `EXPLAIN` or `ANALYZE` — both are rejected so the tool's own `EXPLAIN` prefix can never combine with a smuggled `ANALYZE` to actually execute the statement.
+
+<Tip>
+Because plain `EXPLAIN` never executes the target statement, `explain_sql` is safe to run against write statements too. `explain_sql` on `DELETE FROM users WHERE id = 1` returns the plan without deleting anything.
+</Tip>
+
+## Enabling explain_sql
+
+Add a `[[tools]]` entry with `name = "explain_sql"`. It takes no other options — no `readonly` or `max_rows` — since it's always read-only:
+
+```toml
+[[sources]]
+id = "production"
+dsn = "postgres://user:pass@localhost:5432/mydb"
+
+[[tools]]
+name = "execute_sql"
+source = "production"
+readonly = true
+
+[[tools]]
+name = "search_objects"
+source = "production"
+
+[[tools]]
+name = "explain_sql"
+source = "production"
+```
+
+See [Tool Configuration](/tools/overview#tool-configuration) for how `[[tools]]` entries work across multiple sources.

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -4,11 +4,12 @@ title: "Overview"
 
 ## Available Tools
 
-| Tool        | Command Name  | Description                                                         |
-| ----------- | ------------- | ------------------------------------------------------------------- |
-| Execute SQL | `execute_sql` or `execute_sql_{id}` | Execute single or multiple SQL statements (separated by semicolons) |
-| Search Objects | `search_objects` or `search_objects_{id}` | Search and list database objects (schemas, tables, columns, procedures, indexes) with pattern matching and token-efficient progressive disclosure |
-| Custom Tools | User-defined names | Define reusable, parameterized SQL operations in your `dbhub.toml` configuration file |
+| Tool        | Command Name  | Default | Description                                                         |
+| ----------- | ------------- | ------- | -------------------------------------------------------------------- |
+| Execute SQL | `execute_sql` or `execute_sql_{id}` | On | Execute single or multiple SQL statements (separated by semicolons) |
+| Search Objects | `search_objects` or `search_objects_{id}` | On | Search and list database objects (schemas, tables, columns, procedures, indexes) with pattern matching and token-efficient progressive disclosure |
+| Explain SQL | `explain_sql` or `explain_sql_{id}` | Opt-in | Show the execution plan for a SQL statement without running it |
+| Custom Tools | User-defined names | Opt-in | Define reusable, parameterized SQL operations in your `dbhub.toml` configuration file |
 
 ## Tool Configuration
 
@@ -162,6 +163,9 @@ Special characters in source IDs (hyphens, dots, etc.) are converted to undersco
   </Card>
   <Card title="Search Objects" icon="magnifying-glass" href="/tools/search-objects">
     Search and explore database schemas, tables, and objects
+  </Card>
+  <Card title="Explain SQL" icon="diagram-project" href="/tools/explain-sql">
+    Show a query's execution plan without running it (opt-in)
   </Card>
   <Card title="Custom Tools" icon="wrench" href="/tools/custom-tools">
     Create reusable parameterized SQL operations

--- a/docs/tools/search-objects.mdx
+++ b/docs/tools/search-objects.mdx
@@ -219,3 +219,9 @@ When using `detail_level: "summary"` or `"full"`, the tool includes database com
 <Note>
 The tool supports all three detail levels (`names`, `summary`, `full`) and works seamlessly with multi-database configurations. Results are limited by the `limit` parameter (default: 100, max: 1000) to prevent excessive token usage.
 </Note>
+
+## See Also
+
+- [execute_sql](/tools/execute-sql) - Direct SQL execution tool
+- [explain_sql](/tools/explain-sql) - Query execution plan tool (opt-in)
+- [Custom Tools](/tools/custom-tools) - Reusable, parameterized SQL operations

--- a/skills/dbhub/SKILL.md
+++ b/skills/dbhub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dbhub
-description: Guide for querying databases through DBHub MCP server. Use this skill whenever you need to explore database schemas, inspect tables, or run SQL queries via DBHub's MCP tools (search_objects, execute_sql). Activates on any database query task, schema exploration, data retrieval, or SQL execution through MCP — even if the user just says "check the database" or "find me some data." This skill ensures you follow the correct explore-first workflow instead of guessing table structures.
+description: Guide for querying databases through DBHub MCP server. Use this skill whenever you need to explore database schemas, inspect tables, or run SQL queries via DBHub's MCP tools (search_objects, execute_sql, and the opt-in explain_sql). Activates on any database query task, schema exploration, data retrieval, or SQL execution through MCP — even if the user just says "check the database" or "find me some data." This skill ensures you follow the correct explore-first workflow instead of guessing table structures.
 ---
 
 # DBHub Database Query Guide
@@ -9,14 +9,17 @@ When working with databases through DBHub's MCP server, always follow the **expl
 
 ## Available Tools
 
-DBHub provides two MCP tools:
+DBHub provides two MCP tools by default, plus an opt-in third:
 
 | Tool | Purpose |
 |------|---------|
 | `search_objects` | Explore database structure — schemas, tables, columns, indexes, procedures, functions |
 | `execute_sql` | Run SQL statements against the database |
+| `explain_sql` (opt-in) | Show a query's execution plan without running it — only present if the source's config enables it |
 
 If multiple databases are configured, DBHub registers separate tools for each source (for example, `search_objects_prod_pg`, `execute_sql_staging_mysql`). Select the desired database by calling the correspondingly named tool.
+
+If `explain_sql` is available (check the tool list), prefer it over guessing whether a query will be efficient — it's always safe to call, even against a write-enabled or read-only source, since it never executes the statement.
 
 ## The Explore-Then-Query Workflow
 

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -2030,6 +2030,89 @@ max_rows = ${value}
     });
   });
 
+  describe('explain_sql tool configuration', () => {
+    it('should accept explain_sql with just name and source', () => {
+      const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+
+[[tools]]
+name = "explain_sql"
+source = "test_db"
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+      const result = loadTomlConfig();
+
+      expect(result?.tools).toHaveLength(1);
+      expect(result?.tools![0]).toMatchObject({
+        name: 'explain_sql',
+        source: 'test_db',
+      });
+    });
+
+    it('should reject explain_sql with description/statement/parameters', () => {
+      const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+
+[[tools]]
+name = "explain_sql"
+source = "test_db"
+description = "not allowed"
+statement = "SELECT 1"
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+      expect(() => loadTomlConfig()).toThrow(
+        "built-in tool 'explain_sql' cannot have description, statement, or parameters fields"
+      );
+    });
+
+    it('should reject explain_sql with readonly or max_rows', () => {
+      const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+
+[[tools]]
+name = "explain_sql"
+source = "test_db"
+readonly = true
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+      expect(() => loadTomlConfig()).toThrow(
+        "tool 'explain_sql' cannot have readonly or max_rows fields"
+      );
+    });
+
+    it('should reject a custom tool named explain_sql_foo (reserved naming pattern)', () => {
+      const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+
+[[tools]]
+name = "explain_sql_foo"
+source = "test_db"
+description = "Custom tool colliding with explain_sql naming"
+statement = "SELECT 1"
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+      // toml-loader itself doesn't reject the naming collision (that's
+      // enforced by ToolRegistry.validateCustomTool), but it must at least
+      // parse the tool through unchanged as a non-builtin so the registry can
+      // catch it.
+      const result = loadTomlConfig();
+      expect(result?.tools).toHaveLength(1);
+      expect(result?.tools![0].name).toBe('explain_sql_foo');
+    });
+  });
+
   describe('environment variable interpolation', () => {
     const originalEnv = { ...process.env };
 

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -6,7 +6,7 @@ import type { SourceConfig, TomlConfig, ToolConfig } from "../types/config.js";
 import { parseCommandLineArgs, requireFlagValue } from "./env.js";
 import { parseConnectionInfoFromDSN, getDefaultPortForType } from "../utils/dsn-obfuscate.js";
 import { SafeURL } from "../utils/safe-url.js";
-import { BUILTIN_TOOLS, BUILTIN_TOOL_EXECUTE_SQL, BUILTIN_TOOL_SEARCH_OBJECTS } from "../tools/builtin-tools.js";
+import { BUILTIN_TOOL_EXECUTE_SQL, BUILTIN_TOOL_SEARCH_OBJECTS, ALL_BUILTIN_TOOL_NAMES } from "../tools/builtin-tools.js";
 
 /**
  * Load and parse TOML configuration file
@@ -180,7 +180,7 @@ function validateToolsConfig(
     }
 
     // Validate based on tool type (built-in vs custom)
-    const isBuiltin = (BUILTIN_TOOLS as readonly string[]).includes(tool.name);
+    const isBuiltin = (ALL_BUILTIN_TOOL_NAMES as readonly string[]).includes(tool.name);
     const isExecuteSql = tool.name === BUILTIN_TOOL_EXECUTE_SQL;
 
     if (isBuiltin) {

--- a/src/tools/__tests__/explain-sql.test.ts
+++ b/src/tools/__tests__/explain-sql.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createExplainSqlToolHandler } from '../explain-sql.js';
 import { ConnectorManager } from '../../connectors/manager.js';
+import { requestStore } from '../../requests/index.js';
 import type { Connector, ConnectorType, SQLResult } from '../../connectors/interface.js';
 
 vi.mock('../../connectors/manager.js');
@@ -27,6 +28,12 @@ const parseToolResponse = (response: any) => JSON.parse(response.content[0].text
 
 describe('explain-sql tool', () => {
   const mockGetCurrentConnector = vi.mocked(ConnectorManager.getCurrentConnector);
+
+  beforeEach(() => {
+    // Single-source by default, so resolveTrackedToolName resolves to the
+    // bare tool name; multi-source naming is covered separately below.
+    vi.mocked(ConnectorManager.getAvailableSourceIds).mockReturnValue(['test_source']);
+  });
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -90,6 +97,34 @@ describe('explain-sql tool', () => {
       expect(mockConnector.executeSQL).not.toHaveBeenCalled();
     });
 
+    it.each([
+      '(ANALYZE) DELETE FROM users',
+      '(ANALYZE, VERBOSE) DELETE FROM users',
+      '(VERBOSE,ANALYZE)DELETE FROM users',
+      '-- comment\n(ANALYZE) DELETE FROM users',
+    ])('rejects a leading parenthesized option list containing ANALYZE: %s', async (sql) => {
+      const handler = createExplainSqlToolHandler('test_source');
+      const result = await handler({ sql }, null);
+
+      expect(result.isError).toBe(true);
+      expect(parseToolResponse(result).code).toBe('INVALID_INPUT');
+      expect(mockConnector.executeSQL).not.toHaveBeenCalled();
+    });
+
+    it('allows a leading parenthesized option list that does not contain ANALYZE', async () => {
+      const mockResult: SQLResult = { rows: [{ plan: 'x' }], rowCount: 1 };
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
+
+      const handler = createExplainSqlToolHandler('test_source');
+      const result = await handler({ sql: '(FORMAT JSON) SELECT * FROM users' }, null);
+
+      expect(parseToolResponse(result).success).toBe(true);
+      expect(mockConnector.executeSQL).toHaveBeenCalledWith(
+        'EXPLAIN (FORMAT JSON) SELECT * FROM users',
+        { readonly: true }
+      );
+    });
+
     it('allows explaining a write statement (plain EXPLAIN never executes it)', async () => {
       const mockResult: SQLResult = { rows: [{ plan: 'x' }], rowCount: 1 };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
@@ -102,6 +137,34 @@ describe('explain-sql tool', () => {
         'EXPLAIN DELETE FROM users WHERE id = 1',
         { readonly: true }
       );
+    });
+  });
+
+  describe('request tracking', () => {
+    it('tracks the bare tool name for a single source configured with --id (not "default")', async () => {
+      vi.mocked(ConnectorManager.getAvailableSourceIds).mockReturnValue(['prod']);
+      const mockConnector = createMockConnector('postgres', 'prod');
+      mockGetCurrentConnector.mockReturnValue(mockConnector);
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [], rowCount: 0 });
+      const addSpy = vi.spyOn(requestStore, 'add');
+
+      const handler = createExplainSqlToolHandler('prod');
+      await handler({ sql: 'SELECT 1' }, null);
+
+      expect(addSpy).toHaveBeenCalledWith(expect.objectContaining({ toolName: 'explain_sql' }));
+    });
+
+    it('tracks the normalized, suffixed tool name for a multi-source id with special characters', async () => {
+      vi.mocked(ConnectorManager.getAvailableSourceIds).mockReturnValue(['prod-pg', 'staging']);
+      const mockConnector = createMockConnector('postgres', 'prod-pg');
+      mockGetCurrentConnector.mockReturnValue(mockConnector);
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [], rowCount: 0 });
+      const addSpy = vi.spyOn(requestStore, 'add');
+
+      const handler = createExplainSqlToolHandler('prod-pg');
+      await handler({ sql: 'SELECT 1' }, null);
+
+      expect(addSpy).toHaveBeenCalledWith(expect.objectContaining({ toolName: 'explain_sql_prod_pg' }));
     });
   });
 

--- a/src/tools/__tests__/explain-sql.test.ts
+++ b/src/tools/__tests__/explain-sql.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createExplainSqlToolHandler } from '../explain-sql.js';
+import { ConnectorManager } from '../../connectors/manager.js';
+import type { Connector, ConnectorType, SQLResult } from '../../connectors/interface.js';
+
+vi.mock('../../connectors/manager.js');
+
+const createMockConnector = (id: ConnectorType = 'sqlite', sourceId: string = 'default'): Connector => ({
+  id,
+  name: 'Mock Connector',
+  getId: () => sourceId,
+  dsnParser: {} as any,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  clone: vi.fn(),
+  getSchemas: vi.fn(),
+  getTables: vi.fn(),
+  tableExists: vi.fn(),
+  getTableSchema: vi.fn(),
+  getTableIndexes: vi.fn(),
+  getStoredProcedures: vi.fn(),
+  getStoredProcedureDetail: vi.fn(),
+  executeSQL: vi.fn(),
+});
+
+const parseToolResponse = (response: any) => JSON.parse(response.content[0].text);
+
+describe('explain-sql tool', () => {
+  const mockGetCurrentConnector = vi.mocked(ConnectorManager.getCurrentConnector);
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('dialect-specific EXPLAIN text', () => {
+    it.each([
+      ['postgres', 'EXPLAIN SELECT * FROM users'],
+      ['mysql', 'EXPLAIN SELECT * FROM users'],
+      ['mariadb', 'EXPLAIN SELECT * FROM users'],
+      ['sqlserver', 'EXPLAIN SELECT * FROM users'],
+      ['sqlite', 'EXPLAIN QUERY PLAN SELECT * FROM users'],
+    ] satisfies [ConnectorType, string][])('builds "%s" as expected for %s', async (dialect, expected) => {
+      const mockConnector = createMockConnector(dialect, 'test_source');
+      mockGetCurrentConnector.mockReturnValue(mockConnector);
+      const mockResult: SQLResult = { rows: [{ plan: 'x' }], rowCount: 1 };
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
+
+      const handler = createExplainSqlToolHandler('test_source');
+      const result = await handler({ sql: 'SELECT * FROM users' }, null);
+      const parsed = parseToolResponse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(mockConnector.executeSQL).toHaveBeenCalledWith(expected, { readonly: true });
+    });
+  });
+
+  describe('input validation', () => {
+    let mockConnector: Connector;
+
+    beforeEach(() => {
+      mockConnector = createMockConnector('postgres', 'test_source');
+      mockGetCurrentConnector.mockReturnValue(mockConnector);
+    });
+
+    it('rejects multiple statements', async () => {
+      const handler = createExplainSqlToolHandler('test_source');
+      const result = await handler({ sql: 'SELECT 1; SELECT 2' }, null);
+
+      expect(result.isError).toBe(true);
+      const parsed = parseToolResponse(result);
+      expect(parsed.code).toBe('INVALID_INPUT');
+      expect(mockConnector.executeSQL).not.toHaveBeenCalled();
+    });
+
+    it('rejects input already starting with EXPLAIN', async () => {
+      const handler = createExplainSqlToolHandler('test_source');
+      const result = await handler({ sql: 'EXPLAIN SELECT * FROM users' }, null);
+
+      expect(result.isError).toBe(true);
+      expect(parseToolResponse(result).code).toBe('INVALID_INPUT');
+      expect(mockConnector.executeSQL).not.toHaveBeenCalled();
+    });
+
+    it('rejects input starting with ANALYZE to prevent smuggled execution', async () => {
+      const handler = createExplainSqlToolHandler('test_source');
+      const result = await handler({ sql: 'ANALYZE DELETE FROM users' }, null);
+
+      expect(result.isError).toBe(true);
+      expect(parseToolResponse(result).code).toBe('INVALID_INPUT');
+      expect(mockConnector.executeSQL).not.toHaveBeenCalled();
+    });
+
+    it('allows explaining a write statement (plain EXPLAIN never executes it)', async () => {
+      const mockResult: SQLResult = { rows: [{ plan: 'x' }], rowCount: 1 };
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
+
+      const handler = createExplainSqlToolHandler('test_source');
+      const result = await handler({ sql: 'DELETE FROM users WHERE id = 1' }, null);
+
+      expect(parseToolResponse(result).success).toBe(true);
+      expect(mockConnector.executeSQL).toHaveBeenCalledWith(
+        'EXPLAIN DELETE FROM users WHERE id = 1',
+        { readonly: true }
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns EXECUTION_ERROR when the connector throws', async () => {
+      const mockConnector = createMockConnector('postgres', 'test_source');
+      mockGetCurrentConnector.mockReturnValue(mockConnector);
+      vi.mocked(mockConnector.executeSQL).mockRejectedValue(new Error('boom'));
+
+      const handler = createExplainSqlToolHandler('test_source');
+      const result = await handler({ sql: 'SELECT 1' }, null);
+
+      expect(result.isError).toBe(true);
+      const parsed = parseToolResponse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toBe('boom');
+      expect(parsed.code).toBe('EXECUTION_ERROR');
+    });
+  });
+});

--- a/src/tools/__tests__/registry.test.ts
+++ b/src/tools/__tests__/registry.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolRegistry } from "../registry.js";
+import { ConnectorManager } from "../../connectors/manager.js";
+import type { TomlConfig } from "../../types/config.js";
+
+vi.mock("../../connectors/manager.js");
+
+describe("ToolRegistry", () => {
+  it("defaults a source with no [[tools]] entries to execute_sql + search_objects only", () => {
+    const config: TomlConfig = {
+      sources: [{ id: "db1", type: "postgres" } as any],
+    };
+    const registry = new ToolRegistry(config);
+
+    const enabled = registry.getEnabledToolConfigs("db1").map((t) => t.name);
+    expect(enabled).toEqual(["execute_sql", "search_objects"]);
+    expect(enabled).not.toContain("explain_sql");
+  });
+
+  it("enables explain_sql only when explicitly configured", () => {
+    const config: TomlConfig = {
+      sources: [{ id: "db1", type: "postgres" } as any],
+      tools: [
+        { name: "execute_sql", source: "db1" },
+        { name: "explain_sql", source: "db1" },
+      ],
+    };
+    const registry = new ToolRegistry(config);
+
+    const enabled = registry.getEnabledToolConfigs("db1").map((t) => t.name);
+    expect(enabled).toEqual(["execute_sql", "explain_sql"]);
+    expect(registry.getBuiltinToolConfig("explain_sql", "db1")).toMatchObject({
+      name: "explain_sql",
+      source: "db1",
+    });
+  });
+
+  it("rejects a custom tool whose name collides with the explain_sql naming pattern", () => {
+    vi.mocked(ConnectorManager.getSourceConfig).mockReturnValue({ id: "db1", type: "postgres" } as any);
+    const config: TomlConfig = {
+      sources: [{ id: "db1", type: "postgres" } as any],
+      tools: [
+        {
+          name: "explain_sql_extra",
+          source: "db1",
+          description: "Custom tool colliding with explain_sql",
+          statement: "SELECT 1",
+        } as any,
+      ],
+    };
+
+    expect(() => new ToolRegistry(config)).toThrow(
+      "conflicts with built-in tool naming pattern"
+    );
+  });
+});

--- a/src/tools/builtin-tools.ts
+++ b/src/tools/builtin-tools.ts
@@ -5,8 +5,19 @@
 
 export const BUILTIN_TOOL_EXECUTE_SQL = "execute_sql";
 export const BUILTIN_TOOL_SEARCH_OBJECTS = "search_objects";
+export const BUILTIN_TOOL_EXPLAIN_SQL = "explain_sql";
 
+// The default pair every source gets when it has no [[tools]] entries of its
+// own. explain_sql is intentionally excluded — it's opt-in only.
 export const BUILTIN_TOOLS = [
   BUILTIN_TOOL_EXECUTE_SQL,
   BUILTIN_TOOL_SEARCH_OBJECTS,
+] as const;
+
+// All recognized built-in tool names, including opt-in ones. Used wherever a
+// tool name needs to be identified as "built-in" (skip custom-tool
+// validation, reserve the naming pattern) without affecting the default set.
+export const ALL_BUILTIN_TOOL_NAMES = [
+  ...BUILTIN_TOOLS,
+  BUILTIN_TOOL_EXPLAIN_SQL,
 ] as const;

--- a/src/tools/explain-sql.ts
+++ b/src/tools/explain-sql.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
 import { ConnectorManager } from "../connectors/manager.js";
 import { createToolSuccessResponse, createToolErrorResponse } from "../utils/response-formatter.js";
-import { splitSQLStatements } from "../utils/sql-parser.js";
+import { splitSQLStatements, stripCommentsAndStrings } from "../utils/sql-parser.js";
 import { getFirstKeyword } from "../utils/allowed-keywords.js";
 import type { ConnectorType } from "../connectors/interface.js";
 import {
   getEffectiveSourceId,
+  resolveTrackedToolName,
   trackToolRequest,
   tryClassifyConnectionError,
 } from "../utils/tool-handler-helpers.js";
@@ -53,12 +54,27 @@ function validateExplainInput(sql: string, connectorType: ConnectorType): string
     return "explain_sql does not support ANALYZE (it must never execute the statement)";
   }
 
+  // PostgreSQL's EXPLAIN accepts a parenthesized option list immediately
+  // after EXPLAIN (e.g. EXPLAIN (ANALYZE, VERBOSE) SELECT ...). Input
+  // starting with such a "(...)" block combines with our EXPLAIN prefix into
+  // a form that actually executes the statement, bypassing the bare-ANALYZE
+  // check above (whose \S+ matching never isolates "analyze" as its own
+  // token when it's glued to parens/commas).
+  const cleaned = stripCommentsAndStrings(statements[0], connectorType).trim();
+  const leadingOptions = cleaned.match(/^\(([\s\S]*?)\)/)?.[1];
+  if (leadingOptions && /\banalyze\b/i.test(leadingOptions)) {
+    return "explain_sql does not support ANALYZE (it must never execute the statement)";
+  }
+
   return null;
 }
 
 /**
  * Create an explain_sql tool handler for a specific source
- * @param sourceId - The source ID this handler is bound to (undefined for single-source mode)
+ * @param sourceId - The source ID this handler is bound to. Registration
+ * (see tools/index.ts) always passes a concrete id ("default" or an actual
+ * source id) - undefined is only meaningful for direct/test invocation,
+ * where it's treated the same as "default" via getEffectiveSourceId.
  * @returns A handler function bound to the specified source
  */
 export function createExplainSqlToolHandler(sourceId?: string) {
@@ -108,7 +124,7 @@ export function createExplainSqlToolHandler(sourceId?: string) {
       trackToolRequest(
         {
           sourceId: effectiveSourceId,
-          toolName: effectiveSourceId === "default" ? "explain_sql" : `explain_sql_${effectiveSourceId}`,
+          toolName: resolveTrackedToolName(sourceId, "explain_sql"),
           sql,
         },
         startTime,

--- a/src/tools/explain-sql.ts
+++ b/src/tools/explain-sql.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { ConnectorManager } from "../connectors/manager.js";
+import { createToolSuccessResponse, createToolErrorResponse } from "../utils/response-formatter.js";
+import { splitSQLStatements } from "../utils/sql-parser.js";
+import { getFirstKeyword } from "../utils/allowed-keywords.js";
+import type { ConnectorType } from "../connectors/interface.js";
+import {
+  getEffectiveSourceId,
+  trackToolRequest,
+  tryClassifyConnectionError,
+} from "../utils/tool-handler-helpers.js";
+
+// Schema for explain_sql tool. See execute-sql.ts for why the raw shape is
+// exported separately from the wrapped z.object().
+export const explainSqlSchema = {
+  sql: z.string().describe("Single SQL statement to explain (no trailing semicolon-separated statements)"),
+};
+
+export const explainSqlInputSchema = z.object(explainSqlSchema);
+
+/**
+ * Build the dialect-appropriate EXPLAIN statement for a given connector type.
+ * Deliberately never emits ANALYZE (or any variant that executes the target
+ * statement) - explain_sql is meant to always be side-effect free, regardless
+ * of the source's readonly/write configuration.
+ */
+function buildExplainStatement(connectorType: ConnectorType, sql: string): string {
+  // Bare EXPLAIN on SQLite returns raw VDBE bytecode, not a query plan.
+  // EXPLAIN QUERY PLAN is the human-readable form.
+  if (connectorType === "sqlite") {
+    return `EXPLAIN QUERY PLAN ${sql}`;
+  }
+  return `EXPLAIN ${sql}`;
+}
+
+/**
+ * Reject input that could turn the tool's own EXPLAIN prefix into something
+ * that actually executes the statement (e.g. a leading ANALYZE combining with
+ * our prefix to form "EXPLAIN ANALYZE ..."), or that smuggles multiple
+ * statements past the single EXPLAIN we emit.
+ */
+function validateExplainInput(sql: string, connectorType: ConnectorType): string | null {
+  const statements = splitSQLStatements(sql, connectorType);
+  if (statements.length !== 1) {
+    return "explain_sql only supports a single SQL statement";
+  }
+
+  const firstWord = getFirstKeyword(statements[0], connectorType);
+  if (firstWord === "explain") {
+    return "explain_sql input must not itself start with EXPLAIN";
+  }
+  if (firstWord === "analyze") {
+    return "explain_sql does not support ANALYZE (it must never execute the statement)";
+  }
+
+  return null;
+}
+
+/**
+ * Create an explain_sql tool handler for a specific source
+ * @param sourceId - The source ID this handler is bound to (undefined for single-source mode)
+ * @returns A handler function bound to the specified source
+ */
+export function createExplainSqlToolHandler(sourceId?: string) {
+  return async (args: any, extra: any) => {
+    const { sql } = args as { sql: string };
+    const startTime = Date.now();
+    const effectiveSourceId = getEffectiveSourceId(sourceId);
+    let success = true;
+    let errorMessage: string | undefined;
+    let result: any;
+
+    try {
+      // Ensure source is connected (handles lazy connections)
+      await ConnectorManager.ensureConnected(sourceId);
+
+      // Get connector for the specified source (or default)
+      const connector = ConnectorManager.getCurrentConnector(sourceId);
+
+      const validationError = validateExplainInput(sql, connector.id);
+      if (validationError) {
+        success = false;
+        errorMessage = validationError;
+        return createToolErrorResponse(errorMessage, "INVALID_INPUT");
+      }
+
+      // Always readonly: plain EXPLAIN never executes the target statement
+      // on any supported engine, so this is safe regardless of the source's
+      // own execute_sql readonly/max_rows configuration.
+      const explainStatement = buildExplainStatement(connector.id, sql);
+      result = await connector.executeSQL(explainStatement, { readonly: true });
+
+      const responseData = {
+        rows: result.rows,
+        count: result.rowCount,
+        source_id: effectiveSourceId,
+        ...(result.messages && result.messages.length > 0 ? { messages: result.messages } : {}),
+      };
+
+      return createToolSuccessResponse(responseData);
+    } catch (error) {
+      success = false;
+      errorMessage = (error as Error).message;
+      const classified = tryClassifyConnectionError(error, sourceId, effectiveSourceId);
+      if (classified) return classified;
+      return createToolErrorResponse(errorMessage, "EXECUTION_ERROR");
+    } finally {
+      trackToolRequest(
+        {
+          sourceId: effectiveSourceId,
+          toolName: effectiveSourceId === "default" ? "explain_sql" : `explain_sql_${effectiveSourceId}`,
+          sql,
+        },
+        startTime,
+        extra,
+        success,
+        errorMessage
+      );
+    }
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,13 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/server";
 import { createExecuteSqlToolHandler, executeSqlInputSchema } from "./execute-sql.js";
 import { createSearchDatabaseObjectsToolHandler, searchDatabaseObjectsInputSchema } from "./search-objects.js";
+import { createExplainSqlToolHandler, explainSqlInputSchema } from "./explain-sql.js";
 import { ConnectorManager } from "../connectors/manager.js";
-import { getExecuteSqlMetadata, getSearchObjectsMetadata } from "../utils/tool-metadata.js";
+import { getExecuteSqlMetadata, getSearchObjectsMetadata, getExplainSqlMetadata } from "../utils/tool-metadata.js";
 import { classifySQL } from "../utils/sql-access-policy.js";
 import { createCustomToolHandler, getCustomToolInputSchema } from "./custom-tool-handler.js";
 import type { ToolConfig } from "../types/config.js";
 import { getToolRegistry } from "./registry.js";
-import { BUILTIN_TOOL_EXECUTE_SQL, BUILTIN_TOOL_SEARCH_OBJECTS } from "./builtin-tools.js";
+import { BUILTIN_TOOL_EXECUTE_SQL, BUILTIN_TOOL_SEARCH_OBJECTS, BUILTIN_TOOL_EXPLAIN_SQL } from "./builtin-tools.js";
 
 /**
  * Register all tool handlers with the MCP server
@@ -33,6 +34,8 @@ export function registerTools(server: McpServer): void {
         registerExecuteSqlTool(server, sourceId);
       } else if (toolConfig.name === BUILTIN_TOOL_SEARCH_OBJECTS) {
         registerSearchObjectsTool(server, sourceId);
+      } else if (toolConfig.name === BUILTIN_TOOL_EXPLAIN_SQL) {
+        registerExplainSqlTool(server, sourceId);
       } else {
         // Custom tool
         registerCustomTool(server, sourceId, toolConfig);
@@ -83,6 +86,25 @@ function registerSearchObjectsTool(
       },
     },
     createSearchDatabaseObjectsToolHandler(sourceId)
+  );
+}
+
+/**
+ * Register explain_sql tool for a source
+ */
+function registerExplainSqlTool(
+  server: McpServer,
+  sourceId: string
+): void {
+  const metadata = getExplainSqlMetadata(sourceId);
+  server.registerTool(
+    metadata.name,
+    {
+      description: metadata.description,
+      inputSchema: explainSqlInputSchema,
+      annotations: metadata.annotations,
+    },
+    createExplainSqlToolHandler(sourceId)
   );
 }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -4,7 +4,7 @@
  */
 
 import type { TomlConfig, ToolConfig, ExecuteSqlToolConfig, SearchObjectsToolConfig, ParameterConfig } from "../types/config.js";
-import { BUILTIN_TOOLS } from "./builtin-tools.js";
+import { BUILTIN_TOOLS, ALL_BUILTIN_TOOL_NAMES } from "./builtin-tools.js";
 import { ConnectorManager } from "../connectors/manager.js";
 import { validateParameters } from "../utils/parameter-mapper.js";
 
@@ -23,7 +23,7 @@ export class ToolRegistry {
    * Check if a tool name is a built-in tool
    */
   private isBuiltinTool(toolName: string): boolean {
-    return BUILTIN_TOOLS.includes(toolName);
+    return (ALL_BUILTIN_TOOL_NAMES as readonly string[]).includes(toolName);
   }
 
   /**
@@ -116,14 +116,14 @@ export class ToolRegistry {
     }
 
     // 3. Validate tool name doesn't conflict with built-in tools
-    for (const builtinName of BUILTIN_TOOLS) {
+    for (const builtinName of ALL_BUILTIN_TOOL_NAMES) {
       if (
         toolConfig.name === builtinName ||
         toolConfig.name.startsWith(`${builtinName}_`)
       ) {
         throw new Error(
           `Tool name '${toolConfig.name}' conflicts with built-in tool naming pattern. ` +
-            `Custom tools cannot use names starting with: ${BUILTIN_TOOLS.join(", ")}`
+            `Custom tools cannot use names starting with: ${ALL_BUILTIN_TOOL_NAMES.join(", ")}`
         );
       }
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -91,6 +91,14 @@ export interface SearchObjectsToolConfig {
 }
 
 /**
+ * Built-in tool configuration for explain_sql
+ */
+export interface ExplainSqlToolConfig {
+  name: "explain_sql"; // Must match BUILTIN_TOOL_EXPLAIN_SQL from builtin-tools.ts
+  source: string;
+}
+
+/**
  * Custom tool configuration
  */
 export interface CustomToolConfig {
@@ -106,7 +114,11 @@ export interface CustomToolConfig {
 /**
  * Unified tool configuration (discriminated union)
  */
-export type ToolConfig = ExecuteSqlToolConfig | SearchObjectsToolConfig | CustomToolConfig;
+export type ToolConfig =
+  | ExecuteSqlToolConfig
+  | SearchObjectsToolConfig
+  | ExplainSqlToolConfig
+  | CustomToolConfig;
 
 /**
  * Complete TOML configuration file structure

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -214,6 +214,17 @@ export function isReadOnlySQL(sql: string, connectorType: ConnectorType | string
   );
 }
 
+/**
+ * Extract the first keyword of a SQL statement, after stripping comments and
+ * string literals so a keyword hidden in a comment/string can't be mistaken
+ * for the statement's real leading token. Returns "" for empty/whitespace-only
+ * or comment-only input.
+ */
+export function getFirstKeyword(sql: string, connectorType: ConnectorType | string): string {
+  const cleaned = stripCommentsAndStrings(sql, connectorType as ConnectorType).trim();
+  return cleaned.match(/\S+/)?.[0]?.toLowerCase() ?? "";
+}
+
 function checkReadOnly(cleanedSQL: string, connectorType: ConnectorType | string): boolean {
   // Empty after stripping → deny. Attacker-crafted inputs may reduce to
   // empty strings after comment/string removal to evade keyword checks.

--- a/src/utils/tool-handler-helpers.ts
+++ b/src/utils/tool-handler-helpers.ts
@@ -10,6 +10,7 @@ import { requestStore } from "../requests/index.js";
 import { getClientIdentifier } from "./client-identifier.js";
 import { classifyConnectionError } from "./error-classifier.js";
 import { createToolErrorResponse } from "./response-formatter.js";
+import { normalizeSourceId } from "./normalize-id.js";
 
 /**
  * Request metadata for tracking
@@ -27,6 +28,24 @@ export interface RequestMetadata {
  */
 export function getEffectiveSourceId(sourceId?: string): string {
   return sourceId || "default";
+}
+
+/**
+ * Resolve the tool name a handler was actually registered under, for request
+ * tracking. Mirrors resolveBuiltinToolNaming in tool-metadata.ts: single-source
+ * deployments keep the bare tool name (no suffix, regardless of the source's
+ * own id), while multi-source ones suffix with the *normalized* source id.
+ * Do not substitute a plain `sourceId === "default"` check here - that only
+ * happens to match in the no-`--id` single-source case, and silently
+ * diverges from the registered name for `--id`-configured single sources or
+ * multi-source ids containing characters normalizeSourceId rewrites.
+ */
+export function resolveTrackedToolName(sourceId: string | undefined, baseName: string): string {
+  const isSingleSource = ConnectorManager.getAvailableSourceIds().length === 1;
+  if (isSingleSource) {
+    return baseName;
+  }
+  return `${baseName}_${normalizeSourceId(getEffectiveSourceId(sourceId))}`;
 }
 
 /**

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -4,6 +4,7 @@ import { policyFromReadonly, isReadOnlyPolicy } from "./sql-access-policy.js";
 import { ConnectorManager } from "../connectors/manager.js";
 import { normalizeSourceId } from "./normalize-id.js";
 import { executeSqlSchema } from "../tools/execute-sql.js";
+import { explainSqlSchema } from "../tools/explain-sql.js";
 import { getToolRegistry } from "../tools/registry.js";
 import { BUILTIN_TOOL_EXECUTE_SQL } from "../tools/builtin-tools.js";
 import type { ParameterConfig, ToolConfig } from "../types/config.js";
@@ -108,15 +109,40 @@ export function zodToParameters(schema: Record<string, z.ZodType<any>>): ToolPar
 }
 
 /**
+ * Shared per-source naming for built-in tools: single-source deployments keep
+ * the bare tool name, multi-source ones suffix with the normalized source id
+ * (see CLAUDE.md's "Tool Handlers" section). Also resolves the source's db
+ * type and the user-provided `description` prefix so callers only need to
+ * supply the tool-specific label and body text.
+ */
+function resolveBuiltinToolNaming(sourceId: string, baseName: string, titleLabel: string) {
+  const sourceIds = ConnectorManager.getAvailableSourceIds();
+  const sourceConfig = ConnectorManager.getSourceConfig(sourceId)!;
+  const dbType = sourceConfig.type;
+  const isSingleSource = sourceIds.length === 1;
+
+  const name = isSingleSource ? baseName : `${baseName}_${normalizeSourceId(sourceId)}`;
+  const title = isSingleSource
+    ? `${titleLabel} (${dbType})`
+    : `${titleLabel} on ${sourceId} (${dbType})`;
+  // Prepend the user-provided `description` from the source config (if set)
+  // so AI clients reading the MCP tool list see the source's purpose first.
+  const userDescPrefix = buildSourceDescriptionPrefix(sourceConfig.description);
+
+  return { dbType, isSingleSource, name, title, userDescPrefix };
+}
+
+/**
  * Get execute_sql tool metadata for a specific source
  * @param sourceId - The source ID to get tool metadata for
  * @returns Tool metadata with name, description, and Zod schema
  */
 export function getExecuteSqlMetadata(sourceId: string): ToolMetadata {
-  const sourceIds = ConnectorManager.getAvailableSourceIds();
-  const sourceConfig = ConnectorManager.getSourceConfig(sourceId)!;
-  const dbType = sourceConfig.type;
-  const isSingleSource = sourceIds.length === 1;
+  const { dbType, isSingleSource, name, title, userDescPrefix } = resolveBuiltinToolNaming(
+    sourceId,
+    "execute_sql",
+    "Execute SQL"
+  );
 
   // Get tool configuration from registry to extract readonly/max_rows
   const registry = getToolRegistry();
@@ -126,18 +152,6 @@ export function getExecuteSqlMetadata(sourceId: string): ToolMetadata {
     maxRows: toolConfig?.max_rows,
   };
 
-  // Determine tool name based on single vs multi-source configuration
-  const toolName = isSingleSource ? "execute_sql" : `execute_sql_${normalizeSourceId(sourceId)}`;
-
-  // Determine title (human-readable display name)
-  const title = isSingleSource
-    ? `Execute SQL (${dbType})`
-    : `Execute SQL on ${sourceId} (${dbType})`;
-
-  // Determine description with more context.
-  // Prepend the user-provided `description` from the source config (if set)
-  // so AI clients reading the MCP tool list see the source's purpose first.
-  const userDescPrefix = buildSourceDescriptionPrefix(sourceConfig.description);
   const readonlyNote = executeOptions.readonly ? " [READ-ONLY MODE]" : "";
   const maxRowsNote = executeOptions.maxRows ? ` (limited to ${executeOptions.maxRows} rows)` : "";
   const description = isSingleSource
@@ -159,7 +173,7 @@ export function getExecuteSqlMetadata(sourceId: string): ToolMetadata {
   };
 
   return {
-    name: toolName,
+    name,
     description,
     schema: executeSqlSchema,
     annotations,
@@ -172,26 +186,48 @@ export function getExecuteSqlMetadata(sourceId: string): ToolMetadata {
  * @returns Tool name, description, and annotations
  */
 export function getSearchObjectsMetadata(sourceId: string): { name: string; description: string; title: string } {
-  const sourceIds = ConnectorManager.getAvailableSourceIds();
-  const sourceConfig = ConnectorManager.getSourceConfig(sourceId)!;
-  const dbType = sourceConfig.type;
-  const isSingleSource = sourceIds.length === 1;
+  const { dbType, isSingleSource, name, title, userDescPrefix } = resolveBuiltinToolNaming(
+    sourceId,
+    "search_objects",
+    "Search Database Objects"
+  );
 
-  const toolName = isSingleSource ? "search_objects" : `search_objects_${normalizeSourceId(sourceId)}`;
-  const title = isSingleSource
-    ? `Search Database Objects (${dbType})`
-    : `Search Database Objects on ${sourceId} (${dbType})`;
-  // Prepend the user-provided `description` from the source config (if set)
-  // so AI clients reading the MCP tool list see the source's purpose first.
-  const userDescPrefix = buildSourceDescriptionPrefix(sourceConfig.description);
   const description = isSingleSource
     ? `${userDescPrefix}Search and list database objects on the ${dbType} database`
     : `${userDescPrefix}Search and list database objects on the '${sourceId}' ${dbType} database`;
 
-  return {
-    name: toolName,
-    description,
+  return { name, description, title };
+}
+
+/**
+ * Get explain_sql tool metadata for a specific source
+ * @param sourceId - The source ID to get tool metadata for
+ * @returns Tool metadata with name, description, and Zod schema
+ */
+export function getExplainSqlMetadata(sourceId: string): ToolMetadata {
+  const { dbType, isSingleSource, name, title, userDescPrefix } = resolveBuiltinToolNaming(
+    sourceId,
+    "explain_sql",
+    "Explain Query Plan"
+  );
+
+  const description = isSingleSource
+    ? `${userDescPrefix}Show the execution plan for a SQL statement on the ${dbType} database without running it. Always read-only and safe, independent of the source's read/write mode.`
+    : `${userDescPrefix}Show the execution plan for a SQL statement on the '${sourceId}' ${dbType} database without running it. Always read-only and safe, independent of the source's read/write mode.`;
+
+  const annotations = {
     title,
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  };
+
+  return {
+    name,
+    description,
+    schema: explainSqlSchema,
+    annotations,
   };
 }
 
@@ -286,6 +322,20 @@ function buildSearchObjectsTool(sourceId: string): Tool {
 }
 
 /**
+ * Build explain_sql tool metadata for API response
+ */
+function buildExplainSqlTool(sourceId: string): Tool {
+  const explainMetadata = getExplainSqlMetadata(sourceId);
+
+  return {
+    name: explainMetadata.name,
+    description: explainMetadata.description,
+    parameters: zodToParameters(explainMetadata.schema),
+    readonly: true, // explain_sql is always readonly
+  };
+}
+
+/**
  * Build custom tool metadata for API response
  */
 function buildCustomTool(toolConfig: ToolConfig): Tool {
@@ -317,6 +367,8 @@ export function getToolsForSource(sourceId: string): Tool[] {
       return buildExecuteSqlTool(sourceId, toolConfig);
     } else if (toolConfig.name === "search_objects") {
       return buildSearchObjectsTool(sourceId);
+    } else if (toolConfig.name === "explain_sql") {
+      return buildExplainSqlTool(sourceId);
     } else {
       // Custom tool
       return buildCustomTool(toolConfig);


### PR DESCRIPTION
## Summary

- Adds a dedicated, opt-in `explain_sql` MCP tool (per-source: `explain_sql_{source_id}`) that returns a query's execution plan without running it.
- Not part of the default tool pair (`execute_sql` + `search_objects`) — must be explicitly enabled via `[[tools]] name = "explain_sql"` in `dbhub.toml`, same mechanism already used for `readonly`/`max_rows` on `execute_sql`.
- Always safe to enable regardless of a source's `readonly` setting: plain `EXPLAIN` (never `ANALYZE`) never executes the target statement on any of the 5 supported engines, so it needs no `readonly`/`max_rows` config of its own.
- Builds the dialect-appropriate statement (`EXPLAIN ...` for Postgres/MySQL/MariaDB/SQL Server, `EXPLAIN QUERY PLAN ...` for SQLite) and reuses each connector's existing `executeSQL` — no connector interface changes, since SQL Server's connector already translates a leading `EXPLAIN` into `SET SHOWPLAN_XML`.
- Guards against smuggled execution: rejects multi-statement input, and rejects input that already starts with `EXPLAIN`/`ANALYZE` (which could otherwise combine with the tool's own prefix to form `EXPLAIN ANALYZE ...` and actually execute the statement).
- Extracted a shared `getFirstKeyword` helper in `allowed-keywords.ts` (reused by both the new tool and the existing read-only classifier) and a shared `resolveBuiltinToolNaming` helper in `tool-metadata.ts` to avoid duplicating the single-vs-multi-source naming logic a third time.

## Docs

- New `docs/tools/explain-sql.mdx` page, wired into the docs sidebar (`docs/docs.json`) and the tools overview table (with a new "Default" column showing On/Opt-in per tool).
- `dbhub.toml.example` documents the opt-in `[[tools]]` entry.
- Follow-up sweep across the rest of the doc surface for stale/missing mentions:
  - README.md / docs/index.mdx: softened "just two MCP tools" (was contradicting the tool list beneath it), added `explain_sql` to the tool list and architecture diagram
  - docs/tools/custom-tools.mdx: added `explain_sql` to the built-in name-conflict list and "See Also" links
  - docs/tools/execute-sql.mdx / docs/tools/search-objects.mdx: added "See Also" cross-links to `explain_sql`
  - docs/config/toml.mdx: broadened the `[[tools]] name` field docs (previously only mentioned `execute_sql`)
  - CLAUDE.md: added `explain-sql.ts` to the `src/tools/` file tree
  - skills/dbhub/SKILL.md: documented `explain_sql` as an opt-in third tool

Known follow-up (not addressed here — functional, not doc): the Workbench UI (`frontend/src/components/views/ToolDetailView.tsx`, `Sidebar.tsx`) special-cases `execute_sql`/`search_objects` tool-type detection, so an enabled `explain_sql` tool currently renders as a generic `custom` type there instead of getting a dedicated view.

## Test plan

- [x] `pnpm test` — full suite passes (1230 tests, including new `explain-sql.test.ts`, `registry.test.ts`, and new `toml-loader.test.ts` cases)
- [x] `pnpm run build` (tsup) succeeds with no new type errors
- [x] Manually verified against a real SQLite connector: `EXPLAIN QUERY PLAN` returns a real plan, and wrapping a `DELETE` in it never executes the delete
- [ ] Manual smoke test via `--config` with `explain_sql` enabled against a live Postgres/MySQL/SQL Server source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
