### PR TITLE
docs: add description frontmatter to 12 pages

### DIFF
--- a/docs/config/command-line.mdx
+++ b/docs/config/command-line.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Command-Line Options"
+description: "Complete reference for DBHub CLI flags, environment variables, and DSN formats"
 ---
 
 DBHub connects to your database in one of two ways:

--- a/docs/config/debug.mdx
+++ b/docs/config/debug.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Debug"
+description: "Troubleshoot DBHub with the MCP Inspector and common connection fixes"
 ---
 
 ## MCP Inspector

--- a/docs/config/toml.mdx
+++ b/docs/config/toml.mdx
@@ -1,5 +1,6 @@
 ---
 title: "TOML Configuration"
+description: "Configure multiple database connections, per-source settings, and custom tools with TOML"
 ---
 
 TOML configuration is the recommended way to configure DBHub for multi-database setups and advanced configurations. It provides more flexibility than command-line options or environment variables.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Introduction"
+description: "DBHub is a minimal, token-efficient database MCP server for PostgreSQL, MySQL, SQL Server, MariaDB, and SQLite"
 ---
 
 <img

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Installation"
+description: "Install DBHub via npm, Docker, MCP Bundle, or Claude Code plugin"
 ---
 
 ## npm

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quickstart"
+description: "Get DBHub running with a database and connected to your AI tool in minutes"
 ---
 
 This guide will walk you through setting up DBHub and connecting it to an AI tool for the first time. We'll use demo mode to get started quickly, then show you how to connect to your own database.

--- a/docs/tools/custom-tools.mdx
+++ b/docs/tools/custom-tools.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Tools"
+description: "Define reusable, parameterized SQL operations as custom MCP tools"
 ---
 
 Custom tools allow you to define reusable, parameterized SQL operations that are automatically registered as MCP tools. They provide type-safe interfaces for common database queries without writing repetitive code.

--- a/docs/tools/execute-sql.mdx
+++ b/docs/tools/execute-sql.mdx
@@ -1,5 +1,6 @@
 ---
 title: "execute_sql"
+description: "Execute SQL queries with transaction support, read-only mode, and row limiting"
 ---
 
 Execute SQL queries and statements on your database with support for transactions, multiple statements, and safety controls.

--- a/docs/tools/explain-sql.mdx
+++ b/docs/tools/explain-sql.mdx
@@ -1,5 +1,6 @@
 ---
 title: "explain_sql"
+description: "Show a query's execution plan without executing it (opt-in)"
 ---
 
 Show the execution plan for a SQL statement without running it.

--- a/docs/tools/health-check.mdx
+++ b/docs/tools/health-check.mdx
@@ -1,5 +1,6 @@
 ---
 title: "health_check"
+description: "Monitor connection pool state and buffer cache hit ratio (opt-in)"
 ---
 
 Report operational health metrics for a database source: connection pool state and buffer cache hit ratio.

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: "Overview of DBHub MCP tools: execute_sql, search_objects, explain_sql, health_check, and custom tools"
 ---
 
 ## Available Tools

--- a/docs/tools/search-objects.mdx
+++ b/docs/tools/search-objects.mdx
@@ -1,5 +1,6 @@
 ---
 title: "search_objects"
+description: "Search and list database schemas, tables, columns, and more with progressive disclosure"
 ---
 
 Search and list database objects (schemas, tables, columns, procedures, functions, indexes) with pattern matching. This unified tool supports both targeted searches and browsing all objects, implementing progressive disclosure to minimize token usage.


### PR DESCRIPTION
## Summary

Add a one-line `description` to the frontmatter of 12 pages that currently only have a `title`.

## Why

Mintlify surfaces the frontmatter `description` in:
- **Search results** — pages without a description render incomplete/blank entries
- **Link previews** — shared doc links show no snippet

Each page gets a concise description matching its existing content. One line per file, no content changes.

## Files

`docs/index.mdx`, `docs/installation.mdx`, `docs/quickstart.mdx`, `docs/tools/overview.mdx`, `docs/tools/execute-sql.mdx`, `docs/tools/search-objects.mdx`, `docs/tools/explain-sql.mdx`, `docs/tools/health-check.mdx`, `docs/tools/custom-tools.mdx`, `docs/config/command-line.mdx`, `docs/config/toml.mdx`, `docs/config/debug.mdx`

12 files, +12 lines, docs-only.