### PR TITLE
docs: replace deprecated --max-rows flag reference in execute_sql docs

### DIFF
--- a/docs/tools/execute-sql.mdx
+++ b/docs/tools/execute-sql.mdx
@@ -10,7 +10,7 @@ Execute SQL queries and statements on your database with support for transaction
 - **Multiple statements**: Separate multiple statements with semicolons (`;`)
 - **Transactions**: Wrap operations in `BEGIN`/`COMMIT` blocks for atomic execution
 - **Read-only mode**: Configure a tool with `readonly = true` to restrict execution to read-only operations, enforced by both a keyword classifier and the database's own read-only mode
-- **Row limiting**: Configure `--max-rows` to limit SELECT query results
+- **Row limiting**: Configure `max_rows` per tool via TOML `[[tools]]` to limit SELECT query results
 
 ## Single Query
 


### PR DESCRIPTION
## Summary

The `--max-rows` CLI flag was removed from DBHub — the CLI now prints an error pointing users to the TOML `[[tools]]` configuration instead (see `src/config/env.ts`). The `execute_sql` docs still reference the deprecated flag.

## Change

Update the Row limiting feature entry in `docs/tools/execute-sql.mdx` to reference `max_rows` configured per tool via TOML `[[tools]]`:

```diff
-- **Row limiting**: Configure `--max-rows` to limit SELECT query results
+- **Row limiting**: Configure `max_rows` per tool via TOML `[[tools]]` to limit SELECT query results
```

## Why

- The flag no longer works (exits with an error), so the docs currently describe a non-existent feature
- TOML is the supported way to configure row limiting since the flag was removed

Single-line, docs-only change. No behavior change.