### PR TITLE
chore: release 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbhub",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "mcpName": "io.github.bytebase/dbhub",
   "description": "Minimal, token-efficient Database MCP Server for PostgreSQL, MySQL, SQL Server, SQLite, MariaDB",
   "repository": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dbhub",
   "description": "Token-efficient database MCP server for PostgreSQL, MySQL, MariaDB, SQL Server, and SQLite, with skills for connection setup and schema exploration",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Bytebase",
     "url": "https://www.bytebase.com"

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@bytebase/dbhub@1.1.0",
+        "@bytebase/dbhub@1.2.0",
         "--transport",
         "stdio",
         "--config",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/bytebase/dbhub",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@bytebase/dbhub",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bumps the version to 1.2.0 (`pnpm version`, synced into `plugin/.claude-plugin/plugin.json`, `plugin/.mcp.json`, and `server.json`).

## Changes since 1.1.0

### Features
- Bearer token auth for the HTTP transport via `--auth-token` / `DBHUB_AUTH_TOKEN`, with comma-separated tokens for zero-downtime rotation (#390)
- **Breaking:** `execute_sql` returns per-statement result sets for multi-statement queries, wired up to frontend tabs (#389)

### Fixes
- SQL Server: enforce `max_rows` across `UNION`/`INTERSECT`/`EXCEPT` compound queries (#388)
- MySQL: kill the server-side query on timeout instead of leaking it back into the connection pool (#386)

### Docs & chores
- Render env var names in command-line flag docs (#391)
- Trim verbose tool descriptions and fix `search_objects` parameter drift
- Revise `health_check` tool description
- README fixes
- Single-source version sync for the plugin and `server.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)