### PR TITLE
feat(connectors)!: return per-statement result sets, wire up frontend tabs

### DIFF
--- a/frontend/src/api/tools.ts
+++ b/frontend/src/api/tools.ts
@@ -1,6 +1,8 @@
 import { ApiError } from './errors';
 
 export interface QueryResult {
+  /** Source text of the statement that produced this result, when known. */
+  sql?: string;
   columns: string[];
   rows: any[][];
   rowCount: number;
@@ -21,17 +23,37 @@ interface McpResponse {
 interface ToolResultData {
   success: boolean;
   data: {
-    rows: Record<string, any>[];
-    count: number;
+    statements: Array<{
+      sql?: string;
+      rows: Record<string, any>[];
+      count: number;
+    }>;
     source_id: string;
   } | null;
   error: string | null;
 }
 
+function toQueryResult(statement: { sql?: string; rows: Record<string, any>[]; count: number }): QueryResult {
+  if (statement.rows.length === 0) {
+    // For INSERT/UPDATE/DELETE, rows is empty but count reflects affected rows
+    return { sql: statement.sql, columns: [], rows: [], rowCount: statement.count };
+  }
+
+  const columns = Object.keys(statement.rows[0]);
+  const rowArrays = statement.rows.map((row) => columns.map((col) => row[col]));
+
+  return { sql: statement.sql, columns, rows: rowArrays, rowCount: statement.count };
+}
+
+/**
+ * Executes a tool and returns one `QueryResult` per statement in the batch -
+ * a single SELECT (the common case) is an array of length 1, rather than
+ * different statements' rows being merged together.
+ */
 export async function executeTool(
   toolName: string,
   args: Record<string, any>
-): Promise<QueryResult> {
+): Promise<QueryResult[]> {
   const response = await fetch('/mcp', {
     method: 'POST',
     headers: {
@@ -53,7 +75,20 @@ export async function executeTool(
     throw new ApiError(`HTTP error: ${response.status}`, response.status);
   }
 
-  const mcpResponse: McpResponse = await response.json();
+  // The stateless legacy path (2025-era MCP clients) answers spec-standard
+  // SSE framing - a single "data: {...}" event per exchange - rather than a
+  // plain JSON body, even though this fetch requests both content types.
+  const text = await response.text();
+  let mcpResponse: McpResponse;
+  if (response.headers.get('content-type')?.includes('text/event-stream')) {
+    const dataLine = text.split('\n').find((line) => line.startsWith('data: '));
+    if (!dataLine) {
+      throw new ApiError('No data event in SSE response', 500);
+    }
+    mcpResponse = JSON.parse(dataLine.slice('data: '.length));
+  } else {
+    mcpResponse = JSON.parse(text);
+  }
 
   if (mcpResponse.error) {
     throw new ApiError(mcpResponse.error.message, mcpResponse.error.code);
@@ -69,22 +104,9 @@ export async function executeTool(
     throw new ApiError(toolResult.error || 'Tool execution failed', 500);
   }
 
-  if (!toolResult.data || !toolResult.data.rows) {
-    return { columns: [], rows: [], rowCount: 0 };
+  if (!toolResult.data || !toolResult.data.statements) {
+    return [{ columns: [], rows: [], rowCount: 0 }];
   }
 
-  const rows = toolResult.data.rows;
-  if (rows.length === 0) {
-    // For INSERT/UPDATE/DELETE, rows is empty but count reflects affected rows
-    return { columns: [], rows: [], rowCount: toolResult.data.count };
-  }
-
-  const columns = Object.keys(rows[0]);
-  const rowArrays = rows.map((row) => columns.map((col) => row[col]));
-
-  return {
-    columns,
-    rows: rowArrays,
-    rowCount: toolResult.data.count,
-  };
+  return toolResult.data.statements.map(toQueryResult);
 }

--- a/frontend/src/components/tool/ResultsTabs.tsx
+++ b/frontend/src/components/tool/ResultsTabs.tsx
@@ -22,6 +22,14 @@ function formatTimestamp(date: Date): string {
   });
 }
 
+function formatTabLabel(tab: ResultTab): string {
+  const time = formatTimestamp(tab.timestamp);
+  if (tab.statementTotal && tab.statementTotal > 1) {
+    return `${time} (${tab.statementIndex}/${tab.statementTotal})`;
+  }
+  return time;
+}
+
 export function ResultsTabs({
   tabs,
   activeTabId,
@@ -123,7 +131,7 @@ export function ResultsTabs({
                   : 'border-transparent text-muted-foreground hover:text-foreground'
               )}
             >
-              <span>{formatTimestamp(tab.timestamp)}</span>
+              <span>{formatTabLabel(tab)}</span>
               {tab.error && (
                 <span className="w-1.5 h-1.5 rounded-full bg-destructive" aria-label="Error" />
               )}

--- a/frontend/src/components/tool/types.ts
+++ b/frontend/src/components/tool/types.ts
@@ -7,4 +7,8 @@ export interface ResultTab {
   error: string | null;
   executedSql: string;
   executionTimeMs: number;
+  /** 1-based position of this statement within its batch, when the batch had more than one. */
+  statementIndex?: number;
+  /** Total number of statements in the batch this tab's statement belongs to. */
+  statementTotal?: number;
 }

--- a/frontend/src/components/views/ToolDetailView.tsx
+++ b/frontend/src/components/views/ToolDetailView.tsx
@@ -209,31 +209,39 @@ export default function ToolDetailView() {
     const startTime = performance.now();
 
     try {
-      let queryResult: QueryResult;
+      let queryResults: QueryResult[];
       let sqlToExecute: string;
 
       if (toolType === 'execute_sql') {
         // Get selected SQL from editor (returns selection if any, otherwise full content)
         sqlToExecute = sqlEditorRef.current?.getSelectedSql() ?? sql;
-        queryResult = await executeTool(toolName, { sql: sqlToExecute });
+        queryResults = await executeTool(toolName, { sql: sqlToExecute });
       } else {
         sqlToExecute = getSqlPreview();
-        queryResult = await executeTool(toolName, params);
+        queryResults = await executeTool(toolName, params);
       }
 
       const endTime = performance.now();
       const duration = endTime - startTime;
+      const timestamp = new Date();
+      const isBatch = queryResults.length > 1;
 
-      const newTab: ResultTab = {
+      // One tab per statement, so a multi-statement batch's results don't get
+      // collapsed into a single tab - only the first tab's time reflects the
+      // whole batch's duration, since the others didn't wait separately.
+      const newTabs: ResultTab[] = queryResults.map((result, index) => ({
         id: crypto.randomUUID(),
-        timestamp: new Date(),
-        result: queryResult,
+        // Offset timestamps so tabs from the same run sort stably and get distinct ids/keys.
+        timestamp: new Date(timestamp.getTime() + index),
+        result,
         error: null,
-        executedSql: sqlToExecute,
-        executionTimeMs: duration,
-      };
-      setResultTabs(prev => [newTab, ...prev]);
-      setActiveTabId(newTab.id);
+        executedSql: result.sql ?? sqlToExecute,
+        executionTimeMs: index === 0 ? duration : 0,
+        statementIndex: isBatch ? index + 1 : undefined,
+        statementTotal: isBatch ? queryResults.length : undefined,
+      }));
+      setResultTabs(prev => [...newTabs, ...prev]);
+      setActiveTabId(newTabs[0].id);
     } catch (err) {
       const errorTab: ResultTab = {
         id: crypto.randomUUID(),

--- a/src/__tests__/json-rpc-integration.test.ts
+++ b/src/__tests__/json-rpc-integration.test.ts
@@ -208,11 +208,13 @@ describe('JSON RPC Integration Tests', () => {
       
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data).toHaveProperty('rows');
-      expect(content.data).toHaveProperty('count');
-      expect(content.data.rows).toHaveLength(2);
-      expect(content.data.rows[0].name).toBe('John Doe');
-      expect(content.data.rows[1].name).toBe('Bob Johnson');
+      expect(content.data).toHaveProperty('resultSets');
+      expect(content.data.resultSets).toHaveLength(1);
+      expect(content.data.resultSets[0]).toHaveProperty('rows');
+      expect(content.data.resultSets[0]).toHaveProperty('count');
+      expect(content.data.resultSets[0].rows).toHaveLength(2);
+      expect(content.data.resultSets[0].rows[0].name).toBe('John Doe');
+      expect(content.data.resultSets[0].rows[1].name).toBe('Bob Johnson');
     });
 
     it('should execute a JOIN query successfully', async () => {
@@ -229,9 +231,10 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.rows).toHaveLength(2);
-      expect(content.data.rows[0].total).toBe(149.50);
-      expect(content.data.rows[1].total).toBe(99.99);
+      expect(content.data.resultSets).toHaveLength(1);
+      expect(content.data.resultSets[0].rows).toHaveLength(2);
+      expect(content.data.resultSets[0].rows[0].total).toBe(149.50);
+      expect(content.data.resultSets[0].rows[1].total).toBe(99.99);
     });
 
     it('should execute aggregate queries successfully', async () => {
@@ -249,11 +252,12 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.rows).toHaveLength(1);
-      expect(content.data.rows[0].user_count).toBe(3);
-      expect(content.data.rows[0].avg_age).toBe(30);
-      expect(content.data.rows[0].min_age).toBe(25);
-      expect(content.data.rows[0].max_age).toBe(35);
+      expect(content.data.resultSets).toHaveLength(1);
+      expect(content.data.resultSets[0].rows).toHaveLength(1);
+      expect(content.data.resultSets[0].rows[0].user_count).toBe(3);
+      expect(content.data.resultSets[0].rows[0].avg_age).toBe(30);
+      expect(content.data.resultSets[0].rows[0].min_age).toBe(25);
+      expect(content.data.resultSets[0].rows[0].max_age).toBe(35);
     });
 
     it('should handle multiple statements in a single call', async () => {
@@ -267,8 +271,13 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.rows).toHaveLength(1);
-      expect(content.data.rows[0].total_users).toBe(4);
+      // SQLite runs all write statements before read statements, so the
+      // INSERT's resultSet comes first even though it's first in source
+      // order too here; the SELECT's resultSet follows.
+      expect(content.data.resultSets).toHaveLength(2);
+      expect(content.data.resultSets[0]).toEqual({ rows: [], count: 1 });
+      expect(content.data.resultSets[1].rows).toHaveLength(1);
+      expect(content.data.resultSets[1].rows[0].total_users).toBe(4);
     });
 
     it('should handle SQLite-specific functions', async () => {
@@ -285,10 +294,11 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.rows).toHaveLength(1);
-      expect(content.data.rows[0].version).toBeDefined();
-      expect(content.data.rows[0].uppercase).toBe('HELLO WORLD');
-      expect(content.data.rows[0].str_length).toBe(11);
+      expect(content.data.resultSets).toHaveLength(1);
+      expect(content.data.resultSets[0].rows).toHaveLength(1);
+      expect(content.data.resultSets[0].rows[0].version).toBeDefined();
+      expect(content.data.resultSets[0].rows[0].uppercase).toBe('HELLO WORLD');
+      expect(content.data.resultSets[0].rows[0].str_length).toBe(11);
     });
 
     it('should return error for invalid SQL', async () => {
@@ -311,8 +321,9 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.rows).toHaveLength(0);
-      expect(content.data.count).toBe(0);
+      expect(content.data.resultSets).toHaveLength(1);
+      expect(content.data.resultSets[0].rows).toHaveLength(0);
+      expect(content.data.resultSets[0].count).toBe(0);
     });
 
     it('should work with SQLite transactions', async () => {
@@ -328,9 +339,13 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.rows).toHaveLength(1);
-      expect(content.data.rows[0].name).toBe('Transaction User');
-      expect(content.data.rows[0].age).toBe(40);
+      // SQLite runs all write statements (BEGIN TRANSACTION, INSERT, COMMIT)
+      // before the read statement (SELECT), so the SELECT's resultSet is last.
+      expect(content.data.resultSets).toHaveLength(4);
+      const selectSet = content.data.resultSets[content.data.resultSets.length - 1];
+      expect(selectSet.rows).toHaveLength(1);
+      expect(selectSet.rows[0].name).toBe('Transaction User');
+      expect(selectSet.rows[0].age).toBe(40);
     });
 
     it('should handle PRAGMA statements', async () => {
@@ -341,9 +356,10 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.rows.length).toBeGreaterThan(0);
-      expect(content.data.rows.some((row: any) => row.name === 'id')).toBe(true);
-      expect(content.data.rows.some((row: any) => row.name === 'name')).toBe(true);
+      expect(content.data.resultSets).toHaveLength(1);
+      expect(content.data.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(content.data.resultSets[0].rows.some((row: any) => row.name === 'id')).toBe(true);
+      expect(content.data.resultSets[0].rows.some((row: any) => row.name === 'name')).toBe(true);
     });
   });
 

--- a/src/__tests__/json-rpc-integration.test.ts
+++ b/src/__tests__/json-rpc-integration.test.ts
@@ -208,13 +208,13 @@ describe('JSON RPC Integration Tests', () => {
       
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data).toHaveProperty('resultSets');
-      expect(content.data.resultSets).toHaveLength(1);
-      expect(content.data.resultSets[0]).toHaveProperty('rows');
-      expect(content.data.resultSets[0]).toHaveProperty('count');
-      expect(content.data.resultSets[0].rows).toHaveLength(2);
-      expect(content.data.resultSets[0].rows[0].name).toBe('John Doe');
-      expect(content.data.resultSets[0].rows[1].name).toBe('Bob Johnson');
+      expect(content.data).toHaveProperty('statements');
+      expect(content.data.statements).toHaveLength(1);
+      expect(content.data.statements[0]).toHaveProperty('rows');
+      expect(content.data.statements[0]).toHaveProperty('count');
+      expect(content.data.statements[0].rows).toHaveLength(2);
+      expect(content.data.statements[0].rows[0].name).toBe('John Doe');
+      expect(content.data.statements[0].rows[1].name).toBe('Bob Johnson');
     });
 
     it('should execute a JOIN query successfully', async () => {
@@ -231,10 +231,10 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.resultSets).toHaveLength(1);
-      expect(content.data.resultSets[0].rows).toHaveLength(2);
-      expect(content.data.resultSets[0].rows[0].total).toBe(149.50);
-      expect(content.data.resultSets[0].rows[1].total).toBe(99.99);
+      expect(content.data.statements).toHaveLength(1);
+      expect(content.data.statements[0].rows).toHaveLength(2);
+      expect(content.data.statements[0].rows[0].total).toBe(149.50);
+      expect(content.data.statements[0].rows[1].total).toBe(99.99);
     });
 
     it('should execute aggregate queries successfully', async () => {
@@ -252,12 +252,12 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.resultSets).toHaveLength(1);
-      expect(content.data.resultSets[0].rows).toHaveLength(1);
-      expect(content.data.resultSets[0].rows[0].user_count).toBe(3);
-      expect(content.data.resultSets[0].rows[0].avg_age).toBe(30);
-      expect(content.data.resultSets[0].rows[0].min_age).toBe(25);
-      expect(content.data.resultSets[0].rows[0].max_age).toBe(35);
+      expect(content.data.statements).toHaveLength(1);
+      expect(content.data.statements[0].rows).toHaveLength(1);
+      expect(content.data.statements[0].rows[0].user_count).toBe(3);
+      expect(content.data.statements[0].rows[0].avg_age).toBe(30);
+      expect(content.data.statements[0].rows[0].min_age).toBe(25);
+      expect(content.data.statements[0].rows[0].max_age).toBe(35);
     });
 
     it('should handle multiple statements in a single call', async () => {
@@ -272,12 +272,16 @@ describe('JSON RPC Integration Tests', () => {
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
       // SQLite runs all write statements before read statements, so the
-      // INSERT's resultSet comes first even though it's first in source
-      // order too here; the SELECT's resultSet follows.
-      expect(content.data.resultSets).toHaveLength(2);
-      expect(content.data.resultSets[0]).toEqual({ rows: [], count: 1 });
-      expect(content.data.resultSets[1].rows).toHaveLength(1);
-      expect(content.data.resultSets[1].rows[0].total_users).toBe(4);
+      // INSERT's entry comes first even though it's first in source order
+      // too here; the SELECT's entry follows.
+      expect(content.data.statements).toHaveLength(2);
+      expect(content.data.statements[0]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Test User', 'test@example.com', 28)",
+        rows: [],
+        count: 1,
+      });
+      expect(content.data.statements[1].rows).toHaveLength(1);
+      expect(content.data.statements[1].rows[0].total_users).toBe(4);
     });
 
     it('should handle SQLite-specific functions', async () => {
@@ -294,11 +298,11 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.resultSets).toHaveLength(1);
-      expect(content.data.resultSets[0].rows).toHaveLength(1);
-      expect(content.data.resultSets[0].rows[0].version).toBeDefined();
-      expect(content.data.resultSets[0].rows[0].uppercase).toBe('HELLO WORLD');
-      expect(content.data.resultSets[0].rows[0].str_length).toBe(11);
+      expect(content.data.statements).toHaveLength(1);
+      expect(content.data.statements[0].rows).toHaveLength(1);
+      expect(content.data.statements[0].rows[0].version).toBeDefined();
+      expect(content.data.statements[0].rows[0].uppercase).toBe('HELLO WORLD');
+      expect(content.data.statements[0].rows[0].str_length).toBe(11);
     });
 
     it('should return error for invalid SQL', async () => {
@@ -321,9 +325,9 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.resultSets).toHaveLength(1);
-      expect(content.data.resultSets[0].rows).toHaveLength(0);
-      expect(content.data.resultSets[0].count).toBe(0);
+      expect(content.data.statements).toHaveLength(1);
+      expect(content.data.statements[0].rows).toHaveLength(0);
+      expect(content.data.statements[0].count).toBe(0);
     });
 
     it('should work with SQLite transactions', async () => {
@@ -341,8 +345,8 @@ describe('JSON RPC Integration Tests', () => {
       expect(content.success).toBe(true);
       // SQLite runs all write statements (BEGIN TRANSACTION, INSERT, COMMIT)
       // before the read statement (SELECT), so the SELECT's resultSet is last.
-      expect(content.data.resultSets).toHaveLength(4);
-      const selectSet = content.data.resultSets[content.data.resultSets.length - 1];
+      expect(content.data.statements).toHaveLength(4);
+      const selectSet = content.data.statements[content.data.statements.length - 1];
       expect(selectSet.rows).toHaveLength(1);
       expect(selectSet.rows[0].name).toBe('Transaction User');
       expect(selectSet.rows[0].age).toBe(40);
@@ -356,10 +360,10 @@ describe('JSON RPC Integration Tests', () => {
       expect(response).toHaveProperty('result');
       const content = JSON.parse(response.result.content[0].text);
       expect(content.success).toBe(true);
-      expect(content.data.resultSets).toHaveLength(1);
-      expect(content.data.resultSets[0].rows.length).toBeGreaterThan(0);
-      expect(content.data.resultSets[0].rows.some((row: any) => row.name === 'id')).toBe(true);
-      expect(content.data.resultSets[0].rows.some((row: any) => row.name === 'name')).toBe(true);
+      expect(content.data.statements).toHaveLength(1);
+      expect(content.data.statements[0].rows.length).toBeGreaterThan(0);
+      expect(content.data.statements[0].rows.some((row: any) => row.name === 'id')).toBe(true);
+      expect(content.data.statements[0].rows.some((row: any) => row.name === 'name')).toBe(true);
     });
   });
 

--- a/src/connectors/__tests__/mariadb.integration.test.ts
+++ b/src/connectors/__tests__/mariadb.integration.test.ts
@@ -55,9 +55,9 @@ class MariaDBIntegrationTest extends IntegrationTestBase<MariaDBTestContainer> {
         
         // Check SSL status - cipher should be empty when SSL is disabled
         const result = await sslDisabledConnector.executeSQL("SHOW SESSION STATUS LIKE 'Ssl_cipher'", {});
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].Variable_name).toBe('Ssl_cipher');
-        expect(result.rows[0].Value).toBe('');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].Variable_name).toBe('Ssl_cipher');
+        expect(result.resultSets[0].rows[0].Value).toBe('');
         
         await sslDisabledConnector.disconnect();
       });
@@ -82,10 +82,10 @@ class MariaDBIntegrationTest extends IntegrationTestBase<MariaDBTestContainer> {
           
           // If connection succeeds, check SSL status - cipher should be non-empty when SSL is enabled
           const result = await sslRequiredConnector.executeSQL("SHOW SESSION STATUS LIKE 'Ssl_cipher'", {});
-          expect(result.rows).toHaveLength(1);
-          expect(result.rows[0].Variable_name).toBe('Ssl_cipher');
-          expect(result.rows[0].Value).not.toBe('');
-          expect(result.rows[0].Value).toBeTruthy();
+          expect(result.resultSets[0].rows).toHaveLength(1);
+          expect(result.resultSets[0].rows[0].Variable_name).toBe('Ssl_cipher');
+          expect(result.resultSets[0].rows[0].Value).not.toBe('');
+          expect(result.resultSets[0].rows[0].Value).toBeTruthy();
           
           await sslRequiredConnector.disconnect();
         } catch (error) {
@@ -229,8 +229,8 @@ describe('MariaDB Connector Integration Tests', () => {
         {}
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(Number(result.rows[0].total)).toBe(2);
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(Number(result.resultSets[0].rows[0].total)).toBe(2);
     });
 
     it('should handle MariaDB-specific data types', async () => {
@@ -255,10 +255,10 @@ describe('MariaDB Connector Integration Tests', () => {
         {}
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].enum_val).toBe('large');
-      expect(result.rows[0].json_data).toBeDefined();
-      expect(result.rows[0].bit_val).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].enum_val).toBe('large');
+      expect(result.resultSets[0].rows[0].json_data).toBeDefined();
+      expect(result.resultSets[0].rows[0].bit_val).toBeDefined();
     });
 
     it('should handle MariaDB auto-increment properly', async () => {
@@ -269,8 +269,11 @@ describe('MariaDB Connector Integration Tests', () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.rows).toHaveLength(1);
-      expect(Number(result.rows[0].last_id)).toBeGreaterThan(0);
+      // One resultSet per statement, in source order: INSERT then SELECT.
+      expect(result.resultSets).toHaveLength(2);
+      expect(result.resultSets[0].rows).toHaveLength(0);
+      expect(result.resultSets[1].rows).toHaveLength(1);
+      expect(Number(result.resultSets[1].rows[0].last_id)).toBeGreaterThan(0);
     });
 
     it('should work with MariaDB-specific functions', async () => {
@@ -282,11 +285,11 @@ describe('MariaDB Connector Integration Tests', () => {
           NOW() as timestamp_val
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].mariadb_version).toContain('MariaDB');
-      expect(result.rows[0].current_db).toBe('testdb');
-      expect(result.rows[0].current_user_info).toBeDefined();
-      expect(result.rows[0].timestamp_val).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].mariadb_version).toContain('MariaDB');
+      expect(result.resultSets[0].rows[0].current_db).toBe('testdb');
+      expect(result.resultSets[0].rows[0].current_user_info).toBeDefined();
+      expect(result.resultSets[0].rows[0].timestamp_val).toBeDefined();
     });
 
     it('should handle MariaDB transactions correctly', async () => {
@@ -302,7 +305,7 @@ describe('MariaDB Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email LIKE 'trans%@example.com'",
         {}
       );
-      expect(Number(result.rows[0].count)).toBe(2);
+      expect(Number(result.resultSets[0].rows[0].count)).toBe(2);
     });
 
     it('should handle MariaDB rollback correctly', async () => {
@@ -311,7 +314,7 @@ describe('MariaDB Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'rollback@example.com'",
         {}
       );
-      const beforeCount = Number(beforeResult.rows[0].count);
+      const beforeCount = Number(beforeResult.resultSets[0].rows[0].count);
       
       // Test rollback
       await mariadbTest.connector.executeSQL(`
@@ -324,7 +327,7 @@ describe('MariaDB Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'rollback@example.com'",
         {}
       );
-      const afterCount = Number(afterResult.rows[0].count);
+      const afterCount = Number(afterResult.resultSets[0].rows[0].count);
       
       expect(afterCount).toBe(beforeCount);
     });
@@ -350,8 +353,8 @@ describe('MariaDB Connector Integration Tests', () => {
         AND TABLE_NAME = 'engine_test'
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].ENGINE).toBe('InnoDB');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].ENGINE).toBe('InnoDB');
     });
 
     it('should handle MariaDB virtual and computed columns', async () => {
@@ -375,9 +378,9 @@ describe('MariaDB Connector Integration Tests', () => {
         ORDER BY id
       `, {});
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0].full_name).toBe('John Doe');
-      expect(result.rows[1].full_name).toBe('Jane Smith');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0].full_name).toBe('John Doe');
+      expect(result.resultSets[0].rows[1].full_name).toBe('Jane Smith');
     });
 
     it('should handle MariaDB sequence functionality', async () => {
@@ -395,9 +398,9 @@ describe('MariaDB Connector Integration Tests', () => {
           NEXT VALUE FOR test_seq as next_val2
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(Number(result.rows[0].next_val1)).toBe(100);
-      expect(Number(result.rows[0].next_val2)).toBe(105);
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(Number(result.resultSets[0].rows[0].next_val1)).toBe(100);
+      expect(Number(result.resultSets[0].rows[0].next_val2)).toBe(105);
     });
 
     it('should respect maxRows limit for SELECT queries', async () => {
@@ -407,9 +410,9 @@ describe('MariaDB Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should respect existing LIMIT clause when lower than maxRows', async () => {
@@ -419,8 +422,8 @@ describe('MariaDB Connector Integration Tests', () => {
         { maxRows: 3 }
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
     });
 
     it('should use maxRows when existing LIMIT is higher', async () => {
@@ -430,9 +433,9 @@ describe('MariaDB Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should not affect non-SELECT queries', async () => {
@@ -442,15 +445,15 @@ describe('MariaDB Connector Integration Tests', () => {
         { maxRows: 1 }
       );
       
-      expect(insertResult.rows).toHaveLength(0); // INSERTs don't return rows by default
+      expect(insertResult.resultSets[0].rows).toHaveLength(0); // INSERTs don't return rows by default
       
       // Verify the insert worked
       const selectResult = await mariadbTest.connector.executeSQL(
         "SELECT * FROM users WHERE email = 'maxrows@mariadb.com'",
         {}
       );
-      expect(selectResult.rows).toHaveLength(1);
-      expect(selectResult.rows[0].name).toBe('MaxRows Test');
+      expect(selectResult.resultSets[0].rows).toHaveLength(1);
+      expect(selectResult.resultSets[0].rows[0].name).toBe('MaxRows Test');
     });
 
     it('should handle maxRows with complex queries', async () => {
@@ -462,10 +465,10 @@ describe('MariaDB Connector Integration Tests', () => {
         ORDER BY o.total DESC
       `, { maxRows: 2 });
       
-      expect(result.rows.length).toBeLessThanOrEqual(2);
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('total');
+      expect(result.resultSets[0].rows.length).toBeLessThanOrEqual(2);
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
     it('should handle maxRows with multiple SELECT statements', async () => {
@@ -474,13 +477,18 @@ describe('MariaDB Connector Integration Tests', () => {
         SELECT name FROM users WHERE age > 20 ORDER BY name LIMIT 10;
         SELECT name FROM users WHERE age > 25 ORDER BY name LIMIT 10;
       `, { maxRows: 1 });
-      
-      // Should return only 1 row from each SELECT statement (due to maxRows limit)
-      // MariaDB multi-statement may return more complex results, so we check that maxRows was applied
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows.length).toBeLessThanOrEqual(2); // At most 1 from each SELECT
-      if (result.rows.length > 0) {
-        expect(result.rows[0]).toHaveProperty('name');
+
+      // One resultSet per statement, in source order. Each SELECT is capped
+      // at maxRows independently, so each set has at most 1 row.
+      expect(result.resultSets).toHaveLength(2);
+      const totalRows = result.resultSets.reduce((sum, set) => sum + set.rows.length, 0);
+      expect(totalRows).toBeGreaterThan(0);
+      expect(totalRows).toBeLessThanOrEqual(2);
+      for (const set of result.resultSets) {
+        expect(set.rows.length).toBeLessThanOrEqual(1);
+        if (set.rows.length > 0) {
+          expect(set.rows[0]).toHaveProperty('name');
+        }
       }
     });
 
@@ -492,7 +500,7 @@ describe('MariaDB Connector Integration Tests', () => {
       );
       
       // Should return all users (at least the original 3 plus any added in previous tests)
-      expect(result.rows.length).toBeGreaterThanOrEqual(3);
+      expect(result.resultSets[0].rows.length).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -509,8 +517,8 @@ describe('MariaDB Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].collation).toBe('utf8mb4_unicode_ci');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].collation).toBe('utf8mb4_unicode_ci');
       } finally {
         await connector.disconnect();
       }
@@ -529,9 +537,9 @@ describe('MariaDB Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].charset).toBe('utf8mb4');
-        expect(result.rows[0].collation).toBe('utf8mb4_unicode_ci');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].charset).toBe('utf8mb4');
+        expect(result.resultSets[0].rows[0].collation).toBe('utf8mb4_unicode_ci');
       } finally {
         await connector.disconnect();
       }
@@ -556,7 +564,7 @@ describe('MariaDB Connector Integration Tests', () => {
           "SELECT COUNT(*) AS c FROM users WHERE name='hacked'",
           {}
         );
-        expect(Number(check.rows[0].c)).toBe(0);
+        expect(Number(check.resultSets[0].rows[0].c)).toBe(0);
       } finally {
         await connector.disconnect();
       }
@@ -577,7 +585,7 @@ describe('MariaDB Connector Integration Tests', () => {
           "INSERT INTO users (name, email) VALUES ('rw', 'rw@rw.com')",
           {}
         );
-        expect(insert.rowCount).toBe(1);
+        expect(insert.resultSets[0].rowCount).toBe(1);
         await connector.executeSQL("DELETE FROM users WHERE email = 'rw@rw.com'", {});
       } finally {
         await connector.disconnect();

--- a/src/connectors/__tests__/multi-sqlite-sources.integration.test.ts
+++ b/src/connectors/__tests__/multi-sqlite-sources.integration.test.ts
@@ -83,16 +83,16 @@ describe('Multiple SQLite Sources Integration Test (Issue #115)', () => {
     // Query database_a
     const connectorA = manager.getConnector('database_a');
     const resultA = await connectorA.executeSQL('SELECT COUNT(*) as count FROM employees', {});
-    expect(Number(resultA.rows[0].count)).toBe(2);
+    expect(Number(resultA.resultSets[0].rows[0].count)).toBe(2);
 
     // Query database_b
     const connectorB = manager.getConnector('database_b');
     const resultB = await connectorB.executeSQL('SELECT COUNT(*) as count FROM products', {});
-    expect(Number(resultB.rows[0].count)).toBe(3);
+    expect(Number(resultB.resultSets[0].rows[0].count)).toBe(3);
 
     // Query database_a again to ensure it's still connected to the correct database
     const resultA2 = await connectorA.executeSQL('SELECT COUNT(*) as count FROM employees', {});
-    expect(Number(resultA2.rows[0].count)).toBe(2);
+    expect(Number(resultA2.resultSets[0].rows[0].count)).toBe(2);
 
     // Verify that database_a doesn't have the products table
     await expect(
@@ -112,16 +112,16 @@ describe('Multiple SQLite Sources Integration Test (Issue #115)', () => {
     // Insert into database_a
     await connectorA.executeSQL("INSERT INTO employees (name) VALUES ('Charlie')", {});
     const resultA = await connectorA.executeSQL('SELECT COUNT(*) as count FROM employees', {});
-    expect(Number(resultA.rows[0].count)).toBe(3);
+    expect(Number(resultA.resultSets[0].rows[0].count)).toBe(3);
 
     // Insert into database_b
     await connectorB.executeSQL("INSERT INTO products (title) VALUES ('Thingamajig')", {});
     const resultB = await connectorB.executeSQL('SELECT COUNT(*) as count FROM products', {});
-    expect(Number(resultB.rows[0].count)).toBe(4);
+    expect(Number(resultB.resultSets[0].rows[0].count)).toBe(4);
 
     // Verify database_a still has 3 employees
     const resultA2 = await connectorA.executeSQL('SELECT COUNT(*) as count FROM employees', {});
-    expect(Number(resultA2.rows[0].count)).toBe(3);
+    expect(Number(resultA2.resultSets[0].rows[0].count)).toBe(3);
   });
 
   it('should throw error for non-existent source ID', () => {

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -55,9 +55,9 @@ class MySQLIntegrationTest extends IntegrationTestBase<MySQLTestContainer> {
         
         // Check SSL status - cipher should be empty when SSL is disabled
         const result = await sslDisabledConnector.executeSQL("SHOW SESSION STATUS LIKE 'Ssl_cipher'", {});
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].Variable_name).toBe('Ssl_cipher');
-        expect(result.rows[0].Value).toBe('');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].Variable_name).toBe('Ssl_cipher');
+        expect(result.resultSets[0].rows[0].Value).toBe('');
         
         await sslDisabledConnector.disconnect();
       });
@@ -76,10 +76,10 @@ class MySQLIntegrationTest extends IntegrationTestBase<MySQLTestContainer> {
           
           // If connection succeeds, check SSL status - cipher should be non-empty when SSL is enabled
           const result = await sslRequiredConnector.executeSQL("SHOW SESSION STATUS LIKE 'Ssl_cipher'", {});
-          expect(result.rows).toHaveLength(1);
-          expect(result.rows[0].Variable_name).toBe('Ssl_cipher');
-          expect(result.rows[0].Value).not.toBe('');
-          expect(result.rows[0].Value).toBeTruthy();
+          expect(result.resultSets[0].rows).toHaveLength(1);
+          expect(result.resultSets[0].rows[0].Variable_name).toBe('Ssl_cipher');
+          expect(result.resultSets[0].rows[0].Value).not.toBe('');
+          expect(result.resultSets[0].rows[0].Value).toBeTruthy();
           
           await sslRequiredConnector.disconnect();
         } catch (error) {
@@ -223,8 +223,8 @@ describe('MySQL Connector Integration Tests', () => {
         {}
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(Number(result.rows[0].total)).toBe(2);
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(Number(result.resultSets[0].rows[0].total)).toBe(2);
     });
 
     it('should handle MySQL-specific data types', async () => {
@@ -247,9 +247,9 @@ describe('MySQL Connector Integration Tests', () => {
         {}
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].enum_val).toBe('large');
-      expect(result.rows[0].json_data).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].enum_val).toBe('large');
+      expect(result.resultSets[0].rows[0].json_data).toBeDefined();
     });
 
     it('should handle MySQL auto-increment properly', async () => {
@@ -260,8 +260,11 @@ describe('MySQL Connector Integration Tests', () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.rows).toHaveLength(1);
-      expect(Number(result.rows[0].last_id)).toBeGreaterThan(0);
+      // One resultSet per statement, in source order: INSERT then SELECT.
+      expect(result.resultSets).toHaveLength(2);
+      expect(result.resultSets[0].rows).toHaveLength(0);
+      expect(result.resultSets[1].rows).toHaveLength(1);
+      expect(Number(result.resultSets[1].rows[0].last_id)).toBeGreaterThan(0);
     });
 
     it('should work with MySQL-specific functions', async () => {
@@ -273,11 +276,11 @@ describe('MySQL Connector Integration Tests', () => {
           NOW() as timestamp_val
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].mysql_version).toBeDefined();
-      expect(result.rows[0].current_db).toBe('testdb');
-      expect(result.rows[0].current_user_info).toBeDefined();
-      expect(result.rows[0].timestamp_val).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].mysql_version).toBeDefined();
+      expect(result.resultSets[0].rows[0].current_db).toBe('testdb');
+      expect(result.resultSets[0].rows[0].current_user_info).toBeDefined();
+      expect(result.resultSets[0].rows[0].timestamp_val).toBeDefined();
     });
 
     it('should handle MySQL transactions correctly', async () => {
@@ -293,7 +296,7 @@ describe('MySQL Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email LIKE 'trans%@example.com'",
         {}
       );
-      expect(Number(result.rows[0].count)).toBe(2);
+      expect(Number(result.resultSets[0].rows[0].count)).toBe(2);
     });
 
     it('should handle MySQL rollback correctly', async () => {
@@ -302,7 +305,7 @@ describe('MySQL Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'rollback@example.com'",
         {}
       );
-      const beforeCount = Number(beforeResult.rows[0].count);
+      const beforeCount = Number(beforeResult.resultSets[0].rows[0].count);
       
       // Test rollback
       await mysqlTest.connector.executeSQL(`
@@ -315,7 +318,7 @@ describe('MySQL Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'rollback@example.com'",
         {}
       );
-      const afterCount = Number(afterResult.rows[0].count);
+      const afterCount = Number(afterResult.resultSets[0].rows[0].count);
       
       expect(afterCount).toBe(beforeCount);
     });
@@ -327,9 +330,9 @@ describe('MySQL Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should respect existing LIMIT clause when lower than maxRows', async () => {
@@ -339,8 +342,8 @@ describe('MySQL Connector Integration Tests', () => {
         { maxRows: 3 }
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
     });
 
     it('should use maxRows when existing LIMIT is higher', async () => {
@@ -350,9 +353,9 @@ describe('MySQL Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should not affect non-SELECT queries', async () => {
@@ -362,15 +365,15 @@ describe('MySQL Connector Integration Tests', () => {
         { maxRows: 1 }
       );
       
-      expect(insertResult.rows).toHaveLength(0); // INSERTs don't return rows by default
+      expect(insertResult.resultSets[0].rows).toHaveLength(0); // INSERTs don't return rows by default
       
       // Verify the insert worked
       const selectResult = await mysqlTest.connector.executeSQL(
         "SELECT * FROM users WHERE email = 'maxrows@mysql.com'",
         {}
       );
-      expect(selectResult.rows).toHaveLength(1);
-      expect(selectResult.rows[0].name).toBe('MaxRows Test');
+      expect(selectResult.resultSets[0].rows).toHaveLength(1);
+      expect(selectResult.resultSets[0].rows[0].name).toBe('MaxRows Test');
     });
 
     it('should handle maxRows with complex queries', async () => {
@@ -382,10 +385,10 @@ describe('MySQL Connector Integration Tests', () => {
         ORDER BY o.total DESC
       `, { maxRows: 2 });
       
-      expect(result.rows.length).toBeLessThanOrEqual(2);
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('total');
+      expect(result.resultSets[0].rows.length).toBeLessThanOrEqual(2);
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
     it('should not apply maxRows to CTE queries (WITH clause)', async () => {
@@ -399,9 +402,9 @@ describe('MySQL Connector Integration Tests', () => {
         `, { maxRows: 2 });
         
         // Should return all rows since WITH queries are not limited
-        expect(result.rows.length).toBeGreaterThan(2);
-        expect(result.rows[0]).toHaveProperty('name');
-        expect(result.rows[0]).toHaveProperty('age');
+        expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+        expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+        expect(result.resultSets[0].rows[0]).toHaveProperty('age');
       } catch (error) {
         // Some MySQL versions might not support CTE, that's okay
         console.log('CTE not supported in this MySQL version, skipping test');
@@ -414,13 +417,18 @@ describe('MySQL Connector Integration Tests', () => {
         SELECT name FROM users WHERE age > 20 ORDER BY name LIMIT 10;
         SELECT name FROM users WHERE age > 25 ORDER BY name LIMIT 10;
       `, { maxRows: 1 });
-      
-      // Should return only 1 row from each SELECT statement (due to maxRows limit)
-      // MySQL multi-statement may return more complex results, so we check that maxRows was applied
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows.length).toBeLessThanOrEqual(2); // At most 1 from each SELECT
-      if (result.rows.length > 0) {
-        expect(result.rows[0]).toHaveProperty('name');
+
+      // One resultSet per statement, in source order. Each SELECT is capped
+      // at maxRows independently, so each set has at most 1 row.
+      expect(result.resultSets).toHaveLength(2);
+      const totalRows = result.resultSets.reduce((sum, set) => sum + set.rows.length, 0);
+      expect(totalRows).toBeGreaterThan(0);
+      expect(totalRows).toBeLessThanOrEqual(2);
+      for (const set of result.resultSets) {
+        expect(set.rows.length).toBeLessThanOrEqual(1);
+        if (set.rows.length > 0) {
+          expect(set.rows[0]).toHaveProperty('name');
+        }
       }
     });
 
@@ -432,7 +440,7 @@ describe('MySQL Connector Integration Tests', () => {
       );
 
       // Should return all users (at least the original 3 plus any added in previous tests)
-      expect(result.rows.length).toBeGreaterThanOrEqual(3);
+      expect(result.resultSets[0].rows.length).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -452,8 +460,8 @@ describe('MySQL Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        const iso = new Date(result.rows[0].dt as string | Date).toISOString();
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        const iso = new Date(result.resultSets[0].rows[0].dt as string | Date).toISOString();
         expect(iso).toBe('2025-09-28T17:31:23.000Z');
       } finally {
         await connector.disconnect();
@@ -472,8 +480,8 @@ describe('MySQL Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        const iso = new Date(result.rows[0].dt as string | Date).toISOString();
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        const iso = new Date(result.resultSets[0].rows[0].dt as string | Date).toISOString();
         expect(iso).toBe('2025-09-29T02:31:23.000Z');
       } finally {
         await connector.disconnect();
@@ -497,8 +505,8 @@ describe('MySQL Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].collation).toBe('utf8mb4_general_ci');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].collation).toBe('utf8mb4_general_ci');
       } finally {
         await connector.disconnect();
       }
@@ -516,8 +524,8 @@ describe('MySQL Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].collation).toBe('utf8mb4_0900_ai_ci');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].collation).toBe('utf8mb4_0900_ai_ci');
       } finally {
         await connector.disconnect();
       }
@@ -536,9 +544,9 @@ describe('MySQL Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].charset).toBe('utf8mb4');
-        expect(result.rows[0].collation).toBe('utf8mb4_0900_ai_ci');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].charset).toBe('utf8mb4');
+        expect(result.resultSets[0].rows[0].collation).toBe('utf8mb4_0900_ai_ci');
       } finally {
         await connector.disconnect();
       }
@@ -566,7 +574,7 @@ describe('MySQL Connector Integration Tests', () => {
           "SELECT COUNT(*) AS c FROM users WHERE name='hacked'",
           {}
         );
-        expect(Number(check.rows[0].c)).toBe(0);
+        expect(Number(check.resultSets[0].rows[0].c)).toBe(0);
       } finally {
         await connector.disconnect();
       }
@@ -588,7 +596,7 @@ describe('MySQL Connector Integration Tests', () => {
           "INSERT INTO users (name, email) VALUES ('rw', 'rw@rw.com')",
           {}
         );
-        expect(insert.rowCount).toBe(1);
+        expect(insert.resultSets[0].rowCount).toBe(1);
         await connector.executeSQL("DELETE FROM users WHERE email = 'rw@rw.com'", {});
       } finally {
         await connector.disconnect();

--- a/src/connectors/__tests__/postgres-ssh.integration.test.ts
+++ b/src/connectors/__tests__/postgres-ssh.integration.test.ts
@@ -78,8 +78,8 @@ describe('PostgreSQL SSH Tunnel Simple Integration Tests', () => {
       // Test that connection works
       const connector = manager.getConnector();
       const result = await connector.executeSQL('SELECT 1 as test', {});
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].test).toBe(1);
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].test).toBe(1);
 
       await manager.disconnect();
     });

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -222,8 +222,16 @@ describe('PostgreSQL Connector Integration Tests', () => {
       `, {});
 
       expect(result.resultSets).toHaveLength(3);
-      expect(result.resultSets[0]).toEqual({ rows: [], rowCount: 1 });
-      expect(result.resultSets[1]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[0]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Multi User 1', 'multi1@example.com', 30)",
+        rows: [],
+        rowCount: 1,
+      });
+      expect(result.resultSets[1]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Multi User 2', 'multi2@example.com', 35)",
+        rows: [],
+        rowCount: 1,
+      });
       expect(result.resultSets[2].rows).toHaveLength(1);
       expect(result.resultSets[2].rows[0].total).toBe('2');
     });
@@ -477,11 +485,19 @@ describe('PostgreSQL Connector Integration Tests', () => {
 
       // One resultSet per statement, in source order: INSERT, SELECT, INSERT.
       expect(result.resultSets).toHaveLength(3);
-      expect(result.resultSets[0]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[0]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Multi Test 1', 'multi1@test.com', 30)",
+        rows: [],
+        rowCount: 1,
+      });
       // Should return only 1 row from the SELECT statement
       expect(result.resultSets[1].rows).toHaveLength(1);
       expect(result.resultSets[1].rows[0]).toHaveProperty('name');
-      expect(result.resultSets[2]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[2]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Multi Test 2', 'multi2@test.com', 35)",
+        rows: [],
+        rowCount: 1,
+      });
     });
 
     it('should handle maxRows with PostgreSQL window functions', async () => {

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -59,8 +59,8 @@ class PostgreSQLIntegrationTest extends IntegrationTestBase<PostgreSQLTestContai
         
         // Check SSL status - should be disabled (false)
         const result = await sslDisabledConnector.executeSQL('SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()', {});
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].ssl).toBe(false);
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].ssl).toBe(false);
         
         await sslDisabledConnector.disconnect();
       });
@@ -79,8 +79,8 @@ class PostgreSQLIntegrationTest extends IntegrationTestBase<PostgreSQLTestContai
           
           // If connection succeeds, check SSL status - should be enabled (true)
           const result = await sslRequiredConnector.executeSQL('SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()', {});
-          expect(result.rows).toHaveLength(1);
-          expect(result.rows[0].ssl).toBe(true);
+          expect(result.resultSets[0].rows).toHaveLength(1);
+          expect(result.resultSets[0].rows[0].ssl).toBe(true);
           
           await sslRequiredConnector.disconnect();
         } catch (error) {
@@ -220,9 +220,12 @@ describe('PostgreSQL Connector Integration Tests', () => {
         INSERT INTO users (name, email, age) VALUES ('Multi User 2', 'multi2@example.com', 35);
         SELECT COUNT(*) as total FROM users WHERE email LIKE 'multi%';
       `, {});
-      
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].total).toBe('2');
+
+      expect(result.resultSets).toHaveLength(3);
+      expect(result.resultSets[0]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[1]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[2].rows).toHaveLength(1);
+      expect(result.resultSets[2].rows[0].total).toBe('2');
     });
 
     it('should handle PostgreSQL-specific data types', async () => {
@@ -246,10 +249,10 @@ describe('PostgreSQL Connector Integration Tests', () => {
         {}
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].json_data).toBeDefined();
-      expect(result.rows[0].uuid_val).toBeDefined();
-      expect(result.rows[0].array_val).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].json_data).toBeDefined();
+      expect(result.resultSets[0].rows[0].uuid_val).toBeDefined();
+      expect(result.resultSets[0].rows[0].array_val).toBeDefined();
     });
 
     it('should return comment for views via getTableComment', async () => {
@@ -279,9 +282,9 @@ describe('PostgreSQL Connector Integration Tests', () => {
         {}
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].id).toBeDefined();
-      expect(result.rows[0].name).toBe('Returning Test');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].id).toBeDefined();
+      expect(result.resultSets[0].rows[0].name).toBe('Returning Test');
     });
 
     it('should work with PostgreSQL-specific functions', async () => {
@@ -294,12 +297,12 @@ describe('PostgreSQL Connector Integration Tests', () => {
           gen_random_uuid() as random_uuid
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].postgres_version).toContain('PostgreSQL');
-      expect(result.rows[0].current_db).toBe('testdb');
-      expect(result.rows[0].current_user).toBeDefined();
-      expect(result.rows[0].current_time).toBeDefined();
-      expect(result.rows[0].random_uuid).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].postgres_version).toContain('PostgreSQL');
+      expect(result.resultSets[0].rows[0].current_db).toBe('testdb');
+      expect(result.resultSets[0].rows[0].current_user).toBeDefined();
+      expect(result.resultSets[0].rows[0].current_time).toBeDefined();
+      expect(result.resultSets[0].rows[0].random_uuid).toBeDefined();
     });
 
     it('should handle PostgreSQL transactions correctly', async () => {
@@ -318,7 +321,7 @@ describe('PostgreSQL Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'trans@example.com'",
         {}
       );
-      expect(result.rows[0].count).toBe('0');
+      expect(result.resultSets[0].rows[0].count).toBe('0');
     });
 
     it('should handle PostgreSQL window functions', async () => {
@@ -333,9 +336,9 @@ describe('PostgreSQL Connector Integration Tests', () => {
         ORDER BY age DESC
       `, {});
       
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('age_rank');
-      expect(result.rows[0]).toHaveProperty('avg_age');
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('age_rank');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('avg_age');
     });
 
     it('should handle PostgreSQL arrays and JSON operations', async () => {
@@ -361,9 +364,9 @@ describe('PostgreSQL Connector Integration Tests', () => {
         WHERE data @> '{"tags": ["admin"]}'
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].name).toBe('John');
-      expect(result.rows[0].theme).toBe('dark');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].name).toBe('John');
+      expect(result.resultSets[0].rows[0].theme).toBe('dark');
     });
 
     it('should respect maxRows limit for SELECT queries', async () => {
@@ -373,9 +376,9 @@ describe('PostgreSQL Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should respect existing LIMIT clause when lower than maxRows', async () => {
@@ -385,8 +388,8 @@ describe('PostgreSQL Connector Integration Tests', () => {
         { maxRows: 3 }
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
     });
 
     it('should use maxRows when existing LIMIT is higher', async () => {
@@ -396,9 +399,9 @@ describe('PostgreSQL Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should not affect non-SELECT queries', async () => {
@@ -408,15 +411,15 @@ describe('PostgreSQL Connector Integration Tests', () => {
         { maxRows: 1 }
       );
       
-      expect(insertResult.rows).toHaveLength(0); // INSERTs don't return rows by default
+      expect(insertResult.resultSets[0].rows).toHaveLength(0); // INSERTs don't return rows by default
       
       // Verify the insert worked
       const selectResult = await postgresTest.connector.executeSQL(
         "SELECT * FROM users WHERE email = 'maxrows@example.com'",
         {}
       );
-      expect(selectResult.rows).toHaveLength(1);
-      expect(selectResult.rows[0].name).toBe('MaxRows Test');
+      expect(selectResult.resultSets[0].rows).toHaveLength(1);
+      expect(selectResult.resultSets[0].rows[0].name).toBe('MaxRows Test');
     });
 
     it('should handle maxRows with RETURNING clause', async () => {
@@ -427,11 +430,11 @@ describe('PostgreSQL Connector Integration Tests', () => {
       );
       
       // INSERT...RETURNING returns all inserted rows regardless of maxRows setting
-      expect(insertResult.rows).toHaveLength(2);
-      expect(insertResult.rows[0]).toHaveProperty('id');
-      expect(insertResult.rows[0]).toHaveProperty('name');
-      expect(insertResult.rows[1]).toHaveProperty('id');
-      expect(insertResult.rows[1]).toHaveProperty('name');
+      expect(insertResult.resultSets[0].rows).toHaveLength(2);
+      expect(insertResult.resultSets[0].rows[0]).toHaveProperty('id');
+      expect(insertResult.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(insertResult.resultSets[0].rows[1]).toHaveProperty('id');
+      expect(insertResult.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should handle maxRows with complex queries', async () => {
@@ -443,10 +446,10 @@ describe('PostgreSQL Connector Integration Tests', () => {
         ORDER BY o.total DESC
       `, { maxRows: 2 });
       
-      expect(result.rows.length).toBeLessThanOrEqual(2);
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('total');
+      expect(result.resultSets[0].rows.length).toBeLessThanOrEqual(2);
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
     it('should not apply maxRows to CTE queries (WITH clause)', async () => {
@@ -459,9 +462,9 @@ describe('PostgreSQL Connector Integration Tests', () => {
       `, { maxRows: 2 });
       
       // Should return all rows since WITH queries are not limited anymore
-      expect(result.rows.length).toBeGreaterThan(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('age');
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('age');
     });
 
     it('should handle maxRows in multi-statement execution with transactions', async () => {
@@ -471,10 +474,14 @@ describe('PostgreSQL Connector Integration Tests', () => {
         SELECT name FROM users WHERE email LIKE '%@test.com' ORDER BY name;
         INSERT INTO users (name, email, age) VALUES ('Multi Test 2', 'multi2@test.com', 35);
       `, { maxRows: 1 });
-      
+
+      // One resultSet per statement, in source order: INSERT, SELECT, INSERT.
+      expect(result.resultSets).toHaveLength(3);
+      expect(result.resultSets[0]).toEqual({ rows: [], rowCount: 1 });
       // Should return only 1 row from the SELECT statement
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0]).toHaveProperty('name');
+      expect(result.resultSets[1].rows).toHaveLength(1);
+      expect(result.resultSets[1].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[2]).toEqual({ rows: [], rowCount: 1 });
     });
 
     it('should handle maxRows with PostgreSQL window functions', async () => {
@@ -490,10 +497,10 @@ describe('PostgreSQL Connector Integration Tests', () => {
         ORDER BY age DESC
       `, { maxRows: 2 });
       
-      expect(result.rows.length).toBeLessThanOrEqual(2);
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('age_rank');
-      expect(result.rows[0]).toHaveProperty('avg_age');
+      expect(result.resultSets[0].rows.length).toBeLessThanOrEqual(2);
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('age_rank');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('avg_age');
     });
 
     it('should ignore maxRows when not specified', async () => {
@@ -504,7 +511,7 @@ describe('PostgreSQL Connector Integration Tests', () => {
       );
 
       // Should return at least the original 3 users plus any added in previous tests
-      expect(result.rows.length).toBeGreaterThanOrEqual(3);
+      expect(result.resultSets[0].rows.length).toBeGreaterThanOrEqual(3);
     });
 
   });
@@ -523,8 +530,8 @@ describe('PostgreSQL Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].default_transaction_read_only).toBe('on');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].default_transaction_read_only).toBe('on');
       } finally {
         await readonlyConnector.disconnect();
       }
@@ -542,8 +549,8 @@ describe('PostgreSQL Connector Integration Tests', () => {
           {}
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].name).toBe('John Doe');
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].name).toBe('John Doe');
       } finally {
         await readonlyConnector.disconnect();
       }
@@ -597,7 +604,7 @@ describe('PostgreSQL Connector Integration Tests', () => {
           'SHOW default_transaction_read_only',
           {}
         );
-        expect(showResult.rows[0].default_transaction_read_only).toBe('off');
+        expect(showResult.resultSets[0].rows[0].default_transaction_read_only).toBe('off');
 
         // Should be able to write data
         const insertResult = await normalConnector.executeSQL(
@@ -605,8 +612,8 @@ describe('PostgreSQL Connector Integration Tests', () => {
           {}
         );
 
-        expect(insertResult.rows).toHaveLength(1);
-        expect(insertResult.rows[0].id).toBeDefined();
+        expect(insertResult.resultSets[0].rows).toHaveLength(1);
+        expect(insertResult.resultSets[0].rows[0].id).toBeDefined();
       } finally {
         await normalConnector.disconnect();
       }
@@ -667,7 +674,7 @@ describe('PostgreSQL Connector Integration Tests', () => {
           "INSERT INTO users (name, email) VALUES ('rw', 'rw@rw.com') RETURNING id",
           {}
         );
-        expect(insert.rows).toHaveLength(1);
+        expect(insert.resultSets[0].rows).toHaveLength(1);
 
         await connector.executeSQL("DELETE FROM users WHERE email = 'rw@rw.com'", {});
       } finally {
@@ -687,7 +694,7 @@ describe('PostgreSQL Connector Integration Tests', () => {
 
         // Session search_path should be set
         const result = await connector.executeSQL('SHOW search_path', {});
-        expect(result.rows[0].search_path).toContain('test_schema');
+        expect(result.resultSets[0].rows[0].search_path).toContain('test_schema');
 
         // Discovery defaults to test_schema (first in search_path)
         const tables = await connector.getTables();
@@ -700,7 +707,7 @@ describe('PostgreSQL Connector Integration Tests', () => {
 
         // SQL resolves unqualified names via search_path
         const sqlResult = await connector.executeSQL('SELECT * FROM products', {});
-        expect(sqlResult.rows.length).toBeGreaterThan(0);
+        expect(sqlResult.resultSets[0].rows.length).toBeGreaterThan(0);
       } finally {
         await connector.disconnect();
       }
@@ -721,8 +728,8 @@ describe('PostgreSQL Connector Integration Tests', () => {
 
         // SQL resolves unqualified names via quoted search_path
         const result = await connector.executeSQL('SELECT * FROM items', {});
-        expect(result.rows.length).toBeGreaterThan(0);
-        expect(result.rows[0]).toHaveProperty('label');
+        expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+        expect(result.resultSets[0].rows[0]).toHaveProperty('label');
       } finally {
         await connector.disconnect();
       }

--- a/src/connectors/__tests__/shared/integration-test-base.ts
+++ b/src/connectors/__tests__/shared/integration-test-base.ts
@@ -161,8 +161,8 @@ export abstract class IntegrationTestBase<TContainer extends TestContainer> {
     describe('SQL Execution', () => {
       it('should execute simple SELECT query', async () => {
         const result = await this.connector.executeSQL('SELECT COUNT(*) as count FROM users', {});
-        expect(result.rows).toHaveLength(1);
-        expect(Number(result.rows[0].count)).toBeGreaterThanOrEqual(3);
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(Number(result.resultSets[0].rows[0].count)).toBeGreaterThanOrEqual(3);
       });
 
       it('should execute INSERT and SELECT', async () => {
@@ -170,13 +170,13 @@ export abstract class IntegrationTestBase<TContainer extends TestContainer> {
           "INSERT INTO users (name, email, age) VALUES ('Test User', 'test@example.com', 25)", {}
         );
         expect(insertResult).toBeDefined();
-        
+
         const selectResult = await this.connector.executeSQL(
           "SELECT * FROM users WHERE email = 'test@example.com'", {}
         );
-        expect(selectResult.rows).toHaveLength(1);
-        expect(selectResult.rows[0].name).toBe('Test User');
-        expect(Number(selectResult.rows[0].age)).toBe(25);
+        expect(selectResult.resultSets[0].rows).toHaveLength(1);
+        expect(selectResult.resultSets[0].rows[0].name).toBe('Test User');
+        expect(Number(selectResult.resultSets[0].rows[0].age)).toBe(25);
       });
 
       it('should handle complex queries with joins', async () => {
@@ -189,9 +189,9 @@ export abstract class IntegrationTestBase<TContainer extends TestContainer> {
           ORDER BY order_count DESC
         `, {});
         
-        expect(result.rows.length).toBeGreaterThan(0);
-        expect(result.rows[0]).toHaveProperty('name');
-        expect(result.rows[0]).toHaveProperty('order_count');
+        expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+        expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+        expect(result.resultSets[0].rows[0]).toHaveProperty('order_count');
       });
     });
   }

--- a/src/connectors/__tests__/sqlite.integration.test.ts
+++ b/src/connectors/__tests__/sqlite.integration.test.ts
@@ -255,8 +255,16 @@ describe('SQLite Connector Integration Tests', () => {
       // Two writes then one read, matching both source order and SQLite's
       // writes-then-reads execution order here.
       expect(result.resultSets).toHaveLength(3);
-      expect(result.resultSets[0]).toEqual({ rows: [], rowCount: 1 });
-      expect(result.resultSets[1]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[0]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Multi User 1', 'multi1@example.com', 30)",
+        rows: [],
+        rowCount: 1,
+      });
+      expect(result.resultSets[1]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Multi User 2', 'multi2@example.com', 35)",
+        rows: [],
+        rowCount: 1,
+      });
       expect(result.resultSets[2].rows).toHaveLength(1);
       expect(Number(result.resultSets[2].rows[0].total)).toBe(2);
     });
@@ -400,8 +408,16 @@ describe('SQLite Connector Integration Tests', () => {
       // not the source order [INSERT, SELECT, INSERT]. Both inserts have
       // already run by the time the SELECT executes.
       expect(result.resultSets).toHaveLength(3);
-      expect(result.resultSets[0]).toEqual({ rows: [], rowCount: 1 });
-      expect(result.resultSets[1]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[0]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Multi Test 1', 'multi1@test.com', 30)",
+        rows: [],
+        rowCount: 1,
+      });
+      expect(result.resultSets[1]).toEqual({
+        sql: "INSERT INTO users (name, email, age) VALUES ('Multi Test 2', 'multi2@test.com', 35)",
+        rows: [],
+        rowCount: 1,
+      });
       // Should return only 1 row from the SELECT statement
       expect(result.resultSets[2].rows).toHaveLength(1);
       expect(result.resultSets[2].rows[0].name).toBe('Multi Test 1');

--- a/src/connectors/__tests__/sqlite.integration.test.ts
+++ b/src/connectors/__tests__/sqlite.integration.test.ts
@@ -130,11 +130,11 @@ describe('SQLite Connector Integration Tests', () => {
         'SELECT * FROM types_test ORDER BY id DESC LIMIT 1', {}
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].text_val).toBe('test string');
-      expect(result.rows[0].int_val).toBe(BigInt(42));
-      expect(result.rows[0].real_val).toBe(3.14159);
-      expect(result.rows[0].null_val).toBeNull();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].text_val).toBe('test string');
+      expect(result.resultSets[0].rows[0].int_val).toBe(BigInt(42));
+      expect(result.resultSets[0].rows[0].real_val).toBe(3.14159);
+      expect(result.resultSets[0].rows[0].null_val).toBeNull();
     });
 
     it('should work with SQLite-specific functions', async () => {
@@ -147,12 +147,12 @@ describe('SQLite Connector Integration Tests', () => {
           length('test string') as string_length
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].sqlite_version).toBeDefined();
-      expect(result.rows[0].current_time).toBeDefined();
-      expect(result.rows[0].random_hex).toBeDefined();
-      expect(result.rows[0].uppercase_text).toBe('HELLO WORLD');
-      expect(result.rows[0].string_length).toBe(BigInt(11));
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].sqlite_version).toBeDefined();
+      expect(result.resultSets[0].rows[0].current_time).toBeDefined();
+      expect(result.resultSets[0].rows[0].random_hex).toBeDefined();
+      expect(result.resultSets[0].rows[0].uppercase_text).toBe('HELLO WORLD');
+      expect(result.resultSets[0].rows[0].string_length).toBe(BigInt(11));
     });
 
     it('should handle SQLite transactions correctly', async () => {
@@ -167,7 +167,7 @@ describe('SQLite Connector Integration Tests', () => {
       const successResult = await sqliteTest.connector.executeSQL(
         "SELECT COUNT(*) as count FROM users WHERE email LIKE 'trans%@example.com'", {}
       );
-      expect(Number(successResult.rows[0].count)).toBe(2);
+      expect(Number(successResult.resultSets[0].rows[0].count)).toBe(2);
 
       // Test manual rollback
       await sqliteTest.connector.executeSQL(`
@@ -180,7 +180,7 @@ describe('SQLite Connector Integration Tests', () => {
       const rollbackResult = await sqliteTest.connector.executeSQL(
         "SELECT COUNT(*) as count FROM users WHERE email LIKE 'trans%@example.com'", {}
       );
-      expect(Number(rollbackResult.rows[0].count)).toBe(2);
+      expect(Number(rollbackResult.resultSets[0].rows[0].count)).toBe(2);
     });
 
     it('should handle SQLite pragma statements', async () => {
@@ -188,10 +188,10 @@ describe('SQLite Connector Integration Tests', () => {
         PRAGMA table_info(users);
       `, {});
       
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows.some(row => row.name === 'id')).toBe(true);
-      expect(result.rows.some(row => row.name === 'name')).toBe(true);
-      expect(result.rows.some(row => row.name === 'email')).toBe(true);
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows.some(row => row.name === 'id')).toBe(true);
+      expect(result.resultSets[0].rows.some(row => row.name === 'name')).toBe(true);
+      expect(result.resultSets[0].rows.some(row => row.name === 'email')).toBe(true);
     });
 
     it('should support SQLite window functions', async () => {
@@ -206,9 +206,9 @@ describe('SQLite Connector Integration Tests', () => {
         ORDER BY age DESC
       `, {});
       
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('age_rank');
-      expect(result.rows[0]).toHaveProperty('avg_age');
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('age_rank');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('avg_age');
     });
 
     it('should handle SQLite JSON functions (if available)', async () => {
@@ -236,9 +236,9 @@ describe('SQLite Connector Integration Tests', () => {
           WHERE json_extract(data, '$.age') > 27
         `, {});
         
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].name).toBe('John');
-        expect(Number(result.rows[0].age)).toBe(30);
+        expect(result.resultSets[0].rows).toHaveLength(1);
+        expect(result.resultSets[0].rows[0].name).toBe('John');
+        expect(Number(result.resultSets[0].rows[0].age)).toBe(30);
       } catch (error) {
         // JSON functions not available in this SQLite version, skip this test
         console.log('JSON functions not available in this SQLite version, skipping JSON test');
@@ -251,9 +251,14 @@ describe('SQLite Connector Integration Tests', () => {
         INSERT INTO users (name, email, age) VALUES ('Multi User 2', 'multi2@example.com', 35);
         SELECT COUNT(*) as total FROM users WHERE email LIKE 'multi%';
       `, {});
-      
-      expect(result.rows).toHaveLength(1);
-      expect(Number(result.rows[0].total)).toBe(2);
+
+      // Two writes then one read, matching both source order and SQLite's
+      // writes-then-reads execution order here.
+      expect(result.resultSets).toHaveLength(3);
+      expect(result.resultSets[0]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[1]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[2].rows).toHaveLength(1);
+      expect(Number(result.resultSets[2].rows[0].total)).toBe(2);
     });
 
     it('should handle SQLite foreign key constraints', async () => {
@@ -270,7 +275,7 @@ describe('SQLite Connector Integration Tests', () => {
       const result = await sqliteTest.connector.executeSQL(
         'SELECT COUNT(*) as count FROM orders WHERE total = 200.00', {}
       );
-      expect(Number(result.rows[0].count)).toBe(1);
+      expect(Number(result.resultSets[0].rows[0].count)).toBe(1);
     });
 
     it('should work with SQLite virtual tables (FTS)', async () => {
@@ -291,8 +296,8 @@ describe('SQLite Connector Integration Tests', () => {
           SELECT title FROM docs_fts WHERE docs_fts MATCH 'content' ORDER BY title
         `, {});
         
-        expect(result.rows.length).toBeGreaterThan(0);
-        expect(result.rows.some(row => row.title.includes('Document'))).toBe(true);
+        expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+        expect(result.resultSets[0].rows.some(row => row.title.includes('Document'))).toBe(true);
       } catch (error) {
         // FTS not available in this SQLite build, skip this test
         console.log('FTS extension not available in this SQLite build, skipping FTS test');
@@ -306,9 +311,9 @@ describe('SQLite Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result1.rows).toHaveLength(2);
-      expect(result1.rows[0].name).toBe('John Doe');
-      expect(result1.rows[1].name).toBe('Jane Smith');
+      expect(result1.resultSets[0].rows).toHaveLength(2);
+      expect(result1.resultSets[0].rows[0].name).toBe('John Doe');
+      expect(result1.resultSets[0].rows[1].name).toBe('Jane Smith');
     });
 
     it('should respect existing LIMIT clause when lower than maxRows', async () => {
@@ -318,8 +323,8 @@ describe('SQLite Connector Integration Tests', () => {
         { maxRows: 3 }
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].name).toBe('John Doe');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].name).toBe('John Doe');
     });
 
     it('should use maxRows when existing LIMIT is higher', async () => {
@@ -329,9 +334,9 @@ describe('SQLite Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0].name).toBe('John Doe');
-      expect(result.rows[1].name).toBe('Jane Smith');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0].name).toBe('John Doe');
+      expect(result.resultSets[0].rows[1].name).toBe('Jane Smith');
     });
 
     it('should not affect non-SELECT queries', async () => {
@@ -341,15 +346,15 @@ describe('SQLite Connector Integration Tests', () => {
         { maxRows: 1 }
       );
       
-      expect(insertResult.rows).toHaveLength(0); // INSERTs don't return rows
+      expect(insertResult.resultSets[0].rows).toHaveLength(0); // INSERTs don't return rows
       
       // Verify the insert worked
       const selectResult = await sqliteTest.connector.executeSQL(
         "SELECT * FROM users WHERE email = 'maxrows@example.com'",
         {}
       );
-      expect(selectResult.rows).toHaveLength(1);
-      expect(selectResult.rows[0].name).toBe('MaxRows Test');
+      expect(selectResult.resultSets[0].rows).toHaveLength(1);
+      expect(selectResult.resultSets[0].rows[0].name).toBe('MaxRows Test');
     });
 
     it('should handle maxRows with complex queries', async () => {
@@ -361,9 +366,9 @@ describe('SQLite Connector Integration Tests', () => {
         ORDER BY o.total DESC
       `, { maxRows: 2 });
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('total');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
     it('should not apply maxRows to CTE queries (WITH clause)', async () => {
@@ -376,9 +381,9 @@ describe('SQLite Connector Integration Tests', () => {
       `, { maxRows: 2 });
       
       // Should return all rows since WITH queries are not limited anymore
-      expect(result.rows.length).toBeGreaterThan(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('age');
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('age');
     });
 
     it('should handle maxRows in multi-statement execution', async () => {
@@ -388,10 +393,18 @@ describe('SQLite Connector Integration Tests', () => {
         SELECT name FROM users WHERE email LIKE '%@test.com' ORDER BY name;
         INSERT INTO users (name, email, age) VALUES ('Multi Test 2', 'multi2@test.com', 35);
       `, { maxRows: 1 });
-      
+
+      // SQLite's connector executes all write statements first, then all
+      // read statements, regardless of source order - so resultSets order
+      // here is [INSERT 'Multi Test 1', INSERT 'Multi Test 2', SELECT],
+      // not the source order [INSERT, SELECT, INSERT]. Both inserts have
+      // already run by the time the SELECT executes.
+      expect(result.resultSets).toHaveLength(3);
+      expect(result.resultSets[0]).toEqual({ rows: [], rowCount: 1 });
+      expect(result.resultSets[1]).toEqual({ rows: [], rowCount: 1 });
       // Should return only 1 row from the SELECT statement
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].name).toBe('Multi Test 1');
+      expect(result.resultSets[2].rows).toHaveLength(1);
+      expect(result.resultSets[2].rows[0].name).toBe('Multi Test 1');
     });
 
     it('should ignore maxRows when not specified', async () => {
@@ -402,7 +415,7 @@ describe('SQLite Connector Integration Tests', () => {
       );
 
       // Should return all users (at least the original 3 plus any added in previous tests)
-      expect(result.rows.length).toBeGreaterThanOrEqual(3);
+      expect(result.resultSets[0].rows.length).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -424,7 +437,7 @@ describe('SQLite Connector Integration Tests', () => {
         // Verify we can execute queries
         await connector.executeSQL('CREATE TABLE test (id INTEGER PRIMARY KEY)', {});
         const result = await connector.executeSQL('SELECT * FROM test', {});
-        expect(result.rows).toEqual([]);
+        expect(result.resultSets[0].rows).toEqual([]);
 
         await connector.disconnect();
       } finally {
@@ -459,7 +472,7 @@ describe('SQLite Connector Integration Tests', () => {
         // Verify we can execute queries
         await connector.executeSQL('CREATE TABLE test (id INTEGER PRIMARY KEY)', {});
         const result = await connector.executeSQL('SELECT * FROM test', {});
-        expect(result.rows).toEqual([]);
+        expect(result.resultSets[0].rows).toEqual([]);
 
         await connector.disconnect();
       } finally {
@@ -485,7 +498,7 @@ describe('SQLite Connector Integration Tests', () => {
       // Verify we can execute queries
       await connector.executeSQL('CREATE TABLE test (id INTEGER PRIMARY KEY)', {});
       const result = await connector.executeSQL('SELECT * FROM test', {});
-      expect(result.rows).toEqual([]);
+      expect(result.resultSets[0].rows).toEqual([]);
 
       await connector.disconnect();
     });
@@ -524,7 +537,7 @@ describe('SQLite Connector Integration Tests', () => {
       try {
         // Should be able to read from the main tables
         const result = await readonlyConnector.executeSQL('SELECT * FROM users LIMIT 1', {});
-        expect(result.rows).toHaveLength(1);
+        expect(result.resultSets[0].rows).toHaveLength(1);
 
         // Should NOT be able to write data (SDK-level enforcement)
         await expect(
@@ -547,8 +560,8 @@ describe('SQLite Connector Integration Tests', () => {
       await connector.executeSQL('INSERT INTO test VALUES (1)', {});
 
       const result = await connector.executeSQL('SELECT * FROM test', {});
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].id).toBe(BigInt(1));
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].id).toBe(BigInt(1));
 
       await connector.disconnect();
     });
@@ -596,7 +609,7 @@ describe('SQLite Connector Integration Tests', () => {
         "INSERT INTO users (name, email) VALUES ('rw', 'rw@test.com')",
         {}
       );
-      expect(insert.rowCount).toBe(1);
+      expect(insert.resultSets[0].rowCount).toBe(1);
 
       // Cleanup
       await sqliteTest.connector.executeSQL("DELETE FROM users WHERE email = 'rw@test.com'", {});
@@ -604,10 +617,10 @@ describe('SQLite Connector Integration Tests', () => {
 
     it('should allow read-only PRAGMA and SELECT when options.readonly is set', async () => {
       const select = await sqliteTest.connector.executeSQL('SELECT 1 AS one', { readonly: true });
-      expect(Number(select.rows[0].one)).toBe(1);
+      expect(Number(select.resultSets[0].rows[0].one)).toBe(1);
 
       const pragma = await sqliteTest.connector.executeSQL('PRAGMA table_info(users)', { readonly: true });
-      expect(pragma.rows.length).toBeGreaterThan(0);
+      expect(pragma.resultSets[0].rows.length).toBeGreaterThan(0);
     });
 
     it('should not let an in-batch query_only toggle disable the backstop', async () => {
@@ -624,7 +637,7 @@ describe('SQLite Connector Integration Tests', () => {
         "SELECT COUNT(*) AS c FROM users WHERE email = 'bypass@test.com'",
         {}
       );
-      expect(Number(check.rows[0].c)).toBe(0);
+      expect(Number(check.resultSets[0].rows[0].c)).toBe(0);
     });
   });
 });

--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -817,6 +817,40 @@ describe('SQL Server Connector Integration Tests', () => {
       expect(selectResult.rows[0].name).toBe('MaxRows Test');
     });
 
+    it('should return every result set from a multi-statement SELECT batch', async () => {
+      const result = await sqlServerTest.connector.executeSQL(
+        'SELECT 1 AS a; SELECT 2 AS b;',
+        {}
+      );
+
+      expect(result.rows).toEqual([{ a: 1 }, { b: 2 }]);
+      expect(result.rowCount).toBe(2);
+    });
+
+    it('should sum rowCount across a mixed write/read multi-statement batch', async () => {
+      const result = await sqlServerTest.connector.executeSQL(
+        `
+        INSERT INTO users (name, email, age) VALUES ('Batch User', 'batch@sqlserver.com', 40);
+        SELECT name, email FROM users WHERE email = 'batch@sqlserver.com';
+        `,
+        {}
+      );
+
+      // 1 row affected by the INSERT + 1 row returned by the SELECT
+      expect(result.rowCount).toBe(2);
+      expect(result.rows).toEqual([{ name: 'Batch User', email: 'batch@sqlserver.com' }]);
+    });
+
+    it('should return every result set from a multi-statement SELECT batch in readonly mode', async () => {
+      const result = await sqlServerTest.connector.executeSQL(
+        'SELECT 1 AS a; SELECT 2 AS b;',
+        { readonly: true }
+      );
+
+      expect(result.rows).toEqual([{ a: 1 }, { b: 2 }]);
+      expect(result.rowCount).toBe(2);
+    });
+
     it('should handle maxRows with complex queries', async () => {
       // Test maxRows with JOIN queries
       const result = await sqlServerTest.connector.executeSQL(`

--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -204,8 +204,8 @@ describe('SQL Server Connector Integration Tests', () => {
           END as encryption_status
       `, {});
       
-      expect(encryptionResult.rows[0].encryption_status).toBe('Unencrypted');
-      expect(encryptionResult.rows[0].protocol_type).not.toMatch(/TLS|SSL/i);
+      expect(encryptionResult.resultSets[0].rows[0].encryption_status).toBe('Unencrypted');
+      expect(encryptionResult.resultSets[0].rows[0].protocol_type).not.toMatch(/TLS|SSL/i);
       
       await connector.disconnect();
     });
@@ -237,8 +237,8 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
 
-      expect(result.rows).toHaveLength(1);
-      const planXml = result.rows[0].plan as string;
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      const planXml = result.resultSets[0].rows[0].plan as string;
       expect(typeof planXml).toBe('string');
       // SHOWPLAN_XML output is a ShowPlanXML document referencing the query.
       expect(planXml).toContain('ShowPlanXML');
@@ -250,7 +250,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'explain-noexec@example.com'",
         {}
       );
-      expect(Number(before.rows[0].count)).toBe(0);
+      expect(Number(before.resultSets[0].rows[0].count)).toBe(0);
 
       // SHOWPLAN_XML compiles without executing, so this INSERT must not run.
       await sqlServerTest.connector.executeSQL(
@@ -262,7 +262,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'explain-noexec@example.com'",
         {}
       );
-      expect(Number(after.rows[0].count)).toBe(0);
+      expect(Number(after.resultSets[0].rows[0].count)).toBe(0);
     });
 
     it('should translate EXPLAIN even when preceded by a comment', async () => {
@@ -270,8 +270,8 @@ describe('SQL Server Connector Integration Tests', () => {
         '/* inspect plan */ EXPLAIN SELECT * FROM users',
         {}
       );
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].plan as string).toContain('ShowPlanXML');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].plan as string).toContain('ShowPlanXML');
     });
 
     it('should reject SET SHOWPLAN smuggled into an EXPLAIN query', async () => {
@@ -291,7 +291,7 @@ describe('SQL Server Connector Integration Tests', () => {
         'SELECT COUNT(*) as count FROM users',
         {}
       );
-      expect(Number(after.rows[0].count)).toBe(Number(before.rows[0].count));
+      expect(Number(after.resultSets[0].rows[0].count)).toBe(Number(before.resultSets[0].rows[0].count));
     });
 
     it('should reject an empty EXPLAIN', async () => {
@@ -312,8 +312,8 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
 
-      expect(result.rows).toHaveLength(1);
-      const planXml = result.rows[0].plan as string;
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      const planXml = result.resultSets[0].rows[0].plan as string;
       expect(typeof planXml).toBe('string');
       expect(planXml).toContain('ShowPlanXML');
       expect(planXml).toContain('users');
@@ -328,7 +328,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'explain-analyze-exec@example.com'",
         {}
       );
-      expect(Number(before.rows[0].count)).toBe(0);
+      expect(Number(before.resultSets[0].rows[0].count)).toBe(0);
 
       // Unlike EXPLAIN, EXPLAIN ANALYZE really runs the statement.
       await sqlServerTest.connector.executeSQL(
@@ -340,7 +340,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'explain-analyze-exec@example.com'",
         {}
       );
-      expect(Number(after.rows[0].count)).toBe(1);
+      expect(Number(after.resultSets[0].rows[0].count)).toBe(1);
     });
 
     it('should roll back writes under EXPLAIN ANALYZE in readonly mode', async () => {
@@ -348,21 +348,21 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'explain-analyze-ro@example.com'",
         {}
       );
-      expect(Number(before.rows[0].count)).toBe(0);
+      expect(Number(before.resultSets[0].rows[0].count)).toBe(0);
 
       const result = await sqlServerTest.connector.executeSQL(
         "EXPLAIN ANALYZE INSERT INTO users (name, email, age) VALUES ('RO', 'explain-analyze-ro@example.com', 42)",
         { readonly: true }
       );
       // The plan still comes back...
-      expect(result.rows[0].plan as string).toContain('ShowPlanXML');
+      expect(result.resultSets[0].rows[0].plan as string).toContain('ShowPlanXML');
 
       // ...but the write must not persist.
       const after = await sqlServerTest.connector.executeSQL(
         "SELECT COUNT(*) as count FROM users WHERE email = 'explain-analyze-ro@example.com'",
         {}
       );
-      expect(Number(after.rows[0].count)).toBe(0);
+      expect(Number(after.resultSets[0].rows[0].count)).toBe(0);
     });
 
     it('should translate EXPLAIN ANALYZE even when preceded by a comment', async () => {
@@ -370,8 +370,8 @@ describe('SQL Server Connector Integration Tests', () => {
         '/* real numbers please */ EXPLAIN ANALYZE SELECT * FROM users',
         {}
       );
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].plan as string).toContain('RunTimeInformation');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].plan as string).toContain('RunTimeInformation');
     });
 
     it('should reject SET STATISTICS smuggled into an EXPLAIN ANALYZE query', async () => {
@@ -394,7 +394,7 @@ describe('SQL Server Connector Integration Tests', () => {
         'EXPLAIN (ANALYZE) SELECT name FROM users WHERE age > 30',
         {}
       );
-      expect(result.rows[0].plan as string).toContain('RunTimeInformation');
+      expect(result.resultSets[0].rows[0].plan as string).toContain('RunTimeInformation');
     });
 
     it('should treat EXPLAIN (ANALYZE false) as a plain estimated EXPLAIN', async () => {
@@ -404,7 +404,7 @@ describe('SQL Server Connector Integration Tests', () => {
         'EXPLAIN (ANALYZE false) SELECT name FROM users WHERE age > 30',
         {}
       );
-      const plan = result.rows[0].plan as string;
+      const plan = result.resultSets[0].rows[0].plan as string;
       expect(plan).toContain('ShowPlanXML');
       expect(plan).not.toContain('RunTimeInformation');
     });
@@ -419,7 +419,7 @@ describe('SQL Server Connector Integration Tests', () => {
         'EXPLAIN ANALYZE false SELECT name FROM users WHERE age > 30',
       ]) {
         const result = await sqlServerTest.connector.executeSQL(sql, {});
-        const plan = result.rows[0].plan as string;
+        const plan = result.resultSets[0].rows[0].plan as string;
         expect(plan, sql).toContain('ShowPlanXML');
         expect(plan, sql).not.toContain('RunTimeInformation');
       }
@@ -430,7 +430,7 @@ describe('SQL Server Connector Integration Tests', () => {
         'EXPLAIN (ANALYZE = true) SELECT name FROM users WHERE age > 30',
         {}
       );
-      expect(result.rows[0].plan as string).toContain('RunTimeInformation');
+      expect(result.resultSets[0].rows[0].plan as string).toContain('RunTimeInformation');
     });
 
     it('should block pass-through data sources under readonly EXPLAIN ANALYZE', async () => {
@@ -453,7 +453,7 @@ describe('SQL Server Connector Integration Tests', () => {
         [2]
       );
 
-      const plan = result.rows[0].plan as string;
+      const plan = result.resultSets[0].rows[0].plan as string;
       expect(plan).toContain('RunTimeInformation');
       // Two of the three rows pass the filter, so the value reached the server
       // rather than merely being declared.
@@ -470,7 +470,7 @@ describe('SQL Server Connector Integration Tests', () => {
         [30]
       );
 
-      const plan = result.rows[0].plan as string;
+      const plan = result.resultSets[0].rows[0].plan as string;
       expect(plan).toContain('ShowPlanXML');
       expect(plan).not.toContain('RunTimeInformation');
     });
@@ -482,7 +482,7 @@ describe('SQL Server Connector Integration Tests', () => {
         [1]
       );
 
-      const plan = result.rows[0].plan as string;
+      const plan = result.resultSets[0].rows[0].plan as string;
       expect(plan).toContain('RunTimeInformation');
       expect(plan).toMatch(/ActualRows="1"/);
     });
@@ -500,7 +500,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'analyze-off@example.com'",
         {}
       );
-      expect(Number(before.rows[0].count)).toBe(0);
+      expect(Number(before.resultSets[0].rows[0].count)).toBe(0);
 
       await sqlServerTest.connector.executeSQL(
         "EXPLAIN (ANALYZE off) INSERT INTO users (name, email, age) VALUES ('Off', 'analyze-off@example.com', 7)",
@@ -511,7 +511,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'analyze-off@example.com'",
         {}
       );
-      expect(Number(after.rows[0].count)).toBe(0);
+      expect(Number(after.resultSets[0].rows[0].count)).toBe(0);
     });
 
     it('should reject PostgreSQL-only EXPLAIN options with a clear message', async () => {
@@ -557,10 +557,10 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0].id).toBe(1);
-      expect(result.rows[1].id).toBe(2);
-      expect(result.rows[0].name).toBe('Test 1');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0].id).toBe(1);
+      expect(result.resultSets[0].rows[1].id).toBe(2);
+      expect(result.resultSets[0].rows[0].name).toBe('Test 1');
     });
 
     it('should handle SQL Server-specific data types', async () => {
@@ -585,10 +585,10 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].unicode_text).toBe('Unicode Text 测试');
-      expect(result.rows[0].unique_id).toBeDefined();
-      expect(result.rows[0].xml_data).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].unicode_text).toBe('Unicode Text 测试');
+      expect(result.resultSets[0].rows[0].unique_id).toBeDefined();
+      expect(result.resultSets[0].rows[0].xml_data).toBeDefined();
     });
 
     it('should work with SQL Server-specific functions', async () => {
@@ -601,12 +601,12 @@ describe('SQL Server Connector Integration Tests', () => {
           NEWID() as new_guid
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].sql_version).toContain('Microsoft SQL Server');
-      expect(result.rows[0].current_db).toBeDefined();
-      expect(result.rows[0].current_user_name).toBeDefined();
-      expect(result.rows[0].current_datetime).toBeDefined();
-      expect(result.rows[0].new_guid).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].sql_version).toContain('Microsoft SQL Server');
+      expect(result.resultSets[0].rows[0].current_db).toBeDefined();
+      expect(result.resultSets[0].rows[0].current_user_name).toBeDefined();
+      expect(result.resultSets[0].rows[0].current_datetime).toBeDefined();
+      expect(result.resultSets[0].rows[0].new_guid).toBeDefined();
     });
 
     it('should handle SQL Server transactions correctly', async () => {
@@ -622,7 +622,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email LIKE 'trans%@example.com'",
         {}
       );
-      expect(Number(result.rows[0].count)).toBe(2);
+      expect(Number(result.resultSets[0].rows[0].count)).toBe(2);
     });
 
     it('should handle SQL Server rollback correctly', async () => {
@@ -631,7 +631,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'rollback@example.com'",
         {}
       );
-      const beforeCount = Number(beforeResult.rows[0].count);
+      const beforeCount = Number(beforeResult.resultSets[0].rows[0].count);
       
       // Test rollback
       await sqlServerTest.connector.executeSQL(`
@@ -644,7 +644,7 @@ describe('SQL Server Connector Integration Tests', () => {
         "SELECT COUNT(*) as count FROM users WHERE email = 'rollback@example.com'",
         {}
       );
-      const afterCount = Number(afterResult.rows[0].count);
+      const afterCount = Number(afterResult.resultSets[0].rows[0].count);
       
       expect(afterCount).toBe(beforeCount);
     });
@@ -656,9 +656,9 @@ describe('SQL Server Connector Integration Tests', () => {
         VALUES ('Output Test', 'output@example.com', 40)
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].id).toBeDefined();
-      expect(result.rows[0].name).toBe('Output Test');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].id).toBeDefined();
+      expect(result.resultSets[0].rows[0].name).toBe('Output Test');
     });
 
     it('should handle SQL Server window functions', async () => {
@@ -673,9 +673,9 @@ describe('SQL Server Connector Integration Tests', () => {
         ORDER BY age DESC
       `, {});
       
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('age_rank');
-      expect(result.rows[0]).toHaveProperty('avg_age');
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('age_rank');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('avg_age');
     });
 
     it('should handle SQL Server CTEs (Common Table Expressions)', async () => {
@@ -694,10 +694,10 @@ describe('SQL Server Connector Integration Tests', () => {
         ORDER BY total_spent DESC
       `, {});
       
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('order_count');
-      expect(result.rows[0]).toHaveProperty('total_spent');
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('order_count');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('total_spent');
     });
 
     it('should handle SQL Server JSON functions (SQL Server 2016+)', async () => {
@@ -723,10 +723,10 @@ describe('SQL Server Connector Integration Tests', () => {
         WHERE JSON_VALUE(data, '$.name') = 'John'
       `, {});
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].name).toBe('John');
-      expect(result.rows[0].theme).toBe('dark');
-      expect(result.rows[0].tags).toBeDefined();
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].name).toBe('John');
+      expect(result.resultSets[0].rows[0].theme).toBe('dark');
+      expect(result.resultSets[0].rows[0].tags).toBeDefined();
     });
 
     it('should handle SQL Server MERGE statement', async () => {
@@ -757,9 +757,9 @@ describe('SQL Server Connector Integration Tests', () => {
         OUTPUT $action, INSERTED.name;
       `, {});
       
-      expect(result.rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
       // Should have both UPDATE and INSERT actions
-      const actions = result.rows.map(row => row.$action);
+      const actions = result.resultSets[0].rows.map(row => row.$action);
       expect(actions).toContain('UPDATE');
       expect(actions).toContain('INSERT');
     });
@@ -771,9 +771,9 @@ describe('SQL Server Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should respect existing TOP clause when lower than maxRows', async () => {
@@ -783,8 +783,8 @@ describe('SQL Server Connector Integration Tests', () => {
         { maxRows: 3 }
       );
       
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
     });
 
     it('should use maxRows when existing TOP is higher', async () => {
@@ -794,9 +794,9 @@ describe('SQL Server Connector Integration Tests', () => {
         { maxRows: 2 }
       );
       
-      expect(result.rows).toHaveLength(2);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[1]).toHaveProperty('name');
     });
 
     it('should not affect non-SELECT queries', async () => {
@@ -806,15 +806,15 @@ describe('SQL Server Connector Integration Tests', () => {
         { maxRows: 1 }
       );
       
-      expect(insertResult.rows).toHaveLength(0); // INSERTs without OUTPUT don't return rows by default
+      expect(insertResult.resultSets[0].rows).toHaveLength(0); // INSERTs without OUTPUT don't return rows by default
       
       // Verify the insert worked
       const selectResult = await sqlServerTest.connector.executeSQL(
         "SELECT * FROM users WHERE email = 'maxrows@sqlserver.com'",
         {}
       );
-      expect(selectResult.rows).toHaveLength(1);
-      expect(selectResult.rows[0].name).toBe('MaxRows Test');
+      expect(selectResult.resultSets[0].rows).toHaveLength(1);
+      expect(selectResult.resultSets[0].rows[0].name).toBe('MaxRows Test');
     });
 
     it('should return every result set from a multi-statement SELECT batch', async () => {
@@ -823,8 +823,11 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
 
-      expect(result.rows).toEqual([{ a: 1 }, { b: 2 }]);
-      expect(result.rowCount).toBe(2);
+      // One resultSet per SELECT recordset, in order - not flattened together.
+      expect(result.resultSets).toEqual([
+        { rows: [{ a: 1 }], rowCount: 1 },
+        { rows: [{ b: 2 }], rowCount: 1 },
+      ]);
     });
 
     it('should sum rowCount across a mixed write/read multi-statement batch', async () => {
@@ -836,9 +839,13 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
 
-      // 1 row affected by the INSERT + 1 row returned by the SELECT
-      expect(result.rowCount).toBe(2);
-      expect(result.rows).toEqual([{ name: 'Batch User', email: 'batch@sqlserver.com' }]);
+      // One resultSet for the SELECT's recordset, plus a trailing write-only
+      // resultSet for the INSERT (rowsAffected sums to 2: 1 insert + 1
+      // select-rowcount; leftover after accounting for the select's row is 1).
+      expect(result.resultSets).toEqual([
+        { rows: [{ name: 'Batch User', email: 'batch@sqlserver.com' }], rowCount: 1 },
+        { rows: [], rowCount: 1 },
+      ]);
     });
 
     it('should return every result set from a multi-statement SELECT batch in readonly mode', async () => {
@@ -847,8 +854,10 @@ describe('SQL Server Connector Integration Tests', () => {
         { readonly: true }
       );
 
-      expect(result.rows).toEqual([{ a: 1 }, { b: 2 }]);
-      expect(result.rowCount).toBe(2);
+      expect(result.resultSets).toEqual([
+        { rows: [{ a: 1 }], rowCount: 1 },
+        { rows: [{ b: 2 }], rowCount: 1 },
+      ]);
     });
 
     it('should handle maxRows with complex queries', async () => {
@@ -860,10 +869,10 @@ describe('SQL Server Connector Integration Tests', () => {
         ORDER BY o.total DESC
       `, { maxRows: 2 });
       
-      expect(result.rows.length).toBeLessThanOrEqual(2);
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('total');
+      expect(result.resultSets[0].rows.length).toBeLessThanOrEqual(2);
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
     it('should handle maxRows with window functions', async () => {
@@ -878,10 +887,10 @@ describe('SQL Server Connector Integration Tests', () => {
         ORDER BY age DESC
       `, { maxRows: 2 });
       
-      expect(result.rows.length).toBeLessThanOrEqual(2);
-      expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows[0]).toHaveProperty('name');
-      expect(result.rows[0]).toHaveProperty('age_rank');
+      expect(result.resultSets[0].rows.length).toBeLessThanOrEqual(2);
+      expect(result.resultSets[0].rows.length).toBeGreaterThan(0);
+      expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      expect(result.resultSets[0].rows[0]).toHaveProperty('age_rank');
     });
 
     it('should capture PRINT output in messages', async () => {
@@ -890,8 +899,8 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
 
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].value).toBe(1);
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].rows[0].value).toBe(1);
       expect(result.messages).toBeDefined();
       expect(result.messages!.length).toBeGreaterThan(0);
       expect(result.messages!.some(msg => msg.text === 'hello from sql server')).toBe(true);
@@ -903,7 +912,7 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
 
-      expect(result.rows).toHaveLength(1);
+      expect(result.resultSets[0].rows).toHaveLength(1);
       expect(result.messages).toBeDefined();
       expect(result.messages!.length).toBeGreaterThan(0);
       // STATISTICS TIME emits messages containing "CPU time" and "elapsed time"
@@ -919,7 +928,7 @@ describe('SQL Server Connector Integration Tests', () => {
         {}
       );
 
-      expect(result.rows).toHaveLength(1);
+      expect(result.resultSets[0].rows).toHaveLength(1);
       // messages should be undefined (not present) when no info messages were emitted
       expect(result.messages).toBeUndefined();
     });
@@ -932,7 +941,7 @@ describe('SQL Server Connector Integration Tests', () => {
       );
       
       // Should return all users (at least the original 3 plus any added in previous tests)
-      expect(result.rows.length).toBeGreaterThanOrEqual(3);
+      expect(result.resultSets[0].rows.length).toBeGreaterThanOrEqual(3);
     });
   });
 });

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -26,6 +26,14 @@ export interface DatabaseMessage {
 
 /** The rows and affected-row count produced by one statement in a batch. */
 export interface SQLResultSet {
+  /**
+   * The source text of the statement that produced this result set, when the
+   * connector can attribute it unambiguously. Omitted for SQL Server batches
+   * with more than one statement, where node-mssql's recordsets/rowsAffected
+   * arrays aren't index-aligned per statement (see sqlserver's
+   * `buildResultSets`) - attributing SQL there would be a guess.
+   */
+  sql?: string;
   rows: any[];
   rowCount: number;
 }

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -24,9 +24,19 @@ export interface DatabaseMessage {
   line?: number;
 }
 
-export interface SQLResult {
+/** The rows and affected-row count produced by one statement in a batch. */
+export interface SQLResultSet {
   rows: any[];
   rowCount: number;
+}
+
+export interface SQLResult {
+  /**
+   * One entry per statement in the batch, in execution order. A single
+   * `SELECT` (the common case) is `resultSets` of length 1 - callers that
+   * only care about that should read `resultSets[0]`.
+   */
+  resultSets: SQLResultSet[];
   /** Informational messages from the database (e.g. SQL Server STATISTICS TIME/IO, PRINT output) */
   messages?: DatabaseMessage[];
 }

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -17,7 +17,7 @@ import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { requireDatabaseInDSN, MissingDatabaseError } from "../../utils/dsn-database.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
-import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
+import { parseQueryResultSets } from "../../utils/multi-statement-result-parser.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
 import { withReadOnlyTransaction } from "../../utils/readonly-transaction.js";
 import { quoteIdentifier } from "../../utils/identifier-quoter.js";
@@ -675,10 +675,9 @@ export class MariaDBConnector implements Connector {
           }
 
           // Parse results using shared utility that handles both single and multi-statement queries
-          const rows = parseQueryResults(results);
-          const rowCount = extractAffectedRows(results);
+          const resultSets = parseQueryResultSets(results);
 
-          return { rows, rowCount };
+          return { resultSets };
         }
       );
     } finally {

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -649,12 +649,11 @@ export class MariaDBConnector implements Connector {
         options.readonly,
         this.supportsReadOnlyTransaction,
         async () => {
-          // Apply maxRows limit to SELECT queries if specified
+          // Split up front so the original statement text is available for
+          // attribution below, whether or not maxRows needs to rewrite it.
+          const statements = splitSQLStatements(sql, "mariadb");
           let processedSQL = sql;
           if (options.maxRows) {
-            // Handle multi-statement SQL by processing each statement individually
-            const statements = splitSQLStatements(sql, "mariadb");
-
             const processedStatements = statements.map(statement =>
               SQLRowLimiter.applyMaxRows(statement, options.maxRows)
             );
@@ -675,7 +674,7 @@ export class MariaDBConnector implements Connector {
           }
 
           // Parse results using shared utility that handles both single and multi-statement queries
-          const resultSets = parseQueryResultSets(results);
+          const resultSets = parseQueryResultSets(results, statements);
 
           return { resultSets };
         }

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -679,12 +679,11 @@ export class MySQLConnector implements Connector {
         options.readonly,
         this.supportsReadOnlyTransaction,
         async () => {
-          // Apply maxRows limit to SELECT queries if specified
+          // Split up front so the original statement text is available for
+          // attribution below, whether or not maxRows needs to rewrite it.
+          const statements = splitSQLStatements(sql, "mysql");
           let processedSQL = sql;
           if (options.maxRows) {
-            // Handle multi-statement SQL by processing each statement individually
-            const statements = splitSQLStatements(sql, "mysql");
-
             const processedStatements = statements.map(statement =>
               SQLRowLimiter.applyMaxRows(statement, options.maxRows)
             );
@@ -709,7 +708,7 @@ export class MySQLConnector implements Connector {
           const [firstResult] = results;
 
           // Parse results using shared utility that handles both single and multi-statement queries
-          const resultSets = parseQueryResultSets(firstResult);
+          const resultSets = parseQueryResultSets(firstResult, statements);
 
           return { resultSets };
         }

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -17,7 +17,7 @@ import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { requireDatabaseInDSN, MissingDatabaseError } from "../../utils/dsn-database.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
-import { parseQueryResults, extractAffectedRows } from "../../utils/multi-statement-result-parser.js";
+import { parseQueryResultSets } from "../../utils/multi-statement-result-parser.js";
 import { splitSQLStatements } from "../../utils/sql-parser.js";
 import { withReadOnlyTransaction, isClientSideTimeout } from "../../utils/readonly-transaction.js";
 import { quoteIdentifier } from "../../utils/identifier-quoter.js";
@@ -709,10 +709,9 @@ export class MySQLConnector implements Connector {
           const [firstResult] = results;
 
           // Parse results using shared utility that handles both single and multi-statement queries
-          const rows = parseQueryResults(firstResult);
-          const rowCount = extractAffectedRows(firstResult);
+          const resultSets = parseQueryResultSets(firstResult);
 
-          return { rows, rowCount };
+          return { resultSets };
         }
       );
     } catch (error) {

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -693,7 +693,9 @@ export class PostgresConnector implements Connector {
               : await client.query(processedStatement);
             await client.query('COMMIT');
             return {
-              resultSets: [{ rows: result.rows, rowCount: result.rowCount ?? result.rows.length }],
+              resultSets: [
+                { sql: statements[0], rows: result.rows, rowCount: result.rowCount ?? result.rows.length },
+              ],
             };
           } catch (error) {
             // Best-effort rollback so a failed ROLLBACK (e.g. dropped connection)
@@ -716,7 +718,9 @@ export class PostgresConnector implements Connector {
         }
         // Explicitly return rows and rowCount to ensure rowCount is preserved
         return {
-          resultSets: [{ rows: result.rows, rowCount: result.rowCount ?? result.rows.length }],
+          resultSets: [
+            { sql: statements[0], rows: result.rows, rowCount: result.rowCount ?? result.rows.length },
+          ],
         };
       } else {
         // Multiple statements - parameters not supported for multi-statement queries
@@ -741,6 +745,7 @@ export class PostgresConnector implements Connector {
 
             const result = await client.query(processedStatement);
             resultSets.push({
+              sql: statement,
               rows: result.rows ?? [],
               rowCount: result.rowCount ?? result.rows?.length ?? 0,
             });

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -9,6 +9,7 @@ import {
   ConnectorRegistry,
   DSNParser,
   SQLResult,
+  SQLResultSet,
   TableColumn,
   TableIndex,
   StoredProcedure,
@@ -691,7 +692,9 @@ export class PostgresConnector implements Connector {
               ? await client.query(processedStatement, parameters)
               : await client.query(processedStatement);
             await client.query('COMMIT');
-            return { rows: result.rows, rowCount: result.rowCount ?? result.rows.length };
+            return {
+              resultSets: [{ rows: result.rows, rowCount: result.rowCount ?? result.rows.length }],
+            };
           } catch (error) {
             // Best-effort rollback so a failed ROLLBACK (e.g. dropped connection)
             // can't mask the original query error.
@@ -712,16 +715,20 @@ export class PostgresConnector implements Connector {
           result = await client.query(processedStatement);
         }
         // Explicitly return rows and rowCount to ensure rowCount is preserved
-        return { rows: result.rows, rowCount: result.rowCount ?? result.rows.length };
+        return {
+          resultSets: [{ rows: result.rows, rowCount: result.rowCount ?? result.rows.length }],
+        };
       } else {
         // Multiple statements - parameters not supported for multi-statement queries
         if (parameters && parameters.length > 0) {
           throw new Error("Parameters are not supported for multi-statement queries in PostgreSQL");
         }
 
-        // Execute all in same session for transaction consistency
-        let allRows: any[] = [];
-        let totalRowCount = 0;
+        // Execute all in same session for transaction consistency, keeping
+        // each statement's rows/rowCount as its own result set rather than
+        // merging them into one - a caller needs to tell "SELECT 1 AS a" and
+        // "SELECT 2 AS b" apart, not just see their rows concatenated.
+        const resultSets: SQLResultSet[] = [];
 
         // Execute within a transaction to ensure session consistency.
         // In read-only mode, open it READ ONLY so the engine rejects any write the
@@ -733,14 +740,10 @@ export class PostgresConnector implements Connector {
             const processedStatement = SQLRowLimiter.applyMaxRows(statement, options.maxRows);
 
             const result = await client.query(processedStatement);
-            // Collect rows from SELECT/WITH/EXPLAIN statements
-            if (result.rows && result.rows.length > 0) {
-              allRows.push(...result.rows);
-            }
-            // Accumulate rowCount for INSERT/UPDATE/DELETE statements
-            if (result.rowCount) {
-              totalRowCount += result.rowCount;
-            }
+            resultSets.push({
+              rows: result.rows ?? [],
+              rowCount: result.rowCount ?? result.rows?.length ?? 0,
+            });
           }
           await client.query('COMMIT');
         } catch (error) {
@@ -754,7 +757,7 @@ export class PostgresConnector implements Connector {
           throw error;
         }
 
-        return { rows: allRows, rowCount: totalRowCount };
+        return { resultSets };
       }
     } finally {
       client.release();

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -15,6 +15,7 @@ import {
   ConnectorRegistry,
   DSNParser,
   SQLResult,
+  SQLResultSet,
   TableColumn,
   TableIndex,
   StoredProcedure,
@@ -497,10 +498,10 @@ export class SQLiteConnector implements Connector {
           // Pass parameters if provided
           if (parameters && parameters.length > 0) {
             const rows = this.prepare(processedStatement).all(...parameters);
-            return { rows, rowCount: rows.length };
+            return { resultSets: [{ rows, rowCount: rows.length }] };
           } else {
             const rows = this.prepare(processedStatement).all();
-            return { rows, rowCount: rows.length };
+            return { resultSets: [{ rows, rowCount: rows.length }] };
           }
         } else {
           // Use run() for statements that don't return data
@@ -512,7 +513,7 @@ export class SQLiteConnector implements Connector {
           }
           // node:sqlite returns `changes` as BigInt when BigInt reads are
           // enabled; normalize to a number to match the SQLResult contract.
-          return { rows: [], rowCount: Number(result.changes) };
+          return { resultSets: [{ rows: [], rowCount: Number(result.changes) }] };
         }
       } else {
         // Multiple statements - parameters not supported for multi-statement queries
@@ -543,8 +544,11 @@ export class SQLiteConnector implements Connector {
           }
         }
 
-        // Execute write statements individually to track changes
-        let totalChanges = 0;
+        // Execute write statements individually to track changes. Each
+        // statement becomes its own result set, in the order actually run -
+        // note that's writes-then-reads (see readStatements/writeStatements
+        // split above), not necessarily the original source order.
+        const resultSets: SQLResultSet[] = [];
         for (const statement of writeStatements) {
           // Re-assert the read-only backstop before each statement so an earlier
           // statement in the batch (e.g. `PRAGMA query_only = OFF` / `query_only(0)`)
@@ -553,23 +557,21 @@ export class SQLiteConnector implements Connector {
             this.db.exec("PRAGMA query_only = ON");
           }
           const result = this.prepare(statement).run();
-          totalChanges += Number(result.changes);
+          resultSets.push({ rows: [], rowCount: Number(result.changes) });
         }
 
         // Execute read statements individually to collect results
-        let allRows: any[] = [];
         for (let statement of readStatements) {
           if (options.readonly) {
             this.db.exec("PRAGMA query_only = ON");
           }
           // Apply maxRows limit to SELECT queries if specified
           statement = SQLRowLimiter.applyMaxRows(statement, options.maxRows);
-          const result = this.prepare(statement).all();
-          allRows.push(...result);
+          const rows = this.prepare(statement).all();
+          resultSets.push({ rows, rowCount: rows.length });
         }
 
-        // rowCount is total changes for writes, plus rows returned for reads
-        return { rows: allRows, rowCount: totalChanges + allRows.length };
+        return { resultSets };
       }
     } finally {
       // Restore the connection to writable so non-read-only tools on the same

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -498,10 +498,10 @@ export class SQLiteConnector implements Connector {
           // Pass parameters if provided
           if (parameters && parameters.length > 0) {
             const rows = this.prepare(processedStatement).all(...parameters);
-            return { resultSets: [{ rows, rowCount: rows.length }] };
+            return { resultSets: [{ sql: statements[0], rows, rowCount: rows.length }] };
           } else {
             const rows = this.prepare(processedStatement).all();
-            return { resultSets: [{ rows, rowCount: rows.length }] };
+            return { resultSets: [{ sql: statements[0], rows, rowCount: rows.length }] };
           }
         } else {
           // Use run() for statements that don't return data
@@ -513,7 +513,9 @@ export class SQLiteConnector implements Connector {
           }
           // node:sqlite returns `changes` as BigInt when BigInt reads are
           // enabled; normalize to a number to match the SQLResult contract.
-          return { resultSets: [{ rows: [], rowCount: Number(result.changes) }] };
+          return {
+            resultSets: [{ sql: statements[0], rows: [], rowCount: Number(result.changes) }],
+          };
         }
       } else {
         // Multiple statements - parameters not supported for multi-statement queries
@@ -557,18 +559,18 @@ export class SQLiteConnector implements Connector {
             this.db.exec("PRAGMA query_only = ON");
           }
           const result = this.prepare(statement).run();
-          resultSets.push({ rows: [], rowCount: Number(result.changes) });
+          resultSets.push({ sql: statement, rows: [], rowCount: Number(result.changes) });
         }
 
         // Execute read statements individually to collect results
-        for (let statement of readStatements) {
+        for (const statement of readStatements) {
           if (options.readonly) {
             this.db.exec("PRAGMA query_only = ON");
           }
           // Apply maxRows limit to SELECT queries if specified
-          statement = SQLRowLimiter.applyMaxRows(statement, options.maxRows);
-          const rows = this.prepare(statement).all();
-          resultSets.push({ rows, rowCount: rows.length });
+          const processedStatement = SQLRowLimiter.applyMaxRows(statement, options.maxRows);
+          const rows = this.prepare(processedStatement).all();
+          resultSets.push({ sql: statement, rows, rowCount: rows.length });
         }
 
         return { resultSets };

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -813,7 +813,7 @@ export class SQLServerConnector implements Connector {
     if (!recordsets) {
       return [];
     }
-    return recordsets.flatMap((recordset: any) => recordset || []);
+    return recordsets.flatMap((recordset: any) => recordset ?? []);
   }
 
   /**
@@ -825,7 +825,7 @@ export class SQLServerConnector implements Connector {
     if (!rowsAffected) {
       return 0;
     }
-    return rowsAffected.reduce((total, count) => total + (count || 0), 0);
+    return rowsAffected.reduce((total, count) => total + (count ?? 0), 0);
   }
 
   /**

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -19,7 +19,7 @@ import { isDriverNotInstalled } from "../../utils/module-loader.js";
 import { SafeURL } from "../../utils/safe-url.js";
 import { obfuscateDSNPassword } from "../../utils/dsn-obfuscate.js";
 import { SQLRowLimiter } from "../../utils/sql-row-limiter.js";
-import { stripCommentsAndStrings } from "../../utils/sql-parser.js";
+import { splitSQLStatements, stripCommentsAndStrings } from "../../utils/sql-parser.js";
 import {
   sqlServerDynamicSqlKeywords,
   sqlServerDynamicSqlPattern,
@@ -793,7 +793,7 @@ export class SQLServerConnector implements Connector {
       const result = await request.query(processedSQL);
 
       return {
-        resultSets: SQLServerConnector.buildResultSets(result.recordsets, result.rowsAffected),
+        resultSets: SQLServerConnector.buildResultSets(result.recordsets, result.rowsAffected, processedSQL),
         ...(messages.length > 0 ? { messages } : {}),
       };
     } catch (error) {
@@ -816,8 +816,18 @@ export class SQLServerConnector implements Connector {
    * one result set per select plus one trailing "writes" set for the rest -
    * not a truly per-statement breakdown, but no read statement's rows are
    * ever merged with another's, which is what mattered for #380.
+   *
+   * `sourceSql` is attributed to the single resulting set only when the
+   * batch is unambiguously one statement - for a genuine multi-statement
+   * batch there's no reliable way to say which source statement a given
+   * recordset (or the trailing writes set) came from, so `sql` is left
+   * undefined rather than guessed.
    */
-  private static buildResultSets(recordsets: any, rowsAffected: number[] | undefined): SQLResultSet[] {
+  private static buildResultSets(
+    recordsets: any,
+    rowsAffected: number[] | undefined,
+    sourceSql: string,
+  ): SQLResultSet[] {
     const sets: SQLResultSet[] = (recordsets ?? []).map((recordset: any) => {
       const rows = recordset ?? [];
       return { rows, rowCount: rows.length };
@@ -828,10 +838,13 @@ export class SQLServerConnector implements Connector {
     const writesOnly = totalAffected - accountedFor;
 
     if (sets.length === 0) {
-      return [{ rows: [], rowCount: totalAffected }];
-    }
-    if (writesOnly > 0) {
+      sets.push({ rows: [], rowCount: totalAffected });
+    } else if (writesOnly > 0) {
       sets.push({ rows: [], rowCount: writesOnly });
+    }
+
+    if (sets.length === 1 && splitSQLStatements(sourceSql, "sqlserver").length === 1) {
+      sets[0].sql = sourceSql;
     }
     return sets;
   }
@@ -974,7 +987,7 @@ export class SQLServerConnector implements Connector {
       }
     }
     return {
-      resultSets: SQLServerConnector.buildResultSets(result.recordsets, result.rowsAffected),
+      resultSets: SQLServerConnector.buildResultSets(result.recordsets, result.rowsAffected, processedSQL),
       ...(messages.length > 0 ? { messages } : {}),
     };
   }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -792,13 +792,40 @@ export class SQLServerConnector implements Connector {
       const result = await request.query(processedSQL);
 
       return {
-        rows: result.recordset || [],
-        rowCount: result.rowsAffected[0] || 0,
+        rows: SQLServerConnector.flattenRecordsets(result.recordsets),
+        rowCount: SQLServerConnector.sumRowsAffected(result.rowsAffected),
         ...(messages.length > 0 ? { messages } : {}),
       };
     } catch (error) {
       throw new Error(`Failed to execute query: ${(error as Error).message}`);
     }
+  }
+
+  /**
+   * node-mssql only pushes a `recordsets` entry for statements that produce
+   * columns (SELECT); INSERT/UPDATE/DELETE statements in the same batch
+   * contribute to `rowsAffected` only. Concatenating every entry — rather
+   * than reading `recordset` (singular, first result set only) — is what
+   * makes multi-statement batches return every SELECT's rows, matching the
+   * MySQL/MariaDB connectors' behavior.
+   */
+  private static flattenRecordsets(recordsets: any): any[] {
+    if (!recordsets) {
+      return [];
+    }
+    return recordsets.flatMap((recordset: any) => recordset || []);
+  }
+
+  /**
+   * `rowsAffected` has one entry per statement in the batch (SELECT included,
+   * via @@ROWCOUNT). Summing it mirrors `extractAffectedRows` for
+   * MySQL/MariaDB: the total reflects every statement, not just the first.
+   */
+  private static sumRowsAffected(rowsAffected: number[] | undefined): number {
+    if (!rowsAffected) {
+      return 0;
+    }
+    return rowsAffected.reduce((total, count) => total + (count || 0), 0);
   }
 
   /**
@@ -939,8 +966,8 @@ export class SQLServerConnector implements Connector {
       }
     }
     return {
-      rows: result.recordset || [],
-      rowCount: result.rowsAffected[0] || 0,
+      rows: SQLServerConnector.flattenRecordsets(result.recordsets),
+      rowCount: SQLServerConnector.sumRowsAffected(result.rowsAffected),
       ...(messages.length > 0 ? { messages } : {}),
     };
   }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -763,13 +763,16 @@ export class SQLServerConnector implements Connector {
       if (options.maxRows) {
         processedSQL = SQLRowLimiter.applyMaxRowsForSQLServer(sqlQuery, options.maxRows);
       }
+      // Computed once and threaded into buildResultSets below (directly, or via
+      // executeReadOnly) rather than re-derived from SQL text on every call.
+      const isSingleStatement = splitSQLStatements(processedSQL, "sqlserver").length === 1;
 
       // Engine-level read-only enforcement: SQL Server has no
       // BEGIN TRANSACTION READ ONLY, so we wrap in a transaction and
       // unconditionally ROLLBACK to prevent any modifications from persisting.
       // This is defense-in-depth behind the keyword classifier.
       if (options.readonly) {
-        return await this.executeReadOnly(processedSQL, parameters);
+        return await this.executeReadOnly(processedSQL, parameters, isSingleStatement);
       }
 
       // Create request and collect informational messages (e.g. SET STATISTICS TIME/IO, PRINT)
@@ -793,7 +796,11 @@ export class SQLServerConnector implements Connector {
       const result = await request.query(processedSQL);
 
       return {
-        resultSets: SQLServerConnector.buildResultSets(result.recordsets, result.rowsAffected, processedSQL),
+        resultSets: SQLServerConnector.buildResultSets(
+          result.recordsets,
+          result.rowsAffected,
+          isSingleStatement ? processedSQL : undefined,
+        ),
         ...(messages.length > 0 ? { messages } : {}),
       };
     } catch (error) {
@@ -817,16 +824,16 @@ export class SQLServerConnector implements Connector {
    * not a truly per-statement breakdown, but no read statement's rows are
    * ever merged with another's, which is what mattered for #380.
    *
-   * `sourceSql` is attributed to the single resulting set only when the
-   * batch is unambiguously one statement - for a genuine multi-statement
-   * batch there's no reliable way to say which source statement a given
-   * recordset (or the trailing writes set) came from, so `sql` is left
-   * undefined rather than guessed.
+   * `sourceSql`, when given, is attributed to the single resulting set - it
+   * must be omitted (pass `undefined`) unless the caller has already
+   * confirmed the batch is unambiguously one statement, since for a genuine
+   * multi-statement batch there's no reliable way to say which source
+   * statement a given recordset (or the trailing writes set) came from.
    */
   private static buildResultSets(
     recordsets: any,
     rowsAffected: number[] | undefined,
-    sourceSql: string,
+    sourceSql: string | undefined,
   ): SQLResultSet[] {
     const sets: SQLResultSet[] = (recordsets ?? []).map((recordset: any) => {
       const rows = recordset ?? [];
@@ -843,7 +850,11 @@ export class SQLServerConnector implements Connector {
       sets.push({ rows: [], rowCount: writesOnly });
     }
 
-    if (sets.length === 1 && splitSQLStatements(sourceSql, "sqlserver").length === 1) {
+    // A pure-writes batch collapses to one synthetic set above regardless of
+    // how many write statements it actually had, so sourceSql being given is
+    // not on its own proof of a single statement - the caller's
+    // isSingleStatement check (done once, from the real source text) is.
+    if (sets.length === 1 && sourceSql !== undefined) {
       sets[0].sql = sourceSql;
     }
     return sets;
@@ -946,6 +957,7 @@ export class SQLServerConnector implements Connector {
   private async executeReadOnly(
     processedSQL: string,
     parameters?: any[],
+    isSingleStatement?: boolean,
   ): Promise<SQLResult> {
     this.assertNoReadOnlyEscapes(processedSQL, { transactionControl: true });
 
@@ -987,7 +999,11 @@ export class SQLServerConnector implements Connector {
       }
     }
     return {
-      resultSets: SQLServerConnector.buildResultSets(result.recordsets, result.rowsAffected, processedSQL),
+      resultSets: SQLServerConnector.buildResultSets(
+        result.recordsets,
+        result.rowsAffected,
+        isSingleStatement ? processedSQL : undefined,
+      ),
       ...(messages.length > 0 ? { messages } : {}),
     };
   }

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -5,6 +5,7 @@ import {
   ConnectorRegistry,
   DSNParser,
   SQLResult,
+  SQLResultSet,
   DatabaseMessage,
   TableColumn,
   TableIndex,
@@ -792,8 +793,7 @@ export class SQLServerConnector implements Connector {
       const result = await request.query(processedSQL);
 
       return {
-        rows: SQLServerConnector.flattenRecordsets(result.recordsets),
-        rowCount: SQLServerConnector.sumRowsAffected(result.rowsAffected),
+        resultSets: SQLServerConnector.buildResultSets(result.recordsets, result.rowsAffected),
         ...(messages.length > 0 ? { messages } : {}),
       };
     } catch (error) {
@@ -802,30 +802,38 @@ export class SQLServerConnector implements Connector {
   }
 
   /**
+   * Builds one result set per SELECT-producing statement in the batch, plus
+   * (if any) a trailing result set summarizing the write-only statements.
+   *
    * node-mssql only pushes a `recordsets` entry for statements that produce
    * columns (SELECT); INSERT/UPDATE/DELETE statements in the same batch
-   * contribute to `rowsAffected` only. Concatenating every entry — rather
-   * than reading `recordset` (singular, first result set only) — is what
-   * makes multi-statement batches return every SELECT's rows, matching the
-   * MySQL/MariaDB connectors' behavior.
+   * contribute to `rowsAffected` only, with no way to recover which
+   * `rowsAffected` entry belongs to which statement from the driver's final
+   * arrays (`recordsets`/`rowsAffected` aren't index-aligned - see the
+   * tedious `doneHandler`, which always pushes to `rowsAffected` but only
+   * conditionally to `recordsets`). So a batch of pure writes collapses to a
+   * single summed result set, and a batch mixing writes with selects gets
+   * one result set per select plus one trailing "writes" set for the rest -
+   * not a truly per-statement breakdown, but no read statement's rows are
+   * ever merged with another's, which is what mattered for #380.
    */
-  private static flattenRecordsets(recordsets: any): any[] {
-    if (!recordsets) {
-      return [];
-    }
-    return recordsets.flatMap((recordset: any) => recordset ?? []);
-  }
+  private static buildResultSets(recordsets: any, rowsAffected: number[] | undefined): SQLResultSet[] {
+    const sets: SQLResultSet[] = (recordsets ?? []).map((recordset: any) => {
+      const rows = recordset ?? [];
+      return { rows, rowCount: rows.length };
+    });
 
-  /**
-   * `rowsAffected` has one entry per statement in the batch (SELECT included,
-   * via @@ROWCOUNT). Summing it mirrors `extractAffectedRows` for
-   * MySQL/MariaDB: the total reflects every statement, not just the first.
-   */
-  private static sumRowsAffected(rowsAffected: number[] | undefined): number {
-    if (!rowsAffected) {
-      return 0;
+    const totalAffected = (rowsAffected ?? []).reduce((total, count) => total + (count ?? 0), 0);
+    const accountedFor = sets.reduce((total, set) => total + set.rowCount, 0);
+    const writesOnly = totalAffected - accountedFor;
+
+    if (sets.length === 0) {
+      return [{ rows: [], rowCount: totalAffected }];
     }
-    return rowsAffected.reduce((total, count) => total + (count ?? 0), 0);
+    if (writesOnly > 0) {
+      sets.push({ rows: [], rowCount: writesOnly });
+    }
+    return sets;
   }
 
   /**
@@ -966,8 +974,7 @@ export class SQLServerConnector implements Connector {
       }
     }
     return {
-      rows: SQLServerConnector.flattenRecordsets(result.recordsets),
-      rowCount: SQLServerConnector.sumRowsAffected(result.rowsAffected),
+      resultSets: SQLServerConnector.buildResultSets(result.recordsets, result.rowsAffected),
       ...(messages.length > 0 ? { messages } : {}),
     };
   }
@@ -1041,8 +1048,12 @@ export class SQLServerConnector implements Connector {
       const planRow = planResult.recordset?.[0];
       const planXml = planRow ? Object.values(planRow)[0] : null;
       return {
-        rows: planXml != null ? [{ plan: planXml }] : [],
-        rowCount: planXml != null ? 1 : 0,
+        resultSets: [
+          {
+            rows: planXml != null ? [{ plan: planXml }] : [],
+            rowCount: planXml != null ? 1 : 0,
+          },
+        ],
       };
     } catch (error) {
       throw new Error(`Failed to explain query: ${(error as Error).message}`);
@@ -1204,8 +1215,12 @@ export class SQLServerConnector implements Connector {
 
       const planXml = SQLServerConnector.extractPlanXml(planResult);
       return {
-        rows: planXml != null ? [{ plan: planXml }] : [],
-        rowCount: planXml != null ? 1 : 0,
+        resultSets: [
+          {
+            rows: planXml != null ? [{ plan: planXml }] : [],
+            rowCount: planXml != null ? 1 : 0,
+          },
+        ],
       };
     } catch (error) {
       // Named apart from the plain EXPLAIN path: this one ran the statement, so

--- a/src/tools/__tests__/execute-sql.test.ts
+++ b/src/tools/__tests__/execute-sql.test.ts
@@ -53,7 +53,9 @@ describe('execute-sql tool', () => {
 
   describe('basic execution', () => {
     it('should execute SELECT and return rows', async () => {
-      const mockResult: SQLResult = { resultSets: [{ rows: [{ id: 1, name: 'test' }], rowCount: 1 }] };
+      const mockResult: SQLResult = {
+        resultSets: [{ sql: 'SELECT * FROM users', rows: [{ id: 1, name: 'test' }], rowCount: 1 }],
+      };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('test_source');
@@ -61,15 +63,17 @@ describe('execute-sql tool', () => {
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
-      expect(parsedResult.data.resultSets).toEqual([{ rows: [{ id: 1, name: 'test' }], count: 1 }]);
+      expect(parsedResult.data.statements).toEqual([
+        { sql: 'SELECT * FROM users', rows: [{ id: 1, name: 'test' }], count: 1 },
+      ]);
       expect(mockConnector.executeSQL).toHaveBeenCalledWith('SELECT * FROM users', { readonly: false, maxRows: undefined });
     });
 
     it('should pass multi-statement SQL directly to connector', async () => {
       const mockResult: SQLResult = {
         resultSets: [
-          { rows: [{ id: 1 }], rowCount: 1 },
-          { rows: [{ id: 2 }], rowCount: 1 },
+          { sql: 'SELECT * FROM users', rows: [{ id: 1 }], rowCount: 1 },
+          { sql: 'SELECT * FROM roles', rows: [{ id: 2 }], rowCount: 1 },
         ],
       };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
@@ -80,9 +84,9 @@ describe('execute-sql tool', () => {
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
-      expect(parsedResult.data.resultSets).toEqual([
-        { rows: [{ id: 1 }], count: 1 },
-        { rows: [{ id: 2 }], count: 1 },
+      expect(parsedResult.data.statements).toEqual([
+        { sql: 'SELECT * FROM users', rows: [{ id: 1 }], count: 1 },
+        { sql: 'SELECT * FROM roles', rows: [{ id: 2 }], count: 1 },
       ]);
       expect(mockConnector.executeSQL).toHaveBeenCalledWith(sql, { readonly: false, maxRows: undefined });
     });

--- a/src/tools/__tests__/execute-sql.test.ts
+++ b/src/tools/__tests__/execute-sql.test.ts
@@ -53,7 +53,7 @@ describe('execute-sql tool', () => {
 
   describe('basic execution', () => {
     it('should execute SELECT and return rows', async () => {
-      const mockResult: SQLResult = { rows: [{ id: 1, name: 'test' }], rowCount: 1 };
+      const mockResult: SQLResult = { resultSets: [{ rows: [{ id: 1, name: 'test' }], rowCount: 1 }] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('test_source');
@@ -61,13 +61,17 @@ describe('execute-sql tool', () => {
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
-      expect(parsedResult.data.rows).toEqual([{ id: 1, name: 'test' }]);
-      expect(parsedResult.data.count).toBe(1);
+      expect(parsedResult.data.resultSets).toEqual([{ rows: [{ id: 1, name: 'test' }], count: 1 }]);
       expect(mockConnector.executeSQL).toHaveBeenCalledWith('SELECT * FROM users', { readonly: false, maxRows: undefined });
     });
 
     it('should pass multi-statement SQL directly to connector', async () => {
-      const mockResult: SQLResult = { rows: [{ id: 1 }], rowCount: 1 };
+      const mockResult: SQLResult = {
+        resultSets: [
+          { rows: [{ id: 1 }], rowCount: 1 },
+          { rows: [{ id: 2 }], rowCount: 1 },
+        ],
+      };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const sql = 'SELECT * FROM users; SELECT * FROM roles;';
@@ -76,6 +80,10 @@ describe('execute-sql tool', () => {
       const parsedResult = parseToolResponse(result);
 
       expect(parsedResult.success).toBe(true);
+      expect(parsedResult.data.resultSets).toEqual([
+        { rows: [{ id: 1 }], count: 1 },
+        { rows: [{ id: 2 }], count: 1 },
+      ]);
       expect(mockConnector.executeSQL).toHaveBeenCalledWith(sql, { readonly: false, maxRows: undefined });
     });
 
@@ -165,7 +173,7 @@ describe('execute-sql tool', () => {
     });
 
     it('should allow SELECT statements', async () => {
-      const mockResult: SQLResult = { rows: [{ id: 1 }], rowCount: 1 };
+      const mockResult: SQLResult = { resultSets: [{ rows: [{ id: 1 }], rowCount: 1 }] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('test_source');
@@ -225,7 +233,7 @@ describe('execute-sql tool', () => {
       ['empty string', ''],
       ['only semicolons and whitespace', '   ;  ;  ; '],
     ])('should handle %s', async (_, sql) => {
-      const mockResult: SQLResult = { rows: [], rowCount: 0 };
+      const mockResult: SQLResult = { resultSets: [{ rows: [], rowCount: 0 }] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExecuteSqlToolHandler('test_source');

--- a/src/tools/__tests__/explain-sql.test.ts
+++ b/src/tools/__tests__/explain-sql.test.ts
@@ -49,7 +49,7 @@ describe('explain-sql tool', () => {
     ] satisfies [ConnectorType, string][])('builds "%s" as expected for %s', async (dialect, expected) => {
       const mockConnector = createMockConnector(dialect, 'test_source');
       mockGetCurrentConnector.mockReturnValue(mockConnector);
-      const mockResult: SQLResult = { rows: [{ plan: 'x' }], rowCount: 1 };
+      const mockResult: SQLResult = { resultSets: [{ rows: [{ plan: 'x' }], rowCount: 1 }] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExplainSqlToolHandler('test_source');
@@ -112,7 +112,7 @@ describe('explain-sql tool', () => {
     });
 
     it('allows a leading parenthesized option list that does not contain ANALYZE', async () => {
-      const mockResult: SQLResult = { rows: [{ plan: 'x' }], rowCount: 1 };
+      const mockResult: SQLResult = { resultSets: [{ rows: [{ plan: 'x' }], rowCount: 1 }] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExplainSqlToolHandler('test_source');
@@ -126,7 +126,7 @@ describe('explain-sql tool', () => {
     });
 
     it('allows explaining a write statement (plain EXPLAIN never executes it)', async () => {
-      const mockResult: SQLResult = { rows: [{ plan: 'x' }], rowCount: 1 };
+      const mockResult: SQLResult = { resultSets: [{ rows: [{ plan: 'x' }], rowCount: 1 }] };
       vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
 
       const handler = createExplainSqlToolHandler('test_source');
@@ -145,7 +145,7 @@ describe('explain-sql tool', () => {
       vi.mocked(ConnectorManager.getAvailableSourceIds).mockReturnValue(['prod']);
       const mockConnector = createMockConnector('postgres', 'prod');
       mockGetCurrentConnector.mockReturnValue(mockConnector);
-      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [], rowCount: 0 });
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [{ rows: [], rowCount: 0 }] });
       const addSpy = vi.spyOn(requestStore, 'add');
 
       const handler = createExplainSqlToolHandler('prod');
@@ -158,7 +158,7 @@ describe('explain-sql tool', () => {
       vi.mocked(ConnectorManager.getAvailableSourceIds).mockReturnValue(['prod-pg', 'staging']);
       const mockConnector = createMockConnector('postgres', 'prod-pg');
       mockGetCurrentConnector.mockReturnValue(mockConnector);
-      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [], rowCount: 0 });
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [{ rows: [], rowCount: 0 }] });
       const addSpy = vi.spyOn(requestStore, 'add');
 
       const handler = createExplainSqlToolHandler('prod-pg');

--- a/src/tools/__tests__/search-objects.test.ts
+++ b/src/tools/__tests__/search-objects.test.ts
@@ -193,7 +193,7 @@ describe('search_database_objects tool', () => {
       ];
 
       vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
-      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 100 }] });
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [{ rows: [{ count: 100 }], rowCount: 1 }] });
 
       const handler = createSearchDatabaseObjectsToolHandler();
       const result = await handler(
@@ -230,7 +230,7 @@ describe('search_database_objects tool', () => {
 
       vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
       vi.mocked(mockConnector.getTableIndexes).mockResolvedValue(mockIndexes);
-      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 50 }] });
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [{ rows: [{ count: 50 }], rowCount: 1 }] });
 
       const handler = createSearchDatabaseObjectsToolHandler();
       const result = await handler(
@@ -270,7 +270,7 @@ describe('search_database_objects tool', () => {
       ];
 
       vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
-      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 10 }] });
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [{ rows: [{ count: 10 }], rowCount: 1 }] });
       mockConnector.getTableComment = vi.fn().mockResolvedValue('Application users');
 
       const handler = createSearchDatabaseObjectsToolHandler();
@@ -293,7 +293,7 @@ describe('search_database_objects tool', () => {
       ];
 
       vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
-      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 10 }] });
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [{ rows: [{ count: 10 }], rowCount: 1 }] });
       mockConnector.getTableComment = vi.fn().mockResolvedValue(null);
 
       const handler = createSearchDatabaseObjectsToolHandler();
@@ -321,7 +321,7 @@ describe('search_database_objects tool', () => {
 
       vi.mocked(mockConnector.getTableSchema).mockResolvedValue(mockColumns);
       vi.mocked(mockConnector.getTableIndexes).mockResolvedValue(mockIndexes);
-      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 50 }] });
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [{ rows: [{ count: 50 }], rowCount: 1 }] });
       mockConnector.getTableComment = vi.fn().mockResolvedValue('Application users');
 
       const handler = createSearchDatabaseObjectsToolHandler();
@@ -385,7 +385,7 @@ describe('search_database_objects tool', () => {
     it('should fall back to executeSQL with COUNT(*) when connector lacks getTableRowCount', async () => {
       // Default mock connector does not have getTableRowCount
       delete (mockConnector as any).getTableRowCount;
-      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ rows: [{ count: 99 }] });
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [{ rows: [{ count: 99 }], rowCount: 1 }] });
 
       const handler = createSearchDatabaseObjectsToolHandler();
       const result = await handler(

--- a/src/tools/custom-tool-handler.ts
+++ b/src/tools/custom-tool-handler.ts
@@ -221,10 +221,11 @@ export function createCustomToolHandler(toolConfig: ToolConfig) {
       );
 
       // 8. Build response data. A custom tool's statement is usually one
-      // SQL statement, but isn't restricted to be - surface every result
-      // set produced rather than assuming exactly one.
+      // SQL statement, but isn't restricted to be - surface every statement's
+      // result rather than assuming exactly one.
       const responseData = {
-        resultSets: result.resultSets.map((set: { rows: any[]; rowCount: number }) => ({
+        statements: result.resultSets.map((set: { sql?: string; rows: any[]; rowCount: number }) => ({
+          sql: set.sql,
           rows: set.rows,
           count: set.rowCount,
         })),

--- a/src/tools/custom-tool-handler.ts
+++ b/src/tools/custom-tool-handler.ts
@@ -220,10 +220,14 @@ export function createCustomToolHandler(toolConfig: ToolConfig) {
         paramValues
       );
 
-      // 8. Build response data
+      // 8. Build response data. A custom tool's statement is usually one
+      // SQL statement, but isn't restricted to be - surface every result
+      // set produced rather than assuming exactly one.
       const responseData = {
-        rows: result.rows,
-        count: result.rowCount,
+        resultSets: result.resultSets.map((set: { rows: any[]; rowCount: number }) => ({
+          rows: set.rows,
+          count: set.rowCount,
+        })),
         source_id: toolConfig.source,
       };
 

--- a/src/tools/custom-tool-handler.ts
+++ b/src/tools/custom-tool-handler.ts
@@ -13,6 +13,7 @@ import {
 import { mapArgumentsToArray } from "../utils/parameter-mapper.js";
 import {
   createReadonlyViolationMessage,
+  toStatementsPayload,
   trackToolRequest,
   tryClassifyConnectionError,
 } from "../utils/tool-handler-helpers.js";
@@ -224,11 +225,7 @@ export function createCustomToolHandler(toolConfig: ToolConfig) {
       // SQL statement, but isn't restricted to be - surface every statement's
       // result rather than assuming exactly one.
       const responseData = {
-        statements: result.resultSets.map((set: { sql?: string; rows: any[]; rowCount: number }) => ({
-          sql: set.sql,
-          rows: set.rows,
-          count: set.rowCount,
-        })),
+        statements: toStatementsPayload(result.resultSets),
         source_id: toolConfig.source,
       };
 

--- a/src/tools/execute-sql.ts
+++ b/src/tools/execute-sql.ts
@@ -66,10 +66,11 @@ export function createExecuteSqlToolHandler(sourceId?: string) {
       result = await connector.executeSQL(sql, executeOptions);
 
       // Build response data. Every statement in the batch gets its own
-      // result set - a single SELECT (the common case) is resultSets of
-      // length 1, rather than rows from different statements being merged.
+      // entry - a single SELECT (the common case) is `statements` of length
+      // 1, rather than rows from different statements being merged.
       const responseData = {
-        resultSets: result.resultSets.map((set: { rows: any[]; rowCount: number }) => ({
+        statements: result.resultSets.map((set: { sql?: string; rows: any[]; rowCount: number }) => ({
+          sql: set.sql,
           rows: set.rows,
           count: set.rowCount,
         })),

--- a/src/tools/execute-sql.ts
+++ b/src/tools/execute-sql.ts
@@ -65,10 +65,14 @@ export function createExecuteSqlToolHandler(sourceId?: string) {
       };
       result = await connector.executeSQL(sql, executeOptions);
 
-      // Build response data
+      // Build response data. Every statement in the batch gets its own
+      // result set - a single SELECT (the common case) is resultSets of
+      // length 1, rather than rows from different statements being merged.
       const responseData = {
-        rows: result.rows,
-        count: result.rowCount,
+        resultSets: result.resultSets.map((set: { rows: any[]; rowCount: number }) => ({
+          rows: set.rows,
+          count: set.rowCount,
+        })),
         source_id: effectiveSourceId,
         ...(result.messages && result.messages.length > 0 ? { messages: result.messages } : {}),
       };

--- a/src/tools/execute-sql.ts
+++ b/src/tools/execute-sql.ts
@@ -7,6 +7,7 @@ import { getToolRegistry } from "./registry.js";
 import { BUILTIN_TOOL_EXECUTE_SQL } from "./builtin-tools.js";
 import {
   getEffectiveSourceId,
+  toStatementsPayload,
   trackToolRequest,
   tryClassifyConnectionError,
 } from "../utils/tool-handler-helpers.js";
@@ -69,11 +70,7 @@ export function createExecuteSqlToolHandler(sourceId?: string) {
       // entry - a single SELECT (the common case) is `statements` of length
       // 1, rather than rows from different statements being merged.
       const responseData = {
-        statements: result.resultSets.map((set: { sql?: string; rows: any[]; rowCount: number }) => ({
-          sql: set.sql,
-          rows: set.rows,
-          count: set.rowCount,
-        })),
+        statements: toStatementsPayload(result.resultSets),
         source_id: effectiveSourceId,
         ...(result.messages && result.messages.length > 0 ? { messages: result.messages } : {}),
       };

--- a/src/tools/explain-sql.ts
+++ b/src/tools/explain-sql.ts
@@ -106,9 +106,11 @@ export function createExplainSqlToolHandler(sourceId?: string) {
       const explainStatement = buildExplainStatement(connector.id, sql);
       result = await connector.executeSQL(explainStatement, { readonly: true });
 
+      // explain_sql only ever accepts a single statement (validateExplainInput
+      // above rejects anything else), so exactly one result set comes back.
       const responseData = {
-        rows: result.rows,
-        count: result.rowCount,
+        rows: result.resultSets[0].rows,
+        count: result.resultSets[0].rowCount,
         source_id: effectiveSourceId,
         ...(result.messages && result.messages.length > 0 ? { messages: result.messages } : {}),
       };

--- a/src/tools/search-objects.ts
+++ b/src/tools/search-objects.ts
@@ -115,8 +115,9 @@ async function getTableRowCount(
     // invariant that holds by inspection rather than by argument.
     const result = await connector.executeSQL(countQuery, { maxRows: 1, readonly: true });
 
-    if (result.rows && result.rows.length > 0) {
-      return Number(result.rows[0].count || result.rows[0].COUNT || 0);
+    const rows = result.resultSets[0]?.rows;
+    if (rows && rows.length > 0) {
+      return Number(rows[0].count || rows[0].COUNT || 0);
     }
   } catch (error) {
     // If we can't get row count, return null (not critical)

--- a/src/utils/multi-statement-result-parser.ts
+++ b/src/utils/multi-statement-result-parser.ts
@@ -3,8 +3,10 @@
  *
  * Provides shared logic for parsing multi-statement SQL execution results
  * from different database drivers (MariaDB, MySQL2) that have similar but
- * slightly different result formats.
+ * slightly different result formats, into a list of per-statement result sets.
  */
+
+import type { SQLResultSet } from "../connectors/interface.js";
 
 /**
  * Checks if an element is a metadata object from INSERT/UPDATE/DELETE operations
@@ -45,86 +47,46 @@ function isMultiStatementResult(results: any): boolean {
 }
 
 /**
- * Extracts row arrays from multi-statement results, filtering out metadata objects.
- *
- * @param results - The raw results from a multi-statement query
- * @returns Array containing only the rows from SELECT queries
+ * Builds one `SQLResultSet` per statement from raw multi-statement driver
+ * results, preserving statement order. A `SELECT` becomes `{rows, rowCount:
+ * rows.length}`; an INSERT/UPDATE/DELETE metadata object becomes `{rows: [],
+ * rowCount: affectedRows}`.
  */
-export function extractRowsFromMultiStatement(results: any): any[] {
-  if (!Array.isArray(results)) {
-    return [];
-  }
-
-  const allRows: any[] = [];
-
-  for (const result of results) {
+function buildResultSetsFromMultiStatement(results: any[]): SQLResultSet[] {
+  return results.map((result) => {
     if (Array.isArray(result)) {
-      // This is a row array from a SELECT query - add all rows
-      allRows.push(...result);
+      return { rows: result, rowCount: result.length };
     }
-    // Skip metadata objects from INSERT/UPDATE/DELETE
-  }
-
-  return allRows;
+    if (isMetadataObject(result)) {
+      return { rows: [], rowCount: result.affectedRows || 0 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
 }
 
 /**
- * Extracts total affected rows from query results.
+ * Parses raw database query results into a list of per-statement result
+ * sets, handling both single and multi-statement queries.
  *
- * For INSERT/UPDATE/DELETE operations, returns the sum of affectedRows.
- * For SELECT operations, returns the number of rows.
+ * This function unifies the result parsing logic for MariaDB and MySQL2
+ * drivers, which have similar but slightly different result formats.
  *
  * @param results - Raw results from the database driver
- * @returns Total number of affected/returned rows
+ * @returns One `SQLResultSet` per statement, in execution order
  */
-export function extractAffectedRows(results: any): number {
-  // Handle metadata object (single INSERT/UPDATE/DELETE)
+export function parseQueryResultSets(results: any): SQLResultSet[] {
+  // Non-array results (e.g. a single INSERT/UPDATE/DELETE without RETURNING)
   if (isMetadataObject(results)) {
-    return results.affectedRows || 0;
+    return [{ rows: [], rowCount: results.affectedRows || 0 }];
   }
-
-  // Handle non-array results
   if (!Array.isArray(results)) {
-    return 0;
+    return [{ rows: [], rowCount: 0 }];
   }
 
-  // Check if this is a multi-statement result
   if (isMultiStatementResult(results)) {
-    let totalAffected = 0;
-    for (const result of results) {
-      if (isMetadataObject(result)) {
-        totalAffected += result.affectedRows || 0;
-      } else if (Array.isArray(result)) {
-        totalAffected += result.length;
-      }
-    }
-    return totalAffected;
+    return buildResultSetsFromMultiStatement(results);
   }
 
   // Single statement result - results is the rows array directly
-  return results.length;
-}
-
-/**
- * Parses database query results, handling both single and multi-statement queries.
- *
- * This function unifies the result parsing logic for MariaDB and MySQL2 drivers,
- * which have similar but slightly different result formats.
- *
- * @param results - Raw results from the database driver
- * @returns Array of row objects from SELECT queries
- */
-export function parseQueryResults(results: any): any[] {
-  // Handle non-array results (e.g., from INSERT/UPDATE/DELETE without RETURNING)
-  if (!Array.isArray(results)) {
-    return [];
-  }
-
-  // Check if this is a multi-statement result
-  if (isMultiStatementResult(results)) {
-    return extractRowsFromMultiStatement(results);
-  }
-
-  // Single statement result - results is the rows array directly
-  return results;
+  return [{ rows: results, rowCount: results.length }];
 }

--- a/src/utils/multi-statement-result-parser.ts
+++ b/src/utils/multi-statement-result-parser.ts
@@ -50,17 +50,21 @@ function isMultiStatementResult(results: any): boolean {
  * Builds one `SQLResultSet` per statement from raw multi-statement driver
  * results, preserving statement order. A `SELECT` becomes `{rows, rowCount:
  * rows.length}`; an INSERT/UPDATE/DELETE metadata object becomes `{rows: [],
- * rowCount: affectedRows}`.
+ * rowCount: affectedRows}`. `statementTexts`, when its length matches the
+ * driver's result count, attributes each set to the statement that produced
+ * it - both drivers return one entry per statement in source order, so a
+ * length match means the pairing is exact, not a guess.
  */
-function buildResultSetsFromMultiStatement(results: any[]): SQLResultSet[] {
-  return results.map((result) => {
+function buildResultSetsFromMultiStatement(results: any[], statementTexts?: string[]): SQLResultSet[] {
+  const sql = statementTexts?.length === results.length ? statementTexts : undefined;
+  return results.map((result, index) => {
     if (Array.isArray(result)) {
-      return { rows: result, rowCount: result.length };
+      return { sql: sql?.[index], rows: result, rowCount: result.length };
     }
     if (isMetadataObject(result)) {
-      return { rows: [], rowCount: result.affectedRows || 0 };
+      return { sql: sql?.[index], rows: [], rowCount: result.affectedRows || 0 };
     }
-    return { rows: [], rowCount: 0 };
+    return { sql: sql?.[index], rows: [], rowCount: 0 };
   });
 }
 
@@ -72,21 +76,25 @@ function buildResultSetsFromMultiStatement(results: any[]): SQLResultSet[] {
  * drivers, which have similar but slightly different result formats.
  *
  * @param results - Raw results from the database driver
+ * @param statementTexts - The original, source-order statement texts, used
+ * to attribute each result set to the statement that produced it
  * @returns One `SQLResultSet` per statement, in execution order
  */
-export function parseQueryResultSets(results: any): SQLResultSet[] {
+export function parseQueryResultSets(results: any, statementTexts?: string[]): SQLResultSet[] {
+  const singleStatementSql = statementTexts?.length === 1 ? statementTexts[0] : undefined;
+
   // Non-array results (e.g. a single INSERT/UPDATE/DELETE without RETURNING)
   if (isMetadataObject(results)) {
-    return [{ rows: [], rowCount: results.affectedRows || 0 }];
+    return [{ sql: singleStatementSql, rows: [], rowCount: results.affectedRows || 0 }];
   }
   if (!Array.isArray(results)) {
-    return [{ rows: [], rowCount: 0 }];
+    return [{ sql: singleStatementSql, rows: [], rowCount: 0 }];
   }
 
   if (isMultiStatementResult(results)) {
-    return buildResultSetsFromMultiStatement(results);
+    return buildResultSetsFromMultiStatement(results, statementTexts);
   }
 
   // Single statement result - results is the rows array directly
-  return [{ rows: results, rowCount: results.length }];
+  return [{ sql: singleStatementSql, rows: results, rowCount: results.length }];
 }

--- a/src/utils/tool-handler-helpers.ts
+++ b/src/utils/tool-handler-helpers.ts
@@ -3,7 +3,7 @@
  * Shared utilities for MCP tool handlers to reduce boilerplate
  */
 
-import { ConnectorType } from "../connectors/interface.js";
+import { ConnectorType, SQLResultSet } from "../connectors/interface.js";
 import { ConnectorManager } from "../connectors/manager.js";
 import { allowedKeywords } from "./allowed-keywords.js";
 import { requestStore } from "../requests/index.js";
@@ -28,6 +28,21 @@ export interface RequestMetadata {
  */
 export function getEffectiveSourceId(sourceId?: string): string {
   return sourceId || "default";
+}
+
+/**
+ * Shapes a connector's per-statement result sets into the tool response's
+ * `statements` field. Shared by execute_sql and custom tools so their output
+ * contracts can't silently diverge (e.g. one gaining a field the other doesn't).
+ */
+export function toStatementsPayload(
+  resultSets: SQLResultSet[]
+): Array<{ sql?: string; rows: any[]; count: number }> {
+  return resultSets.map((set) => ({
+    sql: set.sql,
+    rows: set.rows,
+    count: set.rowCount,
+  }));
 }
 
 /**


### PR DESCRIPTION
## Summary

Started as the SQL Server fix for #380 (dropped result sets in a multi-statement batch), but landed on a broader redesign: instead of flattening every statement's rows into one array, `SQLResult` now returns a list of per-statement results, and the local web frontend gets a real multi-tab UI for it.

**Why the redesign, not just a SQL Server fix:** making SQL Server flatten multi-statement rows the same way MySQL/MariaDB already did was itself the wrong shape. `SELECT 1 AS a; SELECT 2 AS b` returning `{rows: [{a:1},{b:2}], rowCount: 2}` is indistinguishable from a single query that returned two differently-shaped rows glued together - a caller has no way to tell where one statement's output ends and the next begins.

**Backend (`src/connectors/interface.ts`):**
- `SQLResult` is now `{ resultSets: SQLResultSet[], messages? }`, one entry per statement in execution order. Each `SQLResultSet` also carries an optional `sql` - the statement that produced it, when a connector can attribute it unambiguously.
- postgres/sqlite/mysql/mariadb populate `sql` for every statement (they process statements in a way that preserves reliable order/count alignment). SQL Server only populates it for an unambiguous single-statement batch: node-mssql's `recordsets`/`rowsAffected` arrays aren't index-aligned per statement (documented in `buildResultSets`), so a batch mixing writes with selects gets one result set per SELECT plus a trailing result set summarizing the write-only statements - not fully per-statement, but no read statement's rows are ever merged with another's, which is the actual #380 bug.
- `execute_sql`/custom-tool JSON responses now key their statement list as `statements: [{sql, rows, count}, ...]` instead of flat `rows`/`count`. `explain_sql` keeps its flat shape since it only ever runs exactly one statement.

**Frontend (`frontend/`):** the shipped local web UI reads `execute_sql`'s response directly and broke under this change, so it's rebuilt around the same idea: `executeTool()` now returns one `QueryResult` per statement instead of a single merged result, and `ToolDetailView` creates one result tab per statement (labeled `(i/N)` for batches of more than one) instead of forcing a whole batch into a single tab. Verified end-to-end in a browser against the `--demo` SQLite backend.

Also fixed, as a byproduct of that browser verification: `frontend/src/api/tools.ts` called `response.json()` directly, but the backend's stateless HTTP transport answers SSE-framed responses for this request shape - every query through the web UI over HTTP transport was silently broken before this PR too, unrelated to the `resultSets` change itself.

**BREAKING CHANGE:** `execute_sql`/custom tool JSON responses no longer have top-level `rows`/`count` - they're under `statements`, each entry additionally carrying `sql`.

## Test plan
- [x] New integration tests per connector for multi-statement batches
- [x] `pnpm test` - full suite, 1272/1272 passing
- [x] `pnpm exec tsc --noEmit` (backend) and `tsc -b` (frontend) - no new errors
- [x] Manual verification in a browser: multi-statement batch → two correctly-labeled tabs, each with its own SQL/rows; single-statement query → one untabbed tab, unchanged

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)