### PR TITLE
docs: add See Also cross-links to tool and config pages

### DIFF
--- a/docs/config/debug.mdx
+++ b/docs/config/debug.mdx
@@ -48,3 +48,8 @@ If DBHub connects but database queries fail:
 ### Logs
 
 DBHub prints startup and error messages to stderr. There is no adjustable log level — review that output, and the MCP Inspector above, when troubleshooting.
+
+## See Also
+
+- [Command-Line Options](/config/command-line) — CLI flags and environment variables
+- [TOML Configuration](/config/toml) — Multi-database setup

--- a/docs/tools/explain-sql.mdx
+++ b/docs/tools/explain-sql.mdx
@@ -58,3 +58,10 @@ source = "production"
 ```
 
 See [Tool Configuration](/tools/overview#tool-configuration) for how `[[tools]]` entries work across multiple sources.
+
+## See Also
+
+- [execute_sql](/tools/execute-sql) — SQL execution with safety controls
+- [search_objects](/tools/search-objects) — Schema and object exploration
+- [Custom Tools](/tools/custom-tools) — Parameterized SQL operations
+- [TOML Configuration](/config/toml) — Tool configuration reference

--- a/docs/tools/health-check.mdx
+++ b/docs/tools/health-check.mdx
@@ -94,3 +94,10 @@ source = "production"
 ```
 
 See [Tool Configuration](/tools/overview#tool-configuration) for how `[[tools]]` entries work across multiple sources.
+
+## See Also
+
+- [execute_sql](/tools/execute-sql) — SQL execution with safety controls
+- [search_objects](/tools/search-objects) — Schema and object exploration
+- [Custom Tools](/tools/custom-tools) — Parameterized SQL operations
+- [TOML Configuration](/config/toml) — Tool configuration reference


### PR DESCRIPTION
## Summary

Add a consistent \`See Also\` section to three pages that end abruptly after their main content and lack cross-references to related topics:

- \`docs/tools/explain-sql.mdx\`
- \`docs/tools/health-check.mdx\`
- \`docs/config/debug.mdx\`

## Change

Each page gains a short list of links to existing pages (\`execute_sql\`, \`search_objects\`, \`custom-tools\`, \`toml\`, \`command-line\`). All targets verified to exist in the current docs tree — no broken links.

## Why

- These pages are discoverable only from the sidebar; readers arriving via search have no way to reach related topics
- The other tool pages (\`execute_sql\`, \`search_objects\`) already follow this pattern
- Docs-only, no behavior change