### PR TITLE
fix: split DSN credentials on the last @ of the authority

### DIFF
--- a/src/utils/__tests__/dsn-obfuscate.test.ts
+++ b/src/utils/__tests__/dsn-obfuscate.test.ts
@@ -67,6 +67,17 @@ describe('DSN Obfuscation Utilities', () => {
       const result = obfuscateDSNPassword(dsn);
       expect(result).toBe('postgres://user:****@localhost:5432?sslmode=require');
     });
+
+    it('should obfuscate the whole password when it contains an @', () => {
+      // Splitting the authority on the first '@' masks only the part before it
+      // and leaves the rest in the string, so the tail of the password reaches
+      // whatever reads this line — DBHub prints it per source at startup.
+      const dsn = 'postgres://user:pa@ss@localhost:5432/db';
+      const result = obfuscateDSNPassword(dsn);
+
+      expect(result).toBe('postgres://user:*****@localhost:5432/db');
+      expect(result).not.toContain('ss@');
+    });
   });
 
   describe('obfuscateSSHConfig', () => {

--- a/src/utils/__tests__/safe-url.test.ts
+++ b/src/utils/__tests__/safe-url.test.ts
@@ -104,4 +104,61 @@ describe('SafeURL', () => {
   it('should throw an error for URLs without a protocol', () => {
     expect(() => new SafeURL('localhost:5432/dbname')).toThrow('Invalid URL format: missing protocol');
   });
+
+  describe("'@' inside the password", () => {
+    it('splits on the last @ of the authority, not the first', () => {
+      // Splitting on the first '@' yields password 'pa' and hostname
+      // 'ss@localhost', so the failure surfaces as a DNS lookup error rather
+      // than as a bad password — a confusing way to learn it was truncated.
+      const url = new SafeURL('sqlserver://user:pa@ss@localhost/dbname');
+
+      expect(url.username).toBe('user');
+      expect(url.password).toBe('pa@ss');
+      expect(url.hostname).toBe('localhost');
+      expect(url.pathname).toBe('/dbname');
+    });
+
+    it('handles a password containing several @ characters', () => {
+      const url = new SafeURL('sqlserver://user:a@b@c@host/db');
+
+      expect(url.username).toBe('user');
+      expect(url.password).toBe('a@b@c');
+      expect(url.hostname).toBe('host');
+    });
+
+    it('does not treat an @ in the path as the separator', () => {
+      // The path is still attached when the authority is split, so an unbounded
+      // lastIndexOf would pick the '@' in the database name instead.
+      const url = new SafeURL('sqlserver://user:pass@localhost/we@ird');
+
+      expect(url.username).toBe('user');
+      expect(url.password).toBe('pass');
+      expect(url.hostname).toBe('localhost');
+      expect(url.pathname).toBe('/we@ird');
+    });
+
+    it('keeps working when only the path contains an @', () => {
+      const url = new SafeURL('sqlserver://localhost/we@ird');
+
+      expect(url.username).toBe('');
+      expect(url.password).toBe('');
+      expect(url.hostname).toBe('localhost');
+      expect(url.pathname).toBe('/we@ird');
+    });
+
+    it('still accepts a percent-encoded @', () => {
+      const url = new SafeURL('sqlserver://user:pa%40ss@localhost/dbname');
+
+      expect(url.password).toBe('pa@ss');
+      expect(url.hostname).toBe('localhost');
+    });
+
+    it('keeps the port when the password carries an @', () => {
+      const url = new SafeURL('sqlserver://user:pa@ss@localhost:1433/dbname');
+
+      expect(url.password).toBe('pa@ss');
+      expect(url.hostname).toBe('localhost');
+      expect(url.port).toBe('1433');
+    });
+  });
 });

--- a/src/utils/safe-url.ts
+++ b/src/utils/safe-url.ts
@@ -82,8 +82,20 @@ export class SafeURL implements ISafeURL {
         });
       }
 
-      // Extract authentication
-      const atIndex: number = urlString.indexOf('@');
+      // Extract authentication.
+      //
+      // The separator is the LAST '@' of the authority, not the first: '@' is a
+      // legal password character, and passwords carrying one are common. Taking
+      // the first '@' would cut the password short and fold its tail into the
+      // hostname, which surfaces as a DNS failure rather than as a bad password.
+      //
+      // The search is bounded by the start of the path, because the path is
+      // still attached at this point and may legitimately contain '@' (a
+      // database named "a@b", say) — an unbounded lastIndexOf would then treat
+      // that one as the separator.
+      const pathStart: number = urlString.indexOf('/');
+      const authorityEnd: number = pathStart === -1 ? urlString.length : pathStart;
+      const atIndex: number = urlString.lastIndexOf('@', authorityEnd - 1);
       if (atIndex !== -1) {
         const auth: string = urlString.substring(0, atIndex);
         urlString = urlString.substring(atIndex + 1);


### PR DESCRIPTION
`SafeURL` takes the **first** `@` as the userinfo separator. `@` is a legal password character, so a password carrying one is cut short there and its tail is folded into the hostname:

```
postgres://user:pa@ss@dbhost:5432/mydb
→ username "user", password "pa", hostname "ss@dbhost"
```

## Scope

Not connector-specific. `SafeURL` parses the DSN for all five connectors, so any of them rejects a password containing `@`:

| connector | hostname | password |
| --- | --- | --- |
| postgres | `ss@dbhost` | `pa` |
| mysql | `ss@dbhost` | `pa` |
| mariadb | `ss@dbhost` | `pa` |
| sqlserver | `ss@dbhost` | `pa` |

The symptom is a DNS failure on the mangled host (`getaddrinfo EAI_FAIL`), or — when the truncated prefix happens to be a valid password for that account — a plain `Login failed`. Neither points at the password, which makes this slow to diagnose from the outside.

## It also weakens the DSN masking

`obfuscateDSNPassword` masks the DSN before it is logged, and relies on the same split. Given the DSN above it produced:

```
postgres://user:**@ss@dbhost:5432/mydb
```

The part of the password after the `@` stays in the string. DBHub prints that line per source at startup, so the tail reaches the server's log — and on the stdio transport, the client's.

I have filed this as a bug rather than through the advisory process, because the exposure is narrow: it is the operator's own password, on a host that already holds the config file containing it in full, and it only arises in a deployment that cannot connect at all — a password with `@` means DBHub fails fast and never serves anything. Happy to move it if you would rather handle it the other way.

## The fix

Standard URL parsing ends userinfo at the last `@` of the authority, so match that.

The search is bounded by the start of the path, because the path is still attached at that point and may legitimately contain `@` — a database named `a@b`. An unbounded `lastIndexOf` would then pick that one as the separator, trading one bug for another.

Percent-encoding already worked, since the parser decodes username and password. This makes the unencoded form work too, which is what a DSN assembled from an environment variable ends up carrying:

```toml
dsn = "postgres://user:${DB_PASSWORD}@dbhost:5432/mydb"
```

## Testing

Six cases added for `SafeURL`: a password with one `@`, with several, `@` in the path both with and without credentials, the percent-encoded form, and a password with `@` alongside an explicit port — which the previous behaviour also mangled.

One case added for `obfuscateDSNPassword`, which had no coverage for this at all.

Verified to fail against the previous behaviour: reverting the one-line change turns four of the six `SafeURL` cases red, and the masking case too.

Full unit suite green on top of this branch (952 passing; the one failure is a pre-existing Windows-only SSH-config test that fails identically on an unmodified checkout), and no new TypeScript errors — 137 before and after.