### PR TITLE
feat: add opt-in health_check tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ src/
 ├── tools/               # MCP tool handlers
 │   ├── execute-sql.ts   # SQL execution handler
 │   ├── search-objects.ts  # Unified search/list with progressive disclosure
-│   └── explain-sql.ts   # Opt-in EXPLAIN plan tool (never executes the target statement)
+│   ├── explain-sql.ts   # Opt-in EXPLAIN plan tool (never executes the target statement)
+│   └── health-check.ts  # Opt-in connection pool + buffer cache metrics tool (Postgres/MySQL/MariaDB/SQL Server)
 ├── utils/               # Shared utilities
 │   ├── dsn-obfuscator.ts# DSN security
 │   ├── response-formatter.ts # Output formatting

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ DBHub implements MCP tools for database operations:
 - **[execute_sql](https://dbhub.ai/tools/execute-sql)**: Execute SQL queries with transaction support and safety controls
 - **[search_objects](https://dbhub.ai/tools/search-objects)**: Search and explore database schemas, tables, columns, indexes, and procedures with progressive disclosure
 - **[explain_sql](https://dbhub.ai/tools/explain-sql)** (opt-in): Show a query's execution plan without running it
+- **[health_check](https://dbhub.ai/tools/health-check)** (opt-in, PostgreSQL/MySQL/MariaDB/SQL Server for now): Report connection pool state and buffer cache hit ratio
 - **[Custom Tools](https://dbhub.ai/tools/custom-tools)**: Define reusable, parameterized SQL operations in your `dbhub.toml` configuration file
 
 ## Workbench

--- a/dbhub.toml.example
+++ b/dbhub.toml.example
@@ -242,6 +242,20 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 # name = "explain_sql"
 # source = "local_pg"
 
+# 'health_check' is opt-in only, like explain_sql. It reports operational
+# metrics (connection pool state, buffer cache hit ratio) for the source.
+# Currently implemented for PostgreSQL, MySQL, MariaDB, and SQL Server;
+# enabling it on other database types returns an "unsupported" error rather
+# than partial data. On MySQL/MariaDB, idle-in-transaction detection
+# additionally requires the PROCESS privilege; on SQL Server, both metrics
+# require VIEW SERVER STATE (VIEW DATABASE STATE on Azure SQL Database).
+# Without the right grant, the tool still returns what it can and adds a
+# `notes` entry explaining the reduced visibility instead of failing
+# outright. Always read-only, no readonly/max_rows options of its own.
+# [[tools]]
+# name = "health_check"
+# source = "local_pg"
+
 # ============================================================================
 # CUSTOM TOOLS (Optional)
 # ============================================================================
@@ -376,6 +390,7 @@ dsn = "postgres://postgres:postgres@localhost:5432/myapp"
 #   readonly = true    # Restrict to SELECT, SHOW, DESCRIBE, EXPLAIN (works for execute_sql and custom tools)
 #   max_rows = 1000    # Limit result set size (works for execute_sql and custom tools)
 #   explain_sql        # Opt-in tool (name = "explain_sql"); no readonly/max_rows options - always safe
+#   health_check       # Opt-in tool (name = "health_check"); PostgreSQL/MySQL/MariaDB/SQL Server for now, always safe
 #
 # Parameter Placeholders by Database:
 #   PostgreSQL:     $1, $2, $3

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -530,7 +530,7 @@ Tools define MCP tools (like `execute_sql`) with specific execution settings. To
 ### name
 
 <ParamField path="name" type="string" required>
-  **Required.** Tool name. Built-in tools are `execute_sql`, `search_objects`, and the opt-in `explain_sql` (see [explain_sql](/tools/explain-sql)); any other name defines a [custom tool](/tools/custom-tools).
+  **Required.** Tool name. Built-in tools are `execute_sql`, `search_objects`, and the opt-in `explain_sql` (see [explain_sql](/tools/explain-sql)) and `health_check` (see [health_check](/tools/health-check)); any other name defines a [custom tool](/tools/custom-tools).
 
   ```toml
   [[tools]]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,6 +27,7 @@
               "tools/execute-sql",
               "tools/search-objects",
               "tools/explain-sql",
+              "tools/health-check",
               "tools/custom-tools"
             ]
           },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -55,6 +55,7 @@ DBHub provides AI assistants with direct database access through these tools:
 - **[execute_sql](/tools/execute-sql)**: Run queries with transaction support and safety controls
 - **[search_objects](/tools/search-objects)**: Explore schemas, tables, columns, indexes, and procedures
 - **[explain_sql](/tools/explain-sql)** (opt-in): Show a query's execution plan without running it
+- **[health_check](/tools/health-check)** (opt-in): Report connection pool state and buffer cache hit ratio
 - **[Custom Tools](/tools/custom-tools)**: Define reusable, parameterized SQL operations
 
 ### Workbench
@@ -86,6 +87,7 @@ flowchart TB
             ES["execute_sql"]
             SO["search_objects"]
             EX["explain_sql (opt-in)"]
+            HC["health_check (opt-in)"]
             CT["custom tools"]
         end
     end

--- a/docs/tools/custom-tools.mdx
+++ b/docs/tools/custom-tools.mdx
@@ -275,7 +275,7 @@ Tools are validated when the server starts:
 
 - All required fields must be present
 - The specified source must exist
-- Tool names must be unique and cannot conflict with built-in tools (`execute_sql`, `search_objects`, `explain_sql`)
+- Tool names must be unique and cannot conflict with built-in tools (`execute_sql`, `search_objects`, `explain_sql`, `health_check`)
 - Parameter count must match SQL placeholders
 - Parameter types must be valid
 
@@ -328,3 +328,4 @@ Custom tools return the same response format as `execute_sql`:
 - [execute_sql](/tools/execute-sql) - Direct SQL execution tool
 - [search_objects](/tools/search-objects) - Database schema exploration tool
 - [explain_sql](/tools/explain-sql) - Query execution plan tool (opt-in)
+- [health_check](/tools/health-check) - Connection pool and buffer cache metrics tool (opt-in)

--- a/docs/tools/execute-sql.mdx
+++ b/docs/tools/execute-sql.mdx
@@ -216,4 +216,5 @@ If no `[[tools]]` entries are defined for a source, both `execute_sql` and `sear
 
 - [search_objects](/tools/search-objects) - Database schema exploration tool
 - [explain_sql](/tools/explain-sql) - Query execution plan tool (opt-in)
+- [health_check](/tools/health-check) - Connection pool and buffer cache metrics tool (opt-in)
 - [Custom Tools](/tools/custom-tools) - Reusable, parameterized SQL operations

--- a/docs/tools/health-check.mdx
+++ b/docs/tools/health-check.mdx
@@ -58,7 +58,7 @@ On MySQL, MariaDB, and SQL Server, some metrics need a privilege the connected u
     "connections": { "...": "..." },
     "buffer_cache": { "...": "..." },
     "notes": [
-      "Connected user lacks the PROCESS privilege: connection counts and active-query duration reflect only this diagnostic session, and idle-in-transaction detection is unavailable."
+      "Connected user lacks the PROCESS privilege: PROCESSLIST visibility is restricted to the connecting user's own sessions, and this diagnostic session is excluded from the count, so connection counts and active-query duration may under-report (down to 0). Idle-in-transaction detection is unavailable."
     ]
   }
 }
@@ -66,7 +66,7 @@ On MySQL, MariaDB, and SQL Server, some metrics need a privilege the connected u
 
 | Engine | Privilege required | Scope |
 | --- | --- | --- |
-| MySQL / MariaDB | `PROCESS` | Idle-in-transaction detection only; connection/buffer-cache counts are still returned (narrowed to the caller's own session without it) |
+| MySQL / MariaDB | `PROCESS` | Idle-in-transaction detection only; connection/buffer-cache counts are still returned, but without it, connection visibility is restricted to the caller's own sessions (and the diagnostic session itself is excluded), so counts may under-report down to 0 |
 | SQL Server | `VIEW SERVER STATE` (`VIEW DATABASE STATE` on Azure SQL Database) | Both connection pool and buffer cache sections |
 | PostgreSQL | None | All metrics are available to any connected user |
 

--- a/docs/tools/health-check.mdx
+++ b/docs/tools/health-check.mdx
@@ -1,0 +1,96 @@
+---
+title: "health_check"
+---
+
+Report operational health metrics for a database source: connection pool state and buffer cache hit ratio.
+
+## Features
+
+- **Connection pool state**: Total/active/idle session counts, idle-in-transaction sessions, the configured connection ceiling, and how long the longest-running query or idle-in-transaction session has been open
+- **Buffer cache hit ratio**: Percentage of reads served from cache vs disk, useful for spotting an undersized cache before it becomes a production incident
+- **Per-engine support**: Implemented for PostgreSQL, MySQL, MariaDB, and SQL Server. SQLite has no connection pool or cache-hit concept to report, so `health_check` returns an `UNSUPPORTED` error there
+- **Graceful degradation**: On MySQL/MariaDB/SQL Server, some metrics require an elevated privilege the connected user may not have. Rather than failing outright, `health_check` returns whatever it can and adds a `notes` entry explaining what's missing
+- **Opt-in only**: Not part of the default tool pair — must be explicitly enabled per source
+
+<Note>
+`health_check` is **opt-in**. Unlike `execute_sql` and `search_objects`, it is not enabled automatically when a source has no `[[tools]]` entries — add it explicitly (see [Enabling health_check](#enabling-health-check) below).
+</Note>
+
+## Usage
+
+Call the tool with no arguments — metrics are always for the source the tool instance is bound to.
+
+```json Example output (PostgreSQL)
+{
+  "success": true,
+  "data": {
+    "source_id": "production",
+    "connections": {
+      "total": 12,
+      "active": 2,
+      "idle": 9,
+      "idle_in_transaction": 1,
+      "idle_in_transaction_aborted": 0,
+      "max_connections": 100,
+      "longest_idle_in_transaction_seconds": 42.1,
+      "longest_active_query_seconds": 0.03
+    },
+    "buffer_cache": {
+      "hit_ratio_pct": 99.12,
+      "blocks_hit": 8452193,
+      "blocks_read": 74301
+    }
+  }
+}
+```
+
+`idle_in_transaction_aborted` is Postgres-specific (a failed statement inside a transaction leaves it open-but-aborted until `ROLLBACK`) and is omitted on engines with no equivalent concept.
+
+### Reduced-privilege output
+
+On MySQL, MariaDB, and SQL Server, some metrics need a privilege the connected user might not have — the tool still returns what it can and explains the gap instead of erroring:
+
+```json Example output (MySQL, without PROCESS privilege)
+{
+  "success": true,
+  "data": {
+    "source_id": "production",
+    "connections": { "...": "..." },
+    "buffer_cache": { "...": "..." },
+    "notes": [
+      "Connected user lacks the PROCESS privilege: connection counts and active-query duration reflect only this diagnostic session, and idle-in-transaction detection is unavailable."
+    ]
+  }
+}
+```
+
+| Engine | Privilege required | Scope |
+| --- | --- | --- |
+| MySQL / MariaDB | `PROCESS` | Idle-in-transaction detection only; connection/buffer-cache counts are still returned (narrowed to the caller's own session without it) |
+| SQL Server | `VIEW SERVER STATE` (`VIEW DATABASE STATE` on Azure SQL Database) | Both connection pool and buffer cache sections |
+| PostgreSQL | None | All metrics are available to any connected user |
+
+## Enabling health_check
+
+Add a `[[tools]]` entry with `name = "health_check"`. It takes no other options — no `readonly` or `max_rows` — since it's always read-only:
+
+```toml
+[[sources]]
+id = "production"
+dsn = "postgres://user:pass@localhost:5432/mydb"
+
+[[tools]]
+name = "execute_sql"
+source = "production"
+readonly = true
+
+[[tools]]
+name = "search_objects"
+source = "production"
+
+[[tools]]
+name = "health_check"
+source = "production"
+```
+
+See [Tool Configuration](/tools/overview#tool-configuration) for how `[[tools]]` entries work across multiple sources.

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -9,6 +9,7 @@ title: "Overview"
 | Execute SQL | `execute_sql` or `execute_sql_{id}` | On | Execute single or multiple SQL statements (separated by semicolons) |
 | Search Objects | `search_objects` or `search_objects_{id}` | On | Search and list database objects (schemas, tables, columns, procedures, indexes) with pattern matching and token-efficient progressive disclosure |
 | Explain SQL | `explain_sql` or `explain_sql_{id}` | Opt-in | Show the execution plan for a SQL statement without running it |
+| Health Check | `health_check` or `health_check_{id}` | Opt-in | Report connection pool state and buffer cache hit ratio (PostgreSQL, MySQL, MariaDB, SQL Server) |
 | Custom Tools | User-defined names | Opt-in | Define reusable, parameterized SQL operations in your `dbhub.toml` configuration file |
 
 ## Tool Configuration
@@ -166,6 +167,9 @@ Special characters in source IDs (hyphens, dots, etc.) are converted to undersco
   </Card>
   <Card title="Explain SQL" icon="diagram-project" href="/tools/explain-sql">
     Show a query's execution plan without running it (opt-in)
+  </Card>
+  <Card title="Health Check" icon="heart-pulse" href="/tools/health-check">
+    Report connection pool state and buffer cache hit ratio (opt-in)
   </Card>
   <Card title="Custom Tools" icon="wrench" href="/tools/custom-tools">
     Create reusable parameterized SQL operations

--- a/docs/tools/search-objects.mdx
+++ b/docs/tools/search-objects.mdx
@@ -224,4 +224,5 @@ The tool supports all three detail levels (`names`, `summary`, `full`) and works
 
 - [execute_sql](/tools/execute-sql) - Direct SQL execution tool
 - [explain_sql](/tools/explain-sql) - Query execution plan tool (opt-in)
+- [health_check](/tools/health-check) - Connection pool and buffer cache metrics tool (opt-in)
 - [Custom Tools](/tools/custom-tools) - Reusable, parameterized SQL operations

--- a/skills/dbhub/SKILL.md
+++ b/skills/dbhub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dbhub
-description: Guide for querying databases through DBHub MCP server. Use this skill whenever you need to explore database schemas, inspect tables, or run SQL queries via DBHub's MCP tools (search_objects, execute_sql, and the opt-in explain_sql). Activates on any database query task, schema exploration, data retrieval, or SQL execution through MCP — even if the user just says "check the database" or "find me some data." This skill ensures you follow the correct explore-first workflow instead of guessing table structures.
+description: Guide for querying databases through DBHub MCP server. Use this skill whenever you need to explore database schemas, inspect tables, or run SQL queries via DBHub's MCP tools (search_objects, execute_sql, and the opt-in explain_sql and health_check). Activates on any database query task, schema exploration, data retrieval, or SQL execution through MCP — even if the user just says "check the database" or "find me some data." This skill ensures you follow the correct explore-first workflow instead of guessing table structures.
 ---
 
 # DBHub Database Query Guide
@@ -9,17 +9,20 @@ When working with databases through DBHub's MCP server, always follow the **expl
 
 ## Available Tools
 
-DBHub provides two MCP tools by default, plus an opt-in third:
+DBHub provides two MCP tools by default, plus opt-in ones:
 
 | Tool | Purpose |
 |------|---------|
 | `search_objects` | Explore database structure — schemas, tables, columns, indexes, procedures, functions |
 | `execute_sql` | Run SQL statements against the database |
 | `explain_sql` (opt-in) | Show a query's execution plan without running it — only present if the source's config enables it |
+| `health_check` (opt-in) | Report connection pool state and buffer cache hit ratio — only present if the source's config enables it; PostgreSQL, MySQL, MariaDB, and SQL Server only |
 
 If multiple databases are configured, DBHub registers separate tools for each source (for example, `search_objects_prod_pg`, `execute_sql_staging_mysql`). Select the desired database by calling the correspondingly named tool.
 
 If `explain_sql` is available (check the tool list), prefer it over guessing whether a query will be efficient — it's always safe to call, even against a write-enabled or read-only source, since it never executes the statement.
+
+If `health_check` is available and a query seems slow or connections seem exhausted, call it before speculating — it reports live connection pool and cache-hit numbers instead of guessing at the cause.
 
 ## The Explore-Then-Query Workflow
 

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -2113,6 +2113,89 @@ statement = "SELECT 1"
     });
   });
 
+  describe('health_check tool configuration', () => {
+    it('should accept health_check with just name and source', () => {
+      const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+
+[[tools]]
+name = "health_check"
+source = "test_db"
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+      const result = loadTomlConfig();
+
+      expect(result?.tools).toHaveLength(1);
+      expect(result?.tools![0]).toMatchObject({
+        name: 'health_check',
+        source: 'test_db',
+      });
+    });
+
+    it('should reject health_check with description/statement/parameters', () => {
+      const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+
+[[tools]]
+name = "health_check"
+source = "test_db"
+description = "not allowed"
+statement = "SELECT 1"
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+      expect(() => loadTomlConfig()).toThrow(
+        "built-in tool 'health_check' cannot have description, statement, or parameters fields"
+      );
+    });
+
+    it('should reject health_check with readonly or max_rows', () => {
+      const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+
+[[tools]]
+name = "health_check"
+source = "test_db"
+readonly = true
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+      expect(() => loadTomlConfig()).toThrow(
+        "tool 'health_check' cannot have readonly or max_rows fields"
+      );
+    });
+
+    it('should reject a custom tool named health_check_foo (reserved naming pattern)', () => {
+      const tomlContent = `
+[[sources]]
+id = "test_db"
+dsn = "postgres://user:pass@localhost:5432/testdb"
+
+[[tools]]
+name = "health_check_foo"
+source = "test_db"
+description = "Custom tool colliding with health_check naming"
+statement = "SELECT 1"
+`;
+      fs.writeFileSync(path.join(tempDir, 'dbhub.toml'), tomlContent);
+
+      // toml-loader itself doesn't reject the naming collision (that's
+      // enforced by ToolRegistry.validateCustomTool), but it must at least
+      // parse the tool through unchanged as a non-builtin so the registry can
+      // catch it.
+      const result = loadTomlConfig();
+      expect(result?.tools).toHaveLength(1);
+      expect(result?.tools![0].name).toBe('health_check_foo');
+    });
+  });
+
   describe('environment variable interpolation', () => {
     const originalEnv = { ...process.env };
 

--- a/src/connectors/__tests__/mariadb.integration.test.ts
+++ b/src/connectors/__tests__/mariadb.integration.test.ts
@@ -196,6 +196,26 @@ describe('MariaDB Connector Integration Tests', () => {
       expect(await mariadbTest.connector.getDefaultSchema!()).toBe('testdb');
     });
 
+    it('should report connection pool state and buffer cache hit ratio via getHealthCheck', async () => {
+      const health = await mariadbTest.connector.getHealthCheck!();
+
+      expect(health.connections).toBeDefined();
+      // Without the PROCESS privilege, PROCESSLIST visibility can be
+      // restricted to the querying connection itself (excluded here via
+      // `ID <> CONNECTION_ID()`), so total may legitimately be 0.
+      expect(health.connections!.total).toBeGreaterThanOrEqual(0);
+      expect(health.connections!.maxConnections).toBeGreaterThan(0);
+      expect(health.connections!.idleInTransaction).toBeGreaterThanOrEqual(0);
+      expect(health.connections!.idleInTransactionAborted).toBeUndefined();
+
+      expect(health.bufferCache).toBeDefined();
+      expect(health.bufferCache!.blocksHit + health.bufferCache!.blocksRead).toBeGreaterThan(0);
+      if (health.bufferCache!.hitRatioPct !== null) {
+        expect(health.bufferCache!.hitRatioPct).toBeGreaterThanOrEqual(0);
+        expect(health.bufferCache!.hitRatioPct).toBeLessThanOrEqual(100);
+      }
+    });
+
     it('should execute multiple statements with native support', async () => {
       // First insert the test data
       await mariadbTest.connector.executeSQL(`

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -190,6 +190,26 @@ describe('MySQL Connector Integration Tests', () => {
       expect(await mysqlTest.connector.getDefaultSchema!()).toBe('testdb');
     });
 
+    it('should report connection pool state and buffer cache hit ratio via getHealthCheck', async () => {
+      const health = await mysqlTest.connector.getHealthCheck!();
+
+      expect(health.connections).toBeDefined();
+      // Without the PROCESS privilege, MySQL's PROCESSLIST visibility can be
+      // restricted to the querying connection itself (excluded here via
+      // `ID <> CONNECTION_ID()`), so total may legitimately be 0.
+      expect(health.connections!.total).toBeGreaterThanOrEqual(0);
+      expect(health.connections!.maxConnections).toBeGreaterThan(0);
+      expect(health.connections!.idleInTransaction).toBeGreaterThanOrEqual(0);
+      expect(health.connections!.idleInTransactionAborted).toBeUndefined();
+
+      expect(health.bufferCache).toBeDefined();
+      expect(health.bufferCache!.blocksHit + health.bufferCache!.blocksRead).toBeGreaterThan(0);
+      if (health.bufferCache!.hitRatioPct !== null) {
+        expect(health.bufferCache!.hitRatioPct).toBeGreaterThanOrEqual(0);
+        expect(health.bufferCache!.hitRatioPct).toBeLessThanOrEqual(100);
+      }
+    });
+
     it('should execute multiple statements with native support', async () => {
       // First insert the test data
       await mysqlTest.connector.executeSQL(`

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -257,6 +257,22 @@ describe('PostgreSQL Connector Integration Tests', () => {
       expect(comment).toBe('Users aged 25 or older');
     });
 
+    it('should report connection pool state and buffer cache hit ratio via getHealthCheck', async () => {
+      const health = await postgresTest.connector.getHealthCheck!();
+
+      expect(health.connections).toBeDefined();
+      expect(health.connections!.total).toBeGreaterThanOrEqual(1);
+      expect(health.connections!.maxConnections).toBeGreaterThan(0);
+      expect(health.connections!.idleInTransaction).toBeGreaterThanOrEqual(0);
+
+      expect(health.bufferCache).toBeDefined();
+      expect(health.bufferCache!.blocksHit + health.bufferCache!.blocksRead).toBeGreaterThan(0);
+      if (health.bufferCache!.hitRatioPct !== null) {
+        expect(health.bufferCache!.hitRatioPct).toBeGreaterThanOrEqual(0);
+        expect(health.bufferCache!.hitRatioPct).toBeLessThanOrEqual(100);
+      }
+    });
+
     it('should handle PostgreSQL returning clause', async () => {
       const result = await postgresTest.connector.executeSQL(
         "INSERT INTO users (name, email, age) VALUES ('Returning Test', 'returning@example.com', 40) RETURNING id, name",

--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -212,6 +212,25 @@ describe('SQL Server Connector Integration Tests', () => {
   });
 
   describe('SQL Server-specific Features', () => {
+    it('should report connection pool state and buffer cache hit ratio via getHealthCheck', async () => {
+      const health = await sqlServerTest.connector.getHealthCheck!();
+
+      // The sa test user has VIEW SERVER STATE, so both sections should be
+      // populated rather than degraded to a `notes` entry.
+      expect(health.notes).toBeUndefined();
+
+      expect(health.connections).toBeDefined();
+      expect(health.connections!.total).toBeGreaterThanOrEqual(0);
+      expect(health.connections!.idleInTransaction).toBeGreaterThanOrEqual(0);
+      expect(health.connections!.idleInTransactionAborted).toBeUndefined();
+
+      expect(health.bufferCache).toBeDefined();
+      if (health.bufferCache!.hitRatioPct !== null) {
+        expect(health.bufferCache!.hitRatioPct).toBeGreaterThanOrEqual(0);
+        expect(health.bufferCache!.hitRatioPct).toBeLessThanOrEqual(100);
+      }
+    });
+
     it('should return an execution plan for EXPLAIN <query> (SHOWPLAN_XML)', async () => {
       const result = await sqlServerTest.connector.executeSQL(
         'EXPLAIN SELECT * FROM users WHERE age > 30',

--- a/src/connectors/health-check-utils.ts
+++ b/src/connectors/health-check-utils.ts
@@ -10,9 +10,15 @@ export function toNullableNumber(value: unknown): number | null {
 /**
  * Computes a cache/buffer hit-ratio percentage (0-100, rounded to 2 decimals)
  * from logical vs physical read counts. Returns null when there's no data
- * yet (zero logical reads).
+ * yet (zero or non-finite logical reads). Clamped to [0, 100]: the two
+ * counters are read via separate, non-atomic queries, so physicalReads can
+ * momentarily exceed logicalReads under concurrent load and would otherwise
+ * produce a nonsensical negative (or >100) ratio.
  */
 export function computeHitRatioPct(logicalReads: number, physicalReads: number): number | null {
-  if (logicalReads === 0) return null;
-  return Math.round(((logicalReads - physicalReads) / logicalReads) * 10000) / 100;
+  if (!Number.isFinite(logicalReads) || !Number.isFinite(physicalReads) || logicalReads === 0) {
+    return null;
+  }
+  const pct = Math.round(((logicalReads - physicalReads) / logicalReads) * 10000) / 100;
+  return Math.min(100, Math.max(0, pct));
 }

--- a/src/connectors/health-check-utils.ts
+++ b/src/connectors/health-check-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared helpers for connector getHealthCheck() implementations.
+ */
+
+/** Converts a possibly-null/undefined driver value to a number, preserving null. */
+export function toNullableNumber(value: unknown): number | null {
+  return value === null || value === undefined ? null : Number(value);
+}
+
+/**
+ * Computes a cache/buffer hit-ratio percentage (0-100, rounded to 2 decimals)
+ * from logical vs physical read counts. Returns null when there's no data
+ * yet (zero logical reads).
+ */
+export function computeHitRatioPct(logicalReads: number, physicalReads: number): number | null {
+  if (logicalReads === 0) return null;
+  return Math.round(((logicalReads - physicalReads) / logicalReads) * 10000) / 100;
+}

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -59,6 +59,41 @@ export interface StoredProcedure {
  * Options for SQL execution
  * This interface allows passing execution-specific options to connectors
  */
+/**
+ * Connection/session pool state, as seen by the database itself (not the
+ * driver-side pool DBHub holds).
+ */
+export interface HealthCheckConnections {
+  /** Total sessions excluding this diagnostic connection itself */
+  total: number;
+  active: number;
+  idle: number;
+  idleInTransaction: number;
+  /** Sessions in Postgres's "idle in transaction (aborted)" state; omitted on engines with no equivalent concept */
+  idleInTransactionAborted?: number;
+  /** Configured connection ceiling, when the engine exposes one */
+  maxConnections: number | null;
+  /** Longest-running idle-in-transaction session, in seconds; null if none */
+  longestIdleInTransactionSeconds: number | null;
+  /** Longest-running active query, in seconds; null if none */
+  longestActiveQuerySeconds: number | null;
+}
+
+/** Buffer/page cache hit ratio for the connected database */
+export interface HealthCheckBufferCache {
+  /** Percentage of reads served from cache, 0-100; null if no reads recorded yet */
+  hitRatioPct: number | null;
+  blocksHit: number;
+  blocksRead: number;
+}
+
+export interface HealthCheckResult {
+  connections?: HealthCheckConnections;
+  bufferCache?: HealthCheckBufferCache;
+  /** Caveats about reduced visibility (e.g. a metric degraded because the connected user lacks a privilege) */
+  notes?: string[];
+}
+
 export interface ExecuteOptions {
   /** Maximum number of rows to return (applied via database-native LIMIT) */
   maxRows?: number;
@@ -265,6 +300,14 @@ export interface Connector {
 
   /** Execute a SQL query with execution options and optional parameters */
   executeSQL(sql: string, options: ExecuteOptions, parameters?: any[]): Promise<SQLResult>;
+
+  /**
+   * Get operational health metrics (connection pool state, buffer cache hit
+   * ratio). Optional — connectors that don't implement it yet are treated as
+   * unsupported by the health_check tool, which returns an explicit error
+   * rather than a partial/fabricated result.
+   */
+  getHealthCheck?(): Promise<HealthCheckResult>;
 }
 
 /**

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -10,7 +10,9 @@ import {
   StoredProcedure,
   ExecuteOptions,
   ConnectorConfig,
+  HealthCheckResult,
 } from "../interface.js";
+import { getMySQLFamilyHealthCheck } from "../mysql-family-health-check.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { requireDatabaseInDSN, MissingDatabaseError } from "../../utils/dsn-database.js";
@@ -438,6 +440,14 @@ export class MariaDBConnector implements Connector {
     } catch (error) {
       return null;
     }
+  }
+
+  async getHealthCheck(): Promise<HealthCheckResult> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+    const pool = this.pool;
+    return getMySQLFamilyHealthCheck((sql) => pool.query(sql) as Promise<any[]>);
   }
 
   async getStoredProcedures(schema?: string, routineType?: "procedure" | "function"): Promise<string[]> {

--- a/src/connectors/mysql-family-health-check.ts
+++ b/src/connectors/mysql-family-health-check.ts
@@ -54,7 +54,7 @@ export async function getMySQLFamilyHealthCheck(query: QueryRows): Promise<Healt
     longestIdleInTransactionSeconds = toNullableNumber(trxOutcome.rows[0].longest_idle_in_transaction_seconds);
   } else {
     notes.push(
-      "Connected user lacks the PROCESS privilege: connection counts and active-query duration reflect only this diagnostic session, and idle-in-transaction detection is unavailable."
+      "Connected user lacks the PROCESS privilege: PROCESSLIST visibility is restricted to the connecting user's own sessions, and this diagnostic session is excluded from the count, so connection counts and active-query duration may under-report (down to 0). Idle-in-transaction detection is unavailable."
     );
   }
 

--- a/src/connectors/mysql-family-health-check.ts
+++ b/src/connectors/mysql-family-health-check.ts
@@ -1,0 +1,87 @@
+import { HealthCheckResult } from "./interface.js";
+import { computeHitRatioPct, toNullableNumber } from "./health-check-utils.js";
+
+/**
+ * Row-array query adapter - lets MySQL (mysql2, returns [rows, fields]) and
+ * MariaDB (mariadb, returns rows directly) share one implementation despite
+ * their differing driver response shapes.
+ */
+type QueryRows = (sql: string) => Promise<any[]>;
+
+/**
+ * Shared getHealthCheck() implementation for MySQL and MariaDB - both
+ * engines expose the same information_schema/SHOW-based diagnostics.
+ */
+export async function getMySQLFamilyHealthCheck(query: QueryRows): Promise<HealthCheckResult> {
+  const [processlistRows, maxConnRows, bufferPoolRows, trxOutcome] = await Promise.all([
+    query(`
+      SELECT
+        COUNT(*) AS total,
+        SUM(CASE WHEN COMMAND != 'Sleep' THEN 1 ELSE 0 END) AS active,
+        SUM(CASE WHEN COMMAND = 'Sleep' THEN 1 ELSE 0 END) AS idle,
+        MAX(CASE WHEN COMMAND != 'Sleep' THEN TIME ELSE NULL END) AS longest_active_query_seconds
+      FROM information_schema.PROCESSLIST
+      WHERE ID <> CONNECTION_ID()
+    `),
+    query(`SHOW VARIABLES LIKE 'max_connections'`),
+    query(`
+      SHOW GLOBAL STATUS WHERE Variable_name IN ('Innodb_buffer_pool_read_requests', 'Innodb_buffer_pool_reads')
+    `),
+    // Joining PROCESSLIST against INNODB_TRX to detect idle-in-transaction
+    // sessions requires the PROCESS privilege - unlike a plain PROCESSLIST
+    // select, which silently narrows to the caller's own session instead of
+    // erroring. Run concurrently with the other queries above, but resolve
+    // rather than reject on failure so it degrades instead of failing the
+    // whole health check.
+    query(`
+      SELECT
+        COUNT(*) AS idle_in_transaction,
+        MAX(TIMESTAMPDIFF(SECOND, t.trx_started, NOW())) AS longest_idle_in_transaction_seconds
+      FROM information_schema.INNODB_TRX t
+      JOIN information_schema.PROCESSLIST p ON p.ID = t.trx_mysql_thread_id
+      WHERE p.COMMAND = 'Sleep'
+    `).then(
+      (rows) => ({ ok: true as const, rows }),
+      () => ({ ok: false as const })
+    ),
+  ]);
+
+  const notes: string[] = [];
+  let idleInTransaction = 0;
+  let longestIdleInTransactionSeconds: number | null = null;
+  if (trxOutcome.ok) {
+    idleInTransaction = Number(trxOutcome.rows[0].idle_in_transaction);
+    longestIdleInTransactionSeconds = toNullableNumber(trxOutcome.rows[0].longest_idle_in_transaction_seconds);
+  } else {
+    notes.push(
+      "Connected user lacks the PROCESS privilege: connection counts and active-query duration reflect only this diagnostic session, and idle-in-transaction detection is unavailable."
+    );
+  }
+
+  const proc = processlistRows[0];
+  const bufferPoolStats = Object.fromEntries(bufferPoolRows.map((row: any) => [row.Variable_name, row.Value]));
+  const readRequests = Number(bufferPoolStats.Innodb_buffer_pool_read_requests ?? 0);
+  const reads = Number(bufferPoolStats.Innodb_buffer_pool_reads ?? 0);
+
+  return {
+    connections: {
+      total: Number(proc.total),
+      active: Number(proc.active),
+      idle: Number(proc.idle),
+      idleInTransaction,
+      // MySQL/MariaDB's InnoDB has no equivalent of Postgres's "idle in
+      // transaction (aborted)" state - a failed statement doesn't leave the
+      // session's transaction in a distinct aborted-but-open state the way
+      // Postgres does - so idleInTransactionAborted is left undefined.
+      maxConnections: maxConnRows.length > 0 ? Number(maxConnRows[0].Value) : null,
+      longestIdleInTransactionSeconds,
+      longestActiveQuerySeconds: toNullableNumber(proc.longest_active_query_seconds),
+    },
+    bufferCache: {
+      hitRatioPct: computeHitRatioPct(readRequests, reads),
+      blocksHit: readRequests - reads,
+      blocksRead: reads,
+    },
+    ...(notes.length > 0 ? { notes } : {}),
+  };
+}

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -10,7 +10,9 @@ import {
   StoredProcedure,
   ExecuteOptions,
   ConnectorConfig,
+  HealthCheckResult,
 } from "../interface.js";
+import { getMySQLFamilyHealthCheck } from "../mysql-family-health-check.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { requireDatabaseInDSN, MissingDatabaseError } from "../../utils/dsn-database.js";
@@ -456,6 +458,17 @@ export class MySQLConnector implements Connector {
     } catch (error) {
       return null;
     }
+  }
+
+  async getHealthCheck(): Promise<HealthCheckResult> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+    const pool = this.pool;
+    return getMySQLFamilyHealthCheck(async (sql) => {
+      const [rows] = (await pool.query(sql)) as [any[], any];
+      return rows;
+    });
   }
 
   async getStoredProcedures(schema?: string, routineType?: "procedure" | "function"): Promise<string[]> {

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -14,7 +14,9 @@ import {
   StoredProcedure,
   ExecuteOptions,
   ConnectorConfig,
+  HealthCheckResult,
 } from "../interface.js";
+import { toNullableNumber } from "../health-check-utils.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
@@ -468,6 +470,68 @@ export class PostgresConnector implements Connector {
         return result.rows[0].table_comment || null;
       }
       return null;
+    } finally {
+      client.release();
+    }
+  }
+
+  async getHealthCheck(): Promise<HealthCheckResult> {
+    if (!this.pool) {
+      throw new Error("Not connected to database");
+    }
+
+    const client = await this.pool.connect();
+    try {
+      const [connectionsResult, maxConnectionsResult, bufferCacheResult] = await Promise.all([
+        client.query(`
+          SELECT
+            count(*) AS total,
+            count(*) FILTER (WHERE state = 'active') AS active,
+            count(*) FILTER (WHERE state = 'idle') AS idle,
+            count(*) FILTER (WHERE state = 'idle in transaction') AS idle_in_transaction,
+            count(*) FILTER (WHERE state = 'idle in transaction (aborted)') AS idle_in_transaction_aborted,
+            max(EXTRACT(EPOCH FROM (now() - state_change)))
+              FILTER (WHERE state = 'idle in transaction') AS longest_idle_in_transaction_seconds,
+            max(EXTRACT(EPOCH FROM (now() - query_start)))
+              FILTER (WHERE state = 'active') AS longest_active_query_seconds
+          FROM pg_stat_activity
+          WHERE pid <> pg_backend_pid()
+        `),
+        client.query(`SHOW max_connections`),
+        client.query(
+          `
+          SELECT
+            blks_hit,
+            blks_read,
+            CASE WHEN (blks_hit + blks_read) = 0 THEN NULL
+                 ELSE round(100.0 * blks_hit / (blks_hit + blks_read), 2)
+            END AS hit_ratio_pct
+          FROM pg_stat_database
+          WHERE datname = current_database()
+        `
+        ),
+      ]);
+
+      const conn = connectionsResult.rows[0];
+      const cache = bufferCacheResult.rows[0];
+
+      return {
+        connections: {
+          total: Number(conn.total),
+          active: Number(conn.active),
+          idle: Number(conn.idle),
+          idleInTransaction: Number(conn.idle_in_transaction),
+          idleInTransactionAborted: Number(conn.idle_in_transaction_aborted),
+          maxConnections: Number(maxConnectionsResult.rows[0].max_connections),
+          longestIdleInTransactionSeconds: toNullableNumber(conn.longest_idle_in_transaction_seconds),
+          longestActiveQuerySeconds: toNullableNumber(conn.longest_active_query_seconds),
+        },
+        bufferCache: {
+          hitRatioPct: toNullableNumber(cache.hit_ratio_pct),
+          blocksHit: Number(cache.blks_hit),
+          blocksRead: Number(cache.blks_read),
+        },
+      };
     } finally {
       client.release();
     }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -11,7 +11,9 @@ import {
   StoredProcedure,
   ExecuteOptions,
   ConnectorConfig,
+  HealthCheckResult,
 } from "../interface.js";
+import { computeHitRatioPct, toNullableNumber } from "../health-check-utils.js";
 import { isDriverNotInstalled } from "../../utils/module-loader.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
@@ -503,6 +505,98 @@ export class SQLServerConnector implements Connector {
     } catch (error) {
       return null;
     }
+  }
+
+  async getHealthCheck(): Promise<HealthCheckResult> {
+    if (!this.connection) {
+      throw new Error("Not connected to SQL Server database");
+    }
+
+    const notes: string[] = [];
+    const result: HealthCheckResult = {};
+
+    // sys.dm_exec_sessions/sys.dm_exec_requests require the VIEW SERVER STATE
+    // permission (VIEW DATABASE STATE on Azure SQL Database) to see anything
+    // beyond the querying session itself, and can outright deny access
+    // depending on edition/permissions. Degrade instead of failing the whole
+    // health check.
+    try {
+      const [connResult, maxConnResult] = await Promise.all([
+        this.connection.request().query(`
+          SELECT
+            COUNT(*) AS total,
+            SUM(CASE WHEN r.session_id IS NOT NULL THEN 1 ELSE 0 END) AS active,
+            SUM(CASE WHEN r.session_id IS NULL THEN 1 ELSE 0 END) AS idle,
+            SUM(CASE WHEN r.session_id IS NULL AND t.session_id IS NOT NULL THEN 1 ELSE 0 END) AS idle_in_transaction,
+            MAX(CASE WHEN r.session_id IS NULL AND t.session_id IS NOT NULL
+                  THEN DATEDIFF(SECOND, s.last_request_end_time, SYSDATETIME()) ELSE NULL END) AS longest_idle_in_transaction_seconds,
+            MAX(CASE WHEN r.session_id IS NOT NULL
+                  THEN DATEDIFF(SECOND, r.start_time, SYSDATETIME()) ELSE NULL END) AS longest_active_query_seconds
+          FROM sys.dm_exec_sessions s
+          LEFT JOIN sys.dm_exec_requests r ON r.session_id = s.session_id
+          LEFT JOIN (SELECT DISTINCT session_id FROM sys.dm_tran_session_transactions) t ON t.session_id = s.session_id
+          WHERE s.is_user_process = 1 AND s.session_id <> @@SPID
+        `),
+        this.connection.request().query(`
+          SELECT CAST(value_in_use AS INT) AS max_connections
+          FROM sys.configurations
+          WHERE name = 'user connections'
+        `),
+      ]);
+      const conn = connResult.recordset[0];
+      // 0 means "auto-configured, no fixed limit" rather than an actual cap.
+      const maxConnections =
+        maxConnResult.recordset.length > 0 && maxConnResult.recordset[0].max_connections > 0
+          ? maxConnResult.recordset[0].max_connections
+          : null;
+
+      result.connections = {
+        total: conn.total ?? 0,
+        active: conn.active ?? 0,
+        idle: conn.idle ?? 0,
+        idleInTransaction: conn.idle_in_transaction ?? 0,
+        // SQL Server has no equivalent of Postgres's "idle in transaction
+        // (aborted)" state - a failed statement doesn't leave the session's
+        // transaction in a distinct aborted-but-open state the way Postgres does.
+        maxConnections,
+        longestIdleInTransactionSeconds: toNullableNumber(conn.longest_idle_in_transaction_seconds),
+        longestActiveQuerySeconds: toNullableNumber(conn.longest_active_query_seconds),
+      };
+    } catch {
+      notes.push(
+        "Connection pool metrics unavailable: connecting user lacks the VIEW SERVER STATE permission (VIEW DATABASE STATE on Azure SQL Database)."
+      );
+    }
+
+    try {
+      const bufferResult = await this.connection.request().query(`
+        SELECT counter_name, CAST(cntr_value AS BIGINT) AS cntr_value
+        FROM sys.dm_os_performance_counters
+        WHERE object_name LIKE '%Buffer Manager%'
+          AND counter_name IN ('Page lookups/sec', 'Page reads/sec')
+      `);
+      const counters = Object.fromEntries(
+        bufferResult.recordset.map((row: any) => [row.counter_name.trim(), Number(row.cntr_value)])
+      );
+      const pageLookups = counters["Page lookups/sec"] ?? 0;
+      const pageReads = counters["Page reads/sec"] ?? 0;
+
+      result.bufferCache = {
+        hitRatioPct: computeHitRatioPct(pageLookups, pageReads),
+        blocksHit: pageLookups - pageReads,
+        blocksRead: pageReads,
+      };
+    } catch {
+      notes.push(
+        "Buffer cache metrics unavailable: connecting user lacks the VIEW SERVER STATE permission (VIEW DATABASE STATE on Azure SQL Database)."
+      );
+    }
+
+    if (notes.length > 0) {
+      result.notes = notes;
+    }
+
+    return result;
   }
 
   async getStoredProcedures(schema?: string, routineType?: "procedure" | "function"): Promise<string[]> {

--- a/src/tools/__tests__/health-check.test.ts
+++ b/src/tools/__tests__/health-check.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createHealthCheckToolHandler } from '../health-check.js';
+import { ConnectorManager } from '../../connectors/manager.js';
+import type { Connector, ConnectorType, HealthCheckResult } from '../../connectors/interface.js';
+
+vi.mock('../../connectors/manager.js');
+
+const createMockConnector = (
+  id: ConnectorType = 'postgres',
+  sourceId: string = 'default',
+  withHealthCheck = true
+): Connector => ({
+  id,
+  name: 'Mock Connector',
+  getId: () => sourceId,
+  dsnParser: {} as any,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  clone: vi.fn(),
+  getSchemas: vi.fn(),
+  getTables: vi.fn(),
+  tableExists: vi.fn(),
+  getTableSchema: vi.fn(),
+  getTableIndexes: vi.fn(),
+  getStoredProcedures: vi.fn(),
+  getStoredProcedureDetail: vi.fn(),
+  executeSQL: vi.fn(),
+  ...(withHealthCheck ? { getHealthCheck: vi.fn() } : {}),
+});
+
+const parseToolResponse = (response: any) => JSON.parse(response.content[0].text);
+
+describe('health-check tool', () => {
+  const mockGetCurrentConnector = vi.mocked(ConnectorManager.getCurrentConnector);
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns connections and buffer_cache in snake_case', async () => {
+    const mockConnector = createMockConnector('postgres', 'test_source');
+    mockGetCurrentConnector.mockReturnValue(mockConnector);
+    const health: HealthCheckResult = {
+      connections: {
+        total: 10,
+        active: 2,
+        idle: 7,
+        idleInTransaction: 1,
+        idleInTransactionAborted: 0,
+        maxConnections: 100,
+        longestIdleInTransactionSeconds: 12.5,
+        longestActiveQuerySeconds: null,
+      },
+      bufferCache: {
+        hitRatioPct: 99.1,
+        blocksHit: 1000,
+        blocksRead: 9,
+      },
+    };
+    vi.mocked(mockConnector.getHealthCheck!).mockResolvedValue(health);
+
+    const handler = createHealthCheckToolHandler('test_source');
+    const result = await handler({}, null);
+    const parsed = parseToolResponse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toEqual({
+      source_id: 'test_source',
+      connections: {
+        total: 10,
+        active: 2,
+        idle: 7,
+        idle_in_transaction: 1,
+        idle_in_transaction_aborted: 0,
+        max_connections: 100,
+        longest_idle_in_transaction_seconds: 12.5,
+        longest_active_query_seconds: null,
+      },
+      buffer_cache: {
+        hit_ratio_pct: 99.1,
+        blocks_hit: 1000,
+        blocks_read: 9,
+      },
+    });
+  });
+
+  it('returns UNSUPPORTED when the connector has no getHealthCheck implementation', async () => {
+    const mockConnector = createMockConnector('sqlite', 'test_source', false);
+    mockGetCurrentConnector.mockReturnValue(mockConnector);
+
+    const handler = createHealthCheckToolHandler('test_source');
+    const result = await handler({}, null);
+
+    expect(result.isError).toBe(true);
+    const parsed = parseToolResponse(result);
+    expect(parsed.code).toBe('UNSUPPORTED');
+  });
+
+  it('returns EXECUTION_ERROR when the connector throws', async () => {
+    const mockConnector = createMockConnector('postgres', 'test_source');
+    mockGetCurrentConnector.mockReturnValue(mockConnector);
+    vi.mocked(mockConnector.getHealthCheck!).mockRejectedValue(new Error('boom'));
+
+    const handler = createHealthCheckToolHandler('test_source');
+    const result = await handler({}, null);
+
+    expect(result.isError).toBe(true);
+    const parsed = parseToolResponse(result);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('boom');
+    expect(parsed.code).toBe('EXECUTION_ERROR');
+  });
+});

--- a/src/tools/__tests__/health-check.test.ts
+++ b/src/tools/__tests__/health-check.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createHealthCheckToolHandler } from '../health-check.js';
-import { ConnectorManager } from '../../connectors/manager.js';
-import type { Connector, ConnectorType, HealthCheckResult } from '../../connectors/interface.js';
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createHealthCheckToolHandler } from "../health-check.js";
+import { ConnectorManager } from "../../connectors/manager.js";
+import type { Connector, ConnectorType, HealthCheckResult } from "../../connectors/interface.js";
 
-vi.mock('../../connectors/manager.js');
+vi.mock("../../connectors/manager.js");
 
 const createMockConnector = (
-  id: ConnectorType = 'postgres',
-  sourceId: string = 'default',
+  id: ConnectorType = "postgres",
+  sourceId: string = "default",
   withHealthCheck = true
 ): Connector => ({
   id,
-  name: 'Mock Connector',
+  name: "Mock Connector",
   getId: () => sourceId,
   dsnParser: {} as any,
   connect: vi.fn(),
@@ -30,15 +30,15 @@ const createMockConnector = (
 
 const parseToolResponse = (response: any) => JSON.parse(response.content[0].text);
 
-describe('health-check tool', () => {
+describe("health-check tool", () => {
   const mockGetCurrentConnector = vi.mocked(ConnectorManager.getCurrentConnector);
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns connections and buffer_cache in snake_case', async () => {
-    const mockConnector = createMockConnector('postgres', 'test_source');
+  it("returns connections and buffer_cache in snake_case", async () => {
+    const mockConnector = createMockConnector("postgres", "test_source");
     mockGetCurrentConnector.mockReturnValue(mockConnector);
     const health: HealthCheckResult = {
       connections: {
@@ -59,13 +59,13 @@ describe('health-check tool', () => {
     };
     vi.mocked(mockConnector.getHealthCheck!).mockResolvedValue(health);
 
-    const handler = createHealthCheckToolHandler('test_source');
+    const handler = createHealthCheckToolHandler("test_source");
     const result = await handler({}, null);
     const parsed = parseToolResponse(result);
 
     expect(parsed.success).toBe(true);
     expect(parsed.data).toEqual({
-      source_id: 'test_source',
+      source_id: "test_source",
       connections: {
         total: 10,
         active: 2,
@@ -84,30 +84,30 @@ describe('health-check tool', () => {
     });
   });
 
-  it('returns UNSUPPORTED when the connector has no getHealthCheck implementation', async () => {
-    const mockConnector = createMockConnector('sqlite', 'test_source', false);
+  it("returns UNSUPPORTED when the connector has no getHealthCheck implementation", async () => {
+    const mockConnector = createMockConnector("sqlite", "test_source", false);
     mockGetCurrentConnector.mockReturnValue(mockConnector);
 
-    const handler = createHealthCheckToolHandler('test_source');
+    const handler = createHealthCheckToolHandler("test_source");
     const result = await handler({}, null);
 
     expect(result.isError).toBe(true);
     const parsed = parseToolResponse(result);
-    expect(parsed.code).toBe('UNSUPPORTED');
+    expect(parsed.code).toBe("UNSUPPORTED");
   });
 
-  it('returns EXECUTION_ERROR when the connector throws', async () => {
-    const mockConnector = createMockConnector('postgres', 'test_source');
+  it("returns EXECUTION_ERROR when the connector throws", async () => {
+    const mockConnector = createMockConnector("postgres", "test_source");
     mockGetCurrentConnector.mockReturnValue(mockConnector);
-    vi.mocked(mockConnector.getHealthCheck!).mockRejectedValue(new Error('boom'));
+    vi.mocked(mockConnector.getHealthCheck!).mockRejectedValue(new Error("boom"));
 
-    const handler = createHealthCheckToolHandler('test_source');
+    const handler = createHealthCheckToolHandler("test_source");
     const result = await handler({}, null);
 
     expect(result.isError).toBe(true);
     const parsed = parseToolResponse(result);
     expect(parsed.success).toBe(false);
-    expect(parsed.error).toBe('boom');
-    expect(parsed.code).toBe('EXECUTION_ERROR');
+    expect(parsed.error).toBe("boom");
+    expect(parsed.code).toBe("EXECUTION_ERROR");
   });
 });

--- a/src/tools/__tests__/registry.test.ts
+++ b/src/tools/__tests__/registry.test.ts
@@ -53,4 +53,41 @@ describe("ToolRegistry", () => {
       "conflicts with built-in tool naming pattern"
     );
   });
+
+  it("enables health_check only when explicitly configured", () => {
+    const config: TomlConfig = {
+      sources: [{ id: "db1", type: "postgres" } as any],
+      tools: [
+        { name: "execute_sql", source: "db1" },
+        { name: "health_check", source: "db1" },
+      ],
+    };
+    const registry = new ToolRegistry(config);
+
+    const enabled = registry.getEnabledToolConfigs("db1").map((t) => t.name);
+    expect(enabled).toEqual(["execute_sql", "health_check"]);
+    expect(registry.getBuiltinToolConfig("health_check", "db1")).toMatchObject({
+      name: "health_check",
+      source: "db1",
+    });
+  });
+
+  it("rejects a custom tool whose name collides with the health_check naming pattern", () => {
+    vi.mocked(ConnectorManager.getSourceConfig).mockReturnValue({ id: "db1", type: "postgres" } as any);
+    const config: TomlConfig = {
+      sources: [{ id: "db1", type: "postgres" } as any],
+      tools: [
+        {
+          name: "health_check_extra",
+          source: "db1",
+          description: "Custom tool colliding with health_check",
+          statement: "SELECT 1",
+        } as any,
+      ],
+    };
+
+    expect(() => new ToolRegistry(config)).toThrow(
+      "conflicts with built-in tool naming pattern"
+    );
+  });
 });

--- a/src/tools/builtin-tools.ts
+++ b/src/tools/builtin-tools.ts
@@ -6,9 +6,11 @@
 export const BUILTIN_TOOL_EXECUTE_SQL = "execute_sql";
 export const BUILTIN_TOOL_SEARCH_OBJECTS = "search_objects";
 export const BUILTIN_TOOL_EXPLAIN_SQL = "explain_sql";
+export const BUILTIN_TOOL_HEALTH_CHECK = "health_check";
 
 // The default pair every source gets when it has no [[tools]] entries of its
-// own. explain_sql is intentionally excluded — it's opt-in only.
+// own. explain_sql and health_check are intentionally excluded — they're
+// opt-in only.
 export const BUILTIN_TOOLS = [
   BUILTIN_TOOL_EXECUTE_SQL,
   BUILTIN_TOOL_SEARCH_OBJECTS,
@@ -20,4 +22,5 @@ export const BUILTIN_TOOLS = [
 export const ALL_BUILTIN_TOOL_NAMES = [
   ...BUILTIN_TOOLS,
   BUILTIN_TOOL_EXPLAIN_SQL,
+  BUILTIN_TOOL_HEALTH_CHECK,
 ] as const;

--- a/src/tools/health-check.ts
+++ b/src/tools/health-check.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+import { ConnectorManager } from "../connectors/manager.js";
+import { createToolSuccessResponse, createToolErrorResponse } from "../utils/response-formatter.js";
+import {
+  getEffectiveSourceId,
+  trackToolRequest,
+  tryClassifyConnectionError,
+} from "../utils/tool-handler-helpers.js";
+
+// health_check takes no input - metrics are always for the source the tool
+// instance is bound to. See execute-sql.ts for why the raw shape is exported
+// separately from the wrapped z.object().
+export const healthCheckSchema = {};
+
+export const healthCheckInputSchema = z.object(healthCheckSchema);
+
+/**
+ * Create a health_check tool handler for a specific source
+ * @param sourceId - The source ID this handler is bound to (undefined for single-source mode)
+ * @returns A handler function bound to the specified source
+ */
+export function createHealthCheckToolHandler(sourceId?: string) {
+  return async (_args: any, extra: any) => {
+    const startTime = Date.now();
+    const effectiveSourceId = getEffectiveSourceId(sourceId);
+    let success = true;
+    let errorMessage: string | undefined;
+
+    try {
+      await ConnectorManager.ensureConnected(sourceId);
+      const connector = ConnectorManager.getCurrentConnector(sourceId);
+
+      if (!connector.getHealthCheck) {
+        success = false;
+        errorMessage = `health_check is not supported for '${connector.id}' sources yet`;
+        return createToolErrorResponse(errorMessage, "UNSUPPORTED");
+      }
+
+      const health = await connector.getHealthCheck();
+
+      return createToolSuccessResponse({
+        source_id: effectiveSourceId,
+        ...(health.connections
+          ? {
+              connections: {
+                total: health.connections.total,
+                active: health.connections.active,
+                idle: health.connections.idle,
+                idle_in_transaction: health.connections.idleInTransaction,
+                ...(health.connections.idleInTransactionAborted !== undefined
+                  ? { idle_in_transaction_aborted: health.connections.idleInTransactionAborted }
+                  : {}),
+                max_connections: health.connections.maxConnections,
+                longest_idle_in_transaction_seconds: health.connections.longestIdleInTransactionSeconds,
+                longest_active_query_seconds: health.connections.longestActiveQuerySeconds,
+              },
+            }
+          : {}),
+        ...(health.bufferCache
+          ? {
+              buffer_cache: {
+                hit_ratio_pct: health.bufferCache.hitRatioPct,
+                blocks_hit: health.bufferCache.blocksHit,
+                blocks_read: health.bufferCache.blocksRead,
+              },
+            }
+          : {}),
+        ...(health.notes && health.notes.length > 0 ? { notes: health.notes } : {}),
+      });
+    } catch (error) {
+      success = false;
+      errorMessage = (error as Error).message;
+      const classified = tryClassifyConnectionError(error, sourceId, effectiveSourceId);
+      if (classified) return classified;
+      return createToolErrorResponse(errorMessage, "EXECUTION_ERROR");
+    } finally {
+      trackToolRequest(
+        {
+          sourceId: effectiveSourceId,
+          toolName: effectiveSourceId === "default" ? "health_check" : `health_check_${effectiveSourceId}`,
+          sql: "",
+        },
+        startTime,
+        extra,
+        success,
+        errorMessage
+      );
+    }
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,13 +2,24 @@ import { McpServer } from "@modelcontextprotocol/server";
 import { createExecuteSqlToolHandler, executeSqlInputSchema } from "./execute-sql.js";
 import { createSearchDatabaseObjectsToolHandler, searchDatabaseObjectsInputSchema } from "./search-objects.js";
 import { createExplainSqlToolHandler, explainSqlInputSchema } from "./explain-sql.js";
+import { createHealthCheckToolHandler, healthCheckInputSchema } from "./health-check.js";
 import { ConnectorManager } from "../connectors/manager.js";
-import { getExecuteSqlMetadata, getSearchObjectsMetadata, getExplainSqlMetadata } from "../utils/tool-metadata.js";
+import {
+  getExecuteSqlMetadata,
+  getSearchObjectsMetadata,
+  getExplainSqlMetadata,
+  getHealthCheckMetadata,
+} from "../utils/tool-metadata.js";
 import { classifySQL } from "../utils/sql-access-policy.js";
 import { createCustomToolHandler, getCustomToolInputSchema } from "./custom-tool-handler.js";
 import type { ToolConfig } from "../types/config.js";
 import { getToolRegistry } from "./registry.js";
-import { BUILTIN_TOOL_EXECUTE_SQL, BUILTIN_TOOL_SEARCH_OBJECTS, BUILTIN_TOOL_EXPLAIN_SQL } from "./builtin-tools.js";
+import {
+  BUILTIN_TOOL_EXECUTE_SQL,
+  BUILTIN_TOOL_SEARCH_OBJECTS,
+  BUILTIN_TOOL_EXPLAIN_SQL,
+  BUILTIN_TOOL_HEALTH_CHECK,
+} from "./builtin-tools.js";
 
 /**
  * Register all tool handlers with the MCP server
@@ -36,6 +47,8 @@ export function registerTools(server: McpServer): void {
         registerSearchObjectsTool(server, sourceId);
       } else if (toolConfig.name === BUILTIN_TOOL_EXPLAIN_SQL) {
         registerExplainSqlTool(server, sourceId);
+      } else if (toolConfig.name === BUILTIN_TOOL_HEALTH_CHECK) {
+        registerHealthCheckTool(server, sourceId);
       } else {
         // Custom tool
         registerCustomTool(server, sourceId, toolConfig);
@@ -105,6 +118,25 @@ function registerExplainSqlTool(
       annotations: metadata.annotations,
     },
     createExplainSqlToolHandler(sourceId)
+  );
+}
+
+/**
+ * Register health_check tool for a source
+ */
+function registerHealthCheckTool(
+  server: McpServer,
+  sourceId: string
+): void {
+  const metadata = getHealthCheckMetadata(sourceId);
+  server.registerTool(
+    metadata.name,
+    {
+      description: metadata.description,
+      inputSchema: healthCheckInputSchema,
+      annotations: metadata.annotations,
+    },
+    createHealthCheckToolHandler(sourceId)
   );
 }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -99,6 +99,14 @@ export interface ExplainSqlToolConfig {
 }
 
 /**
+ * Built-in tool configuration for health_check
+ */
+export interface HealthCheckToolConfig {
+  name: "health_check"; // Must match BUILTIN_TOOL_HEALTH_CHECK from builtin-tools.ts
+  source: string;
+}
+
+/**
  * Custom tool configuration
  */
 export interface CustomToolConfig {
@@ -118,6 +126,7 @@ export type ToolConfig =
   | ExecuteSqlToolConfig
   | SearchObjectsToolConfig
   | ExplainSqlToolConfig
+  | HealthCheckToolConfig
   | CustomToolConfig;
 
 /**

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -5,6 +5,7 @@ import { ConnectorManager } from "../connectors/manager.js";
 import { normalizeSourceId } from "./normalize-id.js";
 import { executeSqlSchema } from "../tools/execute-sql.js";
 import { explainSqlSchema } from "../tools/explain-sql.js";
+import { healthCheckSchema } from "../tools/health-check.js";
 import { getToolRegistry } from "../tools/registry.js";
 import { BUILTIN_TOOL_EXECUTE_SQL } from "../tools/builtin-tools.js";
 import type { ParameterConfig, ToolConfig } from "../types/config.js";
@@ -227,6 +228,38 @@ export function getExplainSqlMetadata(sourceId: string): ToolMetadata {
     name,
     description,
     schema: explainSqlSchema,
+    annotations,
+  };
+}
+
+/**
+ * Get health_check tool metadata for a specific source
+ * @param sourceId - The source ID to get tool metadata for
+ * @returns Tool metadata with name, description, and Zod schema
+ */
+export function getHealthCheckMetadata(sourceId: string): ToolMetadata {
+  const { dbType, isSingleSource, name, title, userDescPrefix } = resolveBuiltinToolNaming(
+    sourceId,
+    "health_check",
+    "Health Check"
+  );
+
+  const description = isSingleSource
+    ? `${userDescPrefix}Report operational health metrics (connection pool state, buffer cache hit ratio) for the ${dbType} database. Read-only, independent of the source's read/write mode.`
+    : `${userDescPrefix}Report operational health metrics (connection pool state, buffer cache hit ratio) for the '${sourceId}' ${dbType} database. Read-only, independent of the source's read/write mode.`;
+
+  const annotations = {
+    title,
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: false, // Metrics change from call to call, unlike explain_sql's plan output
+    openWorldHint: false,
+  };
+
+  return {
+    name,
+    description,
+    schema: healthCheckSchema,
     annotations,
   };
 }


### PR DESCRIPTION
## Summary

Adds a second opt-in MCP tool, `health_check` (per-source: `health_check_{source_id}`), reporting connection pool state and buffer cache hit ratio. Builds on #383's `explain_sql` work (merged), reusing the shared per-source tool naming/registration infrastructure (`resolveBuiltinToolNaming`, `ALL_BUILTIN_TOOL_NAMES`) that PR introduced. Rebased onto `main` now that #383 is merged, so this diff is scoped to just the `health_check` delta.

- Same opt-in mechanism as `explain_sql`: `[[tools]] name = "health_check"`, no `readonly`/`max_rows` options, always read-only.
- Reports connection pool state (active/idle/idle-in-transaction counts, max connections, longest-running query/idle-in-transaction session) and buffer cache hit ratio.
- Implemented for PostgreSQL, MySQL, MariaDB, and SQL Server via a new optional `getHealthCheck?()` method on the `Connector` interface. SQLite has no connection pool or cache-hit concept to report, so it returns an explicit `UNSUPPORTED` error there instead of fabricating data.
- MySQL and MariaDB share one implementation (`src/connectors/mysql-family-health-check.ts`) since both expose the same `information_schema`/`SHOW`-based diagnostics, differing only in driver response shape (mysql2 vs mariadb).
- Graceful degradation instead of hard failure: on MySQL/MariaDB, detecting idle-in-transaction sessions requires the `PROCESS` privilege; on SQL Server, both metric sections require `VIEW SERVER STATE` (`VIEW DATABASE STATE` on Azure SQL Database). Without the grant, the tool still returns what it can and adds a `notes` field explaining the gap.
- Shared numeric helpers (`toNullableNumber`, `computeHitRatioPct`) in `src/connectors/health-check-utils.ts` to avoid repeating the same null-coalescing/ratio math across four connectors.

## Docs

- New `docs/tools/health-check.mdx` page, wired into the docs sidebar and the tools overview table, following the same structure as `docs/tools/explain-sql.mdx`.
- `dbhub.toml.example` documents the opt-in `[[tools]]` entry.
- Same cross-reference sweep as #383: README.md / docs/index.mdx tool list + architecture diagram, docs/tools/custom-tools.mdx name-conflict list + See Also, docs/tools/execute-sql.mdx / search-objects.mdx See Also links, docs/config/toml.mdx `name` field docs, CLAUDE.md file tree, skills/dbhub/SKILL.md tool table + usage tip.

Known follow-up (same as #383, not addressed here — functional, not doc): the Workbench UI (`frontend/src/components/views/ToolDetailView.tsx`, `Sidebar.tsx`) special-cases `execute_sql`/`search_objects` tool-type detection, so an enabled `health_check` tool currently renders as a generic `custom` type there instead of getting a dedicated view.

## Test plan

- [x] `pnpm test` — full suite passes (1243 tests)
- [x] `pnpm exec tsc --noEmit` — no new type errors beyond pre-existing unrelated ones
- [x] Integration tests run against real Postgres/MySQL/MariaDB/SQL Server Testcontainers, including the MySQL/MariaDB degraded-privilege path (surfaced the real `PROCESS` privilege requirement) and the SQL Server fully-populated path (`sa` has `VIEW SERVER STATE`)
- [ ] Manual smoke test via `--config` with `health_check` enabled against a live Postgres/MySQL/SQL Server source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

