### PR TITLE
fix: honour request cancellation on PostgreSQL, and apply max_rows to comment-prefixed and CTE queries

### DIFF
--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -391,8 +391,9 @@ describe('MySQL Connector Integration Tests', () => {
       expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
-    it('should not apply maxRows to CTE queries (WITH clause)', async () => {
-      // Test that maxRows is not applied to CTE queries (WITH clause)
+    it('should apply maxRows to CTE queries (WITH clause)', async () => {
+      // A CTE is the ordinary shape of an analytical query, so leaving it
+      // uncapped left max_rows silently inert for most real queries.
       try {
         const result = await mysqlTest.connector.executeSQL(`
           WITH user_summary AS (
@@ -400,9 +401,8 @@ describe('MySQL Connector Integration Tests', () => {
           )
           SELECT * FROM user_summary ORDER BY age
         `, { maxRows: 2 });
-        
-        // Should return all rows since WITH queries are not limited
-        expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+
+        expect(result.resultSets[0].rows).toHaveLength(2);
         expect(result.resultSets[0].rows[0]).toHaveProperty('name');
         expect(result.resultSets[0].rows[0]).toHaveProperty('age');
       } catch (error) {

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -738,6 +738,125 @@ describe('PostgreSQL Connector Integration Tests', () => {
     });
   });
 
+  describe('Query cancellation (options.signal)', () => {
+    // A cancelled MCP tool call must stop the query on the *server*. Without
+    // that, aborting only stops us waiting for the answer while the backend
+    // keeps burning IO to produce a result nobody will read.
+    const PROBE = 'dbhub_cancel_probe';
+
+    /** Backends the server currently reports as running the probe query. */
+    const runningProbes = async (observer: PostgresConnector): Promise<number> => {
+      const result = await observer.executeSQL(
+        `SELECT count(*)::int AS n FROM pg_stat_activity
+         WHERE state = 'active'
+           AND query LIKE '%${PROBE}%'
+           AND query NOT LIKE '%pg_stat_activity%'`,
+        {}
+      );
+      return result.resultSets[0].rows[0].n;
+    };
+
+    const waitFor = async (predicate: () => Promise<boolean>, timeoutMs: number) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (await predicate()) return true;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      return false;
+    };
+
+    it.each([
+      ['plain execution', {} as const],
+      ['inside a READ ONLY transaction', { readonly: true } as const],
+    ])('kills the running backend when the request is aborted (%s)', async (_label, options) => {
+      const connector = new PostgresConnector();
+      const observer = new PostgresConnector();
+      try {
+        await connector.connect(postgresTest.connectionString);
+        await observer.connect(postgresTest.connectionString);
+
+        const controller = new AbortController();
+        const query = connector.executeSQL(`SELECT pg_sleep(30), '${PROBE}'`, {
+          ...options,
+          signal: controller.signal,
+        });
+        // Capture the rejection now so polling below can't trip an unhandled one.
+        const settled = query.then(
+          () => null,
+          (error) => error as NodeJS.ErrnoException
+        );
+
+        expect(await waitFor(async () => (await runningProbes(observer)) === 1, 10000)).toBe(true);
+
+        controller.abort();
+
+        const error = await settled;
+        expect(error).toBeInstanceOf(Error);
+        // 57014 = query_canceled: the server stopped it, we didn't just walk away.
+        expect((error as any).code).toBe('57014');
+
+        expect(await waitFor(async () => (await runningProbes(observer)) === 0, 10000)).toBe(true);
+      } finally {
+        await connector.disconnect();
+        await observer.disconnect();
+      }
+    }, 60000);
+
+    it('leaves the connector usable after a cancellation', async () => {
+      // The cancelled connection is destroyed rather than returned to the pool:
+      // a CancelRequest races the statement it targets, so it can land on the
+      // cleanup ROLLBACK instead and strand the session in an aborted
+      // transaction that the next borrower would inherit.
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(postgresTest.connectionString);
+
+        const controller = new AbortController();
+        const cancelled = connector
+          .executeSQL(`SELECT pg_sleep(30), '${PROBE}'`, {
+            readonly: true,
+            signal: controller.signal,
+          })
+          .catch(() => 'rejected');
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        controller.abort();
+        expect(await cancelled).toBe('rejected');
+
+        const after = await connector.executeSQL('SELECT 1 AS ok', { readonly: true });
+        expect(after.resultSets[0].rows[0].ok).toBe(1);
+      } finally {
+        await connector.disconnect();
+      }
+    }, 60000);
+
+    it('does not run the query at all when the signal is already aborted', async () => {
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(postgresTest.connectionString);
+
+        const controller = new AbortController();
+        controller.abort();
+
+        await expect(
+          connector.executeSQL('SELECT 1', { signal: controller.signal })
+        ).rejects.toThrow();
+      } finally {
+        await connector.disconnect();
+      }
+    }, 30000);
+
+    it('runs normally when no signal is supplied', async () => {
+      const connector = new PostgresConnector();
+      try {
+        await connector.connect(postgresTest.connectionString);
+        const result = await connector.executeSQL('SELECT 1 AS ok', {});
+        expect(result.resultSets[0].rows[0].ok).toBe(1);
+      } finally {
+        await connector.disconnect();
+      }
+    }, 30000);
+  });
+
   describe('Search Path Configuration Tests', () => {
     it('should use first schema in search_path as default for discovery', async () => {
       const connector = new PostgresConnector();

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -460,19 +460,58 @@ describe('PostgreSQL Connector Integration Tests', () => {
       expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
-    it('should not apply maxRows to CTE queries (WITH clause)', async () => {
-      // Test that maxRows is not applied to CTE queries (WITH clause)
+    it('should apply maxRows to CTE queries (WITH clause)', async () => {
+      // A CTE is the ordinary shape of an analytical query, so leaving it
+      // uncapped left max_rows silently inert for most real queries.
       const result = await postgresTest.connector.executeSQL(`
         WITH user_summary AS (
           SELECT name, age FROM users WHERE age IS NOT NULL
         )
         SELECT * FROM user_summary ORDER BY age
       `, { maxRows: 2 });
-      
-      // Should return all rows since WITH queries are not limited anymore
-      expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[0]).toHaveProperty('age');
+    });
+
+    it('should apply maxRows to a query introduced by a comment', async () => {
+      const result = await postgresTest.connector.executeSQL(
+        '-- dbhub attribution tag\nSELECT name FROM users ORDER BY name',
+        { maxRows: 2 }
+      );
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
+    });
+
+    it('should cap the statement itself rather than tightening a CTE\'s own LIMIT', async () => {
+      // The inner LIMIT caps only the CTE; the statement can still return more
+      // rows than that, so it needs a cap of its own.
+      const result = await postgresTest.connector.executeSQL(`
+        WITH first_three AS (
+          SELECT name FROM users ORDER BY name LIMIT 3
+        )
+        SELECT * FROM first_three
+      `, { maxRows: 2 });
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
+    });
+
+    it('should not apply maxRows to a data-modifying CTE', async () => {
+      const result = await postgresTest.connector.executeSQL(`
+        WITH inserted AS (
+          INSERT INTO users (name, email, age)
+          VALUES ('dm1', 'dm1@dm.com', 41), ('dm2', 'dm2@dm.com', 42), ('dm3', 'dm3@dm.com', 43)
+          RETURNING id, name
+        )
+        SELECT * FROM inserted
+      `, { maxRows: 2 });
+
+      // A LIMIT here would cap the rows handed back while all three rows were
+      // still written - a cap that isn't one.
+      expect(result.resultSets[0].rows).toHaveLength(3);
+
+      await postgresTest.connector.executeSQL("DELETE FROM users WHERE email LIKE '%@dm.com'", {});
     });
 
     it('should handle maxRows in multi-statement execution with transactions', async () => {

--- a/src/connectors/__tests__/sqlite.integration.test.ts
+++ b/src/connectors/__tests__/sqlite.integration.test.ts
@@ -379,17 +379,17 @@ describe('SQLite Connector Integration Tests', () => {
       expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
-    it('should not apply maxRows to CTE queries (WITH clause)', async () => {
-      // Test that maxRows is not applied to CTE queries (WITH clause)
+    it('should apply maxRows to CTE queries (WITH clause)', async () => {
+      // A CTE is the ordinary shape of an analytical query, so leaving it
+      // uncapped left max_rows silently inert for most real queries.
       const result = await sqliteTest.connector.executeSQL(`
         WITH user_summary AS (
           SELECT name, age FROM users WHERE age IS NOT NULL
         )
         SELECT * FROM user_summary ORDER BY age
       `, { maxRows: 2 });
-      
-      // Should return all rows since WITH queries are not limited anymore
-      expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[0]).toHaveProperty('age');
     });

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -121,6 +121,14 @@ export interface ExecuteOptions {
    * Note: SDK-level readonly enforcement is set via ConnectorConfig.readonly
    */
   readonly?: boolean;
+  /**
+   * Cancellation signal for the request this execution serves — the MCP
+   * request's own AbortSignal, so a tool call the client cancels stops the
+   * query on the *database* instead of leaving it running while nobody waits
+   * for the result. Honoured by the PostgreSQL connector; a connector that
+   * ignores it runs the query to completion as before.
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -155,6 +155,10 @@ export class PostgresConnector implements Connector {
 
   private pool: pg.Pool | null = null;
 
+  // Kept so cancelBackend can open its own connection to the same server
+  // without borrowing from the pool
+  private poolConfig: pg.PoolConfig | null = null;
+
   // Source ID is set by ConnectorManager after cloning
   private sourceId: string = "default";
 
@@ -193,6 +197,7 @@ export class PostgresConnector implements Connector {
         }
       }
 
+      this.poolConfig = poolConfig;
       this.pool = new Pool(poolConfig);
 
       // Test the connection
@@ -206,6 +211,7 @@ export class PostgresConnector implements Connector {
         this.pool = null;
         await closeQuietly(() => pool.end());
       }
+      this.poolConfig = null;
       console.error("Failed to connect to PostgreSQL database:", err);
       throw err;
     }
@@ -216,6 +222,7 @@ export class PostgresConnector implements Connector {
       await this.pool.end();
       this.pool = null;
     }
+    this.poolConfig = null;
   }
 
   async getSchemas(): Promise<string[]> {
@@ -668,13 +675,46 @@ export class PostgresConnector implements Connector {
   }
 
 
+  /**
+   * How long to give the out-of-band cancellation before abandoning it.
+   * Connecting and asking the server to signal a backend is metadata-only work
+   * that a healthy server answers in milliseconds; the bound exists only so
+   * cleanup cannot outlive the query it is cleaning up after, independently of
+   * the user's (possibly long, possibly unset) query timeout.
+   */
+  private static readonly CANCEL_TIMEOUT_MS = 5000;
+
   async executeSQL(sql: string, options: ExecuteOptions, parameters?: any[]): Promise<SQLResult> {
     if (!this.pool) {
       throw new Error("Not connected to database");
     }
 
+    const signal = options.signal;
+    // Nothing to run for a caller that is already gone - and no reason to take
+    // a connection from the pool to find that out.
+    signal?.throwIfAborted();
+
     const client = await this.pool.connect();
+    // Captured up front: after the cancellation lands, reading this off the
+    // client races its teardown.
+    const backendPid = backendPidOf(client);
+    let wasCancelled = false;
+    const onAbort = () => {
+      wasCancelled = true;
+      // Fire-and-forget: an abort listener cannot be awaited, and the
+      // cancellation reaches the caller through the in-flight query rejecting
+      // with 57014 (query_canceled), not through this call. cancelBackend
+      // never rejects.
+      void this.cancelBackend(backendPid);
+    };
+
     try {
+      // Re-checked now that we hold a connection: an AbortSignal dispatches
+      // "abort" exactly once, so one that fired while we waited for the pool
+      // would never reach a listener registered afterwards.
+      signal?.throwIfAborted();
+      signal?.addEventListener("abort", onAbort, { once: true });
+
       // Check if this is a multi-statement query
       const statements = splitSQLStatements(sql, "postgres");
 
@@ -765,9 +805,70 @@ export class PostgresConnector implements Connector {
         return { resultSets };
       }
     } finally {
-      client.release();
+      // Removed explicitly rather than left to `once`: a signal outlives a
+      // single executeSQL call, so listeners would otherwise pile up pointing
+      // at connections that have already gone back to the pool.
+      signal?.removeEventListener("abort", onAbort);
+      // release(true) destroys the connection instead of returning it to the
+      // pool. After a cancellation the session's state is not trustworthy: the
+      // CancelRequest races the statement it targets, so it can instead land
+      // on the ROLLBACK issued during cleanup and leave the session sitting in
+      // an aborted transaction that the next borrower would inherit. Same
+      // reasoning as the MySQL connector's isConnectionPoisoned handling.
+      client.release(wasCancelled);
     }
   }
+
+  /**
+   * Best-effort server-side cancellation of whatever `backendPid` is running,
+   * for when the MCP client aborts the tool call.
+   *
+   * PostgreSQL cancellation is out-of-band by design: the request has to arrive
+   * on a *different* connection, because the one running the query is blocked
+   * waiting for its result. This opens a dedicated short-lived connection
+   * rather than borrowing from the pool - a pool saturated with the very
+   * long-running queries being cancelled has nothing left to lend, which is
+   * exactly the situation this runs in. That mirrors what `pg`'s own
+   * Client.cancel does at the protocol level; that entry point is not reusable
+   * here because it needs the internal Query object, which the promise-based
+   * query API never exposes.
+   *
+   * Cancellation is advisory: the backend acts on it only at an interrupt
+   * point, and a statement that has already finished ignores it. A resolved
+   * call is therefore not a guarantee that anything stopped.
+   */
+  private async cancelBackend(backendPid: number | null): Promise<void> {
+    if (backendPid === null || !this.poolConfig) {
+      return;
+    }
+    const cancelClient = new pg.Client({
+      ...this.poolConfig,
+      connectionTimeoutMillis: PostgresConnector.CANCEL_TIMEOUT_MS,
+      query_timeout: PostgresConnector.CANCEL_TIMEOUT_MS,
+    });
+    try {
+      await cancelClient.connect();
+      await cancelClient.query("SELECT pg_cancel_backend($1)", [backendPid]);
+    } catch (error) {
+      // Unconfirmed cancellation: the statement may still be running. There is
+      // nothing further to do from here - the caller already sees the abort -
+      // but it must be visible, since it means a query outlived its request.
+      console.error(`Failed to cancel PostgreSQL backend ${backendPid}:`, error);
+    } finally {
+      await closeQuietly(() => cancelClient.end());
+    }
+  }
+}
+
+/**
+ * The server-side PID of the backend serving this connection. `pg` fills it in
+ * from the BackendKeyData message at connection time, but does not declare it
+ * on its published types, hence the narrow cast. Null when it is unavailable,
+ * which leaves the connection simply uncancellable rather than erroring.
+ */
+function backendPidOf(client: pg.PoolClient): number | null {
+  const processID = (client as unknown as { processID?: number | null }).processID;
+  return typeof processID === "number" ? processID : null;
 }
 
 // Create and register the connector

--- a/src/tools/__tests__/execute-sql.test.ts
+++ b/src/tools/__tests__/execute-sql.test.ts
@@ -164,6 +164,36 @@ describe('execute-sql tool', () => {
     });
   });
 
+  describe('cancellation', () => {
+    // The connector needs the request's AbortSignal to stop the query on the
+    // database. Without it a cancelled tool call only stops us waiting for the
+    // answer, and the query runs to completion server-side.
+    it('forwards the request AbortSignal to the connector', async () => {
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [] });
+      const controller = new AbortController();
+
+      const handler = createExecuteSqlToolHandler('test_source');
+      await handler({ sql: 'SELECT 1' }, { signal: controller.signal });
+
+      expect(mockConnector.executeSQL).toHaveBeenCalledWith(
+        'SELECT 1',
+        expect.objectContaining({ signal: controller.signal })
+      );
+    });
+
+    it('passes an undefined signal when the caller provides no extra', async () => {
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue({ resultSets: [] });
+
+      const handler = createExecuteSqlToolHandler('test_source');
+      await handler({ sql: 'SELECT 1' }, null);
+
+      expect(mockConnector.executeSQL).toHaveBeenCalledWith(
+        'SELECT 1',
+        expect.objectContaining({ signal: undefined })
+      );
+    });
+  });
+
   describe('read-only mode enforcement', () => {
     // Statement-classification coverage (write keywords, comment stripping,
     // dialect-specific bypasses, ...) is pinned in

--- a/src/tools/execute-sql.ts
+++ b/src/tools/execute-sql.ts
@@ -63,6 +63,10 @@ export function createExecuteSqlToolHandler(sourceId?: string) {
       const executeOptions = {
         readonly: isReadOnlyPolicy(policy),
         maxRows: toolConfig?.max_rows,
+        // The MCP request's cancellation signal. Without it a cancelled tool
+        // call only stops us waiting for the answer: the query keeps running
+        // on the database, still burning the IO nobody is going to read.
+        signal: extra?.signal as AbortSignal | undefined,
       };
       result = await connector.executeSQL(sql, executeOptions);
 

--- a/src/utils/__tests__/sql-row-limiter.test.ts
+++ b/src/utils/__tests__/sql-row-limiter.test.ts
@@ -155,7 +155,168 @@ describe("SQLRowLimiter", () => {
     });
   });
 
+  describe("applyMaxRows - leading comments", () => {
+    // A query introduced by a comment (an attribution tag, say) is still a
+    // SELECT. Classifying on the raw text made `max_rows` silently inert for
+    // every one of them.
+    it("caps a query introduced by a -- line comment", () => {
+      const sql = "-- dbhub agent query\nSELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "-- dbhub agent query\nSELECT * FROM users\nLIMIT 100"
+      );
+    });
+
+    it("caps a query introduced by a block comment", () => {
+      const sql = "/* tag: report */ SELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "/* tag: report */ SELECT * FROM users\nLIMIT 100"
+      );
+    });
+
+    it("caps a query introduced by several mixed leading comments", () => {
+      const sql = "-- one\n/* two */\n-- three\nSELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "-- one\n/* two */\n-- three\nSELECT * FROM users\nLIMIT 100"
+      );
+    });
+
+    it("leaves the caller's comment text untouched", () => {
+      // The comment is load-bearing for query attribution, so only the
+      // classification sees the stripped form - the SQL sent to the server
+      // keeps it verbatim.
+      const sql = "/* app=dbhub; user='bob' */\nSELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toContain("/* app=dbhub; user='bob' */");
+    });
+
+    it("still leaves a non-SELECT hidden behind a comment alone", () => {
+      const sql = "-- looks harmless\nUPDATE users SET active = true";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(sql);
+    });
+  });
+
+  describe("applyMaxRows - CTEs", () => {
+    it("caps a WITH ... SELECT query", () => {
+      const sql = "WITH recent AS (SELECT * FROM orders) SELECT * FROM recent";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "WITH recent AS (SELECT * FROM orders) SELECT * FROM recent\nLIMIT 100"
+      );
+    });
+
+    it("appends its own LIMIT instead of tightening a CTE's inner LIMIT", () => {
+      // The CTE's LIMIT caps only the CTE; the statement can still return far
+      // more rows than that (here via the join), so it needs a cap of its own.
+      const sql =
+        "WITH recent AS (SELECT * FROM orders LIMIT 5) SELECT * FROM recent JOIN big ON true";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "WITH recent AS (SELECT * FROM orders LIMIT 5) SELECT * FROM recent JOIN big ON true\nLIMIT 100"
+      );
+    });
+
+    it("tightens the statement's own LIMIT on a CTE query", () => {
+      const sql = "WITH recent AS (SELECT * FROM orders LIMIT 5) SELECT * FROM recent LIMIT 500";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "WITH recent AS (SELECT * FROM orders LIMIT 5) SELECT * FROM recent LIMIT 100"
+      );
+    });
+
+    it("wraps a CTE query whose own LIMIT is parameterized", () => {
+      const sql = "WITH recent AS (SELECT * FROM orders) SELECT * FROM recent LIMIT $1";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "SELECT * FROM (WITH recent AS (SELECT * FROM orders) SELECT * FROM recent LIMIT $1\n) AS subq LIMIT 100"
+      );
+    });
+
+    it.each([
+      ["DELETE", "WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d"],
+      ["INSERT", "WITH i AS (INSERT INTO t SELECT * FROM s RETURNING *) SELECT * FROM i"],
+      ["UPDATE", "WITH u AS (UPDATE t SET a = 1 RETURNING *) SELECT * FROM u"],
+    ])("does not cap a data-modifying CTE (%s)", (_label, sql) => {
+      // A LIMIT here would cap the rows handed back while the write still runs
+      // in full - a cap that isn't one.
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(sql);
+    });
+  });
+
+  describe("applyMaxRows - set operations and nesting", () => {
+    it("caps a parenthesised set operation", () => {
+      const sql = "(SELECT id FROM a) UNION (SELECT id FROM b)";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "(SELECT id FROM a) UNION (SELECT id FROM b)\nLIMIT 100"
+      );
+    });
+
+    it("keeps appending a trailing LIMIT to a bare UNION ALL, which binds to the whole set operation", () => {
+      const sql = "SELECT id FROM a UNION ALL SELECT id FROM b";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "SELECT id FROM a UNION ALL SELECT id FROM b\nLIMIT 100"
+      );
+    });
+
+    it("appends its own LIMIT instead of tightening a subquery's LIMIT", () => {
+      const sql = "SELECT * FROM (SELECT * FROM t LIMIT 5) s";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "SELECT * FROM (SELECT * FROM t LIMIT 5) s\nLIMIT 100"
+      );
+    });
+  });
+
+  describe("clause detection ignores nested clauses", () => {
+    it("does not report a subquery's LIMIT as the statement's own", () => {
+      const sql = "SELECT * FROM (SELECT * FROM t LIMIT 5) s";
+      expect(SQLRowLimiter.hasLimitClause(sql)).toBe(false);
+      expect(SQLRowLimiter.extractLimitValue(sql)).toBe(null);
+    });
+
+    it("does not report a CTE's parameterized LIMIT as the statement's own", () => {
+      const sql = "WITH x AS (SELECT * FROM t LIMIT $1) SELECT * FROM x";
+      expect(SQLRowLimiter.hasParameterizedLimit(sql)).toBe(false);
+    });
+
+    it("does not report a CTE's TOP as the statement's own", () => {
+      const sql = "WITH x AS (SELECT TOP 5 id FROM t) SELECT * FROM x";
+      expect(SQLRowLimiter.hasTopClause(sql)).toBe(false);
+      expect(SQLRowLimiter.extractTopValue(sql)).toBe(null);
+    });
+  });
+
   describe("applyMaxRowsForSQLServer", () => {
+    it("caps a query introduced by a leading comment", () => {
+      const sql = "-- tag\nSELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(
+        "-- tag\nSELECT TOP 100 * FROM users"
+      );
+    });
+
+    it("puts TOP on the statement's own SELECT, not on the CTE's", () => {
+      const sql = "WITH x AS (SELECT id FROM t) SELECT * FROM x";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(
+        "WITH x AS (SELECT id FROM t) SELECT TOP 100 * FROM x"
+      );
+    });
+
+    it("leaves a CTE's own TOP alone and caps the final SELECT", () => {
+      const sql = "WITH x AS (SELECT TOP 5 id FROM t) SELECT * FROM x";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(
+        "WITH x AS (SELECT TOP 5 id FROM t) SELECT TOP 100 * FROM x"
+      );
+    });
+
+    it("keeps a leading CTE outside the wrapped subquery for a set operation", () => {
+      // T-SQL has no `SELECT ... FROM (WITH ...) AS subq` form, but a CTE
+      // declared before the SELECT is in scope inside the derived table.
+      const sql = "WITH x AS (SELECT id FROM t) SELECT id FROM x UNION ALL SELECT id FROM y";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(
+        "WITH x AS (SELECT id FROM t) SELECT TOP 100 * FROM (SELECT id FROM x UNION ALL SELECT id FROM y\n) AS subq"
+      );
+    });
+
+    it("does not cap a data-modifying CTE", () => {
+      const sql = "WITH d AS (DELETE FROM t OUTPUT deleted.*) SELECT * FROM d";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(sql);
+    });
+  });
+
+  describe("applyMaxRowsForSQLServer - pre-existing behaviour", () => {
     it("should not modify SQL when maxRows is undefined", () => {
       const sql = "SELECT * FROM users";
       expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, undefined)).toBe(sql);

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -178,6 +178,19 @@ const mutatingPatterns: Record<ConnectorType, RegExp> = {
   sqlserver: mutatingPatternSqlServer,
 };
 
+/**
+ * Whether (comment/string-stripped) SQL contains a data-modifying keyword.
+ * Shared by the read-only classifier's CTE check and the row limiter, so both
+ * agree on what counts as a write hidden inside a WITH. Falls back to the
+ * dialect-independent keyword set when no connector type is given.
+ */
+export function hasMutatingKeyword(
+  strippedSQL: string,
+  connectorType?: ConnectorType | string
+): boolean {
+  return (mutatingPatterns[connectorType as ConnectorType] ?? mutatingPattern).test(strippedSQL);
+}
+
 const selectIntoPattern = /\bselect\b[\s\S]+\binto\b/i;
 
 /**
@@ -251,11 +264,8 @@ function checkReadOnly(cleanedSQL: string, connectorType: ConnectorType | string
   }
 
   // WITH statements can embed DML in CTEs (e.g. WITH cte AS (UPDATE ...))
-  if (firstWord === "with") {
-    const pattern = mutatingPatterns[connectorType as ConnectorType] ?? mutatingPattern;
-    if (pattern.test(cleanedSQL)) {
-      return false;
-    }
+  if (firstWord === "with" && hasMutatingKeyword(cleanedSQL, connectorType)) {
+    return false;
   }
 
   // SQLite PRAGMA: a pragma that sets a value mutates durable or session state and

--- a/src/utils/sql-row-limiter.ts
+++ b/src/utils/sql-row-limiter.ts
@@ -1,97 +1,122 @@
-import { stripCommentsAndStrings, blankCommentsAndStrings } from "./sql-parser.js";
+import type { ConnectorType } from "../connectors/interface.js";
+import { hasMutatingKeyword } from "./allowed-keywords.js";
+import { blankCommentsAndStrings } from "./sql-parser.js";
 
 /**
- * Shared utility for applying row limits to SELECT queries only using database-native LIMIT clauses
+ * Shared utility for applying row limits to row-returning queries using
+ * database-native LIMIT clauses (or TOP on SQL Server).
+ *
+ * Every check here reasons about the statement's *own* clauses: the SQL is
+ * first blanked of comments and string literals, then scanned with parenthesis
+ * depth tracking, so a LIMIT/TOP/ORDER BY belonging to a CTE body, a subquery,
+ * or one branch of a set operation is never mistaken for the statement's own.
+ * Such a nested clause caps only its own branch, so the statement still needs
+ * a cap of its own.
  */
 export class SQLRowLimiter {
   /**
-   * Check if a SQL statement is a SELECT query that can benefit from row limiting
-   * Only handles SELECT queries
+   * Check if a SQL statement is a row-returning query that can benefit from row limiting.
+   *
+   * Classification runs on the comment-blanked text, so a query introduced by a
+   * `--` or `/* ... *\/` comment — a query tag, say — is classified by its real
+   * leading keyword rather than by the comment. The SQL the caller wrote is
+   * never rewritten by this check: only the classification sees the blanked
+   * form, so an attribution comment survives to the server verbatim.
+   *
+   * `WITH` leads a CTE whose final statement is normally a SELECT, so it is
+   * limitable too — except for a data-modifying CTE
+   * (`WITH x AS (DELETE ... RETURNING *) SELECT ...`), where a LIMIT would cap
+   * the rows handed back while the write still runs in full: a cap that isn't
+   * one. Detection there is the same keyword heuristic the read-only classifier
+   * uses, so a false positive only means the statement keeps today's behaviour
+   * of not being limited.
    */
   static isSelectQuery(sql: string): boolean {
-    const trimmed = sql.trim().toLowerCase();
-    return trimmed.startsWith('select');
+    const blankedSQL = blankCommentsAndStrings(sql).trim().toLowerCase();
+    // Leading parentheses are skipped: `(SELECT ...) UNION (SELECT ...)` is a
+    // row-returning statement whose first token is `(`.
+    const firstKeyword = /^[(\s]*([a-z_]+)/.exec(blankedSQL)?.[1] ?? "";
+    if (firstKeyword === "select") {
+      return true;
+    }
+    return firstKeyword === "with" && !hasMutatingKeyword(blankedSQL);
   }
 
   /**
-   * Check if a SQL statement already has a LIMIT clause.
-   * Strips comments and string literals first to avoid false positives.
+   * Check if a SQL statement has a LIMIT clause of its own.
    */
   static hasLimitClause(sql: string): boolean {
-    // Strip comments and strings to avoid matching LIMIT inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    // Detect LIMIT clause - handles literal numbers and parameter placeholders ($1, ?, @p1)
-    const limitRegex = /\blimit\s+(?:\d+|\$\d+|\?|@p\d+)/i;
-    return limitRegex.test(cleanedSQL);
+    return this.findTopLevelLimit(sql) !== null;
   }
 
   /**
-   * Check if a SQL statement already has a TOP clause (SQL Server).
-   * Strips comments and string literals first to avoid false positives.
+   * Check if a SQL statement has a TOP clause of its own (SQL Server).
    */
   static hasTopClause(sql: string): boolean {
-    // Strip comments and strings to avoid matching TOP inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    // Simple regex to detect TOP clause - handles most common cases
-    const topRegex = /\bselect\s+top\s+\d+/i;
-    return topRegex.test(cleanedSQL);
+    return this.findTopLevelTop(sql) !== null;
   }
 
   /**
-   * Extract existing LIMIT value from SQL if present.
-   * Strips comments and string literals first to avoid false positives.
+   * Extract the statement's own LIMIT value. Null when it has no LIMIT of its
+   * own, or when that LIMIT is a parameter placeholder rather than a literal
+   * (see hasParameterizedLimit).
    */
   static extractLimitValue(sql: string): number | null {
-    // Strip comments and strings to avoid matching LIMIT inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    const limitMatch = cleanedSQL.match(/\blimit\s+(\d+)/i);
-    if (limitMatch) {
-      return parseInt(limitMatch[1], 10);
-    }
-    return null;
+    return this.findTopLevelLimit(sql)?.value ?? null;
   }
 
   /**
-   * Extract existing TOP value from SQL if present (SQL Server).
-   * Strips comments and string literals first to avoid false positives.
+   * Extract the statement's own TOP value (SQL Server), or null when it has none.
    */
   static extractTopValue(sql: string): number | null {
-    // Strip comments and strings to avoid matching TOP inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    const topMatch = cleanedSQL.match(/\bselect\s+top\s+(\d+)/i);
-    if (topMatch) {
-      return parseInt(topMatch[1], 10);
-    }
-    return null;
+    return this.findTopLevelTop(sql)?.value ?? null;
   }
 
   /**
-   * Add or modify LIMIT clause in a SQL statement
+   * Check if the statement's own LIMIT clause uses a parameter placeholder
+   * ($1, ?, @p1) instead of a literal number.
+   */
+  static hasParameterizedLimit(sql: string): boolean {
+    const limit = this.findTopLevelLimit(sql);
+    return limit !== null && limit.value === null;
+  }
+
+  /**
+   * Add or tighten the LIMIT clause of a SQL statement
    */
   static applyLimitToQuery(sql: string, maxRows: number): string {
-    const existingLimit = this.extractLimitValue(sql);
-    
-    if (existingLimit !== null) {
-      // Use the minimum of existing limit and maxRows
-      const effectiveLimit = Math.min(existingLimit, maxRows);
-      return sql.replace(/\blimit\s+\d+/i, `LIMIT ${effectiveLimit}`);
-    } else {
-      // Add LIMIT clause to the end of the query
-      // Handle semicolon at the end
-      const trimmed = sql.trim();
-      const hasSemicolon = trimmed.endsWith(';');
-      const sqlWithoutSemicolon = hasSemicolon ? trimmed.slice(0, -1) : trimmed;
+    const limit = this.findTopLevelLimit(sql);
 
-      // Append on a new line: if the query ends in a `--` line comment, a
-      // same-line LIMIT would land inside the comment and be inert.
-      return `${sqlWithoutSemicolon}\nLIMIT ${maxRows}${hasSemicolon ? ';' : ''}`;
+    if (limit !== null && limit.value !== null) {
+      // Splice at the clause's own position rather than replacing the first
+      // LIMIT found textually, which on a CTE would rewrite the CTE's cap and
+      // leave the statement itself uncapped.
+      const effectiveLimit = Math.min(limit.value, maxRows);
+      return `${sql.slice(0, limit.index)}LIMIT ${effectiveLimit}${sql.slice(limit.index + limit.length)}`;
     }
+
+    const { sql: sqlWithoutSemicolon, semicolon } = trimSemicolon(sql);
+
+    if (limit !== null) {
+      // Parameterized LIMIT: the value only exists at execution time, so it
+      // cannot be compared against maxRows here. Wrap the statement and cap
+      // the outer result set to enforce max_rows as a hard ceiling.
+      // Note: subquery wrapping is safe for PostgreSQL, MySQL, MariaDB and SQLite.
+      // Close the subquery on a new line: if the inner query ends in a `--`
+      // line comment, a same-line `)` would be swallowed by the comment and
+      // the wrapped statement would be syntactically broken.
+      return `SELECT * FROM (${sqlWithoutSemicolon}\n) AS subq LIMIT ${maxRows}${semicolon}`;
+    }
+
+    // Append on a new line: if the query ends in a `--` line comment, a
+    // same-line LIMIT would land inside the comment and be inert.
+    return `${sqlWithoutSemicolon}\nLIMIT ${maxRows}${semicolon}`;
   }
 
   /**
    * Scan blanked (comment/string-free, length-preserving) SQL for parenthesis
    * depth, invoking onMatch for every regex hit at depth 0 (i.e. not nested
-   * inside a subquery, function call, or window OVER clause).
+   * inside a CTE body, subquery, function call, or window OVER clause).
    */
   private static scanTopLevel(
     blankedSQL: string,
@@ -109,37 +134,103 @@ export class SQLRowLimiter {
   }
 
   /**
+   * The first or last regex match at parenthesis depth 0 — one belonging to the
+   * statement itself rather than to a nested query. Match indices refer to
+   * positions in the original `sql`, since blankCommentsAndStrings preserves
+   * length. The regex must offer `\(` and `\)` alternatives so depth can be
+   * tracked, and must carry the `g` flag.
+   */
+  private static findTopLevelMatch(
+    sql: string,
+    regex: RegExp,
+    pick: "first" | "last",
+    dialect?: ConnectorType
+  ): RegExpExecArray | null {
+    const matches: RegExpExecArray[] = [];
+    this.scanTopLevel(blankCommentsAndStrings(sql, dialect), regex, (m) => {
+      matches.push(m);
+    });
+    if (matches.length === 0) {
+      return null;
+    }
+    return pick === "last" ? matches[matches.length - 1] : matches[0];
+  }
+
+  /**
+   * Position and value of the statement's own LIMIT clause. `value` is null
+   * when the clause holds a parameter placeholder instead of a literal.
+   */
+  private static findTopLevelLimit(
+    sql: string
+  ): { index: number; length: number; value: number | null } | null {
+    const match = this.findTopLevelMatch(
+      sql,
+      /\(|\)|\blimit\s+(?:(\d+)|\$\d+|\?|@p\d+)/gi,
+      "last"
+    );
+    if (match === null) {
+      return null;
+    }
+    return {
+      index: match.index,
+      length: match[0].length,
+      value: match[1] !== undefined ? parseInt(match[1], 10) : null,
+    };
+  }
+
+  /** Position and value of the statement's own `SELECT TOP n` clause (SQL Server). */
+  private static findTopLevelTop(
+    sql: string
+  ): { index: number; length: number; value: number } | null {
+    const match = this.findTopLevelMatch(
+      sql,
+      /\(|\)|\bselect\s+top\s+(\d+)/gi,
+      "first",
+      "sqlserver"
+    );
+    if (match === null) {
+      return null;
+    }
+    return { index: match.index, length: match[0].length, value: parseInt(match[1], 10) };
+  }
+
+  /**
+   * The statement's own SELECT keyword (SQL Server). For a CTE this is the
+   * final SELECT, not the one inside a CTE body.
+   */
+  private static findTopLevelSelect(sql: string): RegExpExecArray | null {
+    return this.findTopLevelMatch(sql, /\(|\)|\bselect\b/gi, "first", "sqlserver");
+  }
+
+  /**
    * Check if a SQL statement combines multiple SELECTs with a set operator
    * (UNION [ALL], INTERSECT, EXCEPT) at the top level — i.e. not nested
-   * inside a subquery already wrapped in parentheses. Strips comments and
-   * string literals first to avoid false positives.
+   * inside a subquery already wrapped in parentheses.
    */
   static hasSetOperator(sql: string): boolean {
-    const blankedSQL = blankCommentsAndStrings(sql, "sqlserver");
-    let found = false;
-    this.scanTopLevel(blankedSQL, /\(|\)|\bunion\b|\bintersect\b|\bexcept\b/gi, () => {
-      found = true;
-    });
-    return found;
+    return (
+      this.findTopLevelMatch(
+        sql,
+        /\(|\)|\bunion\b|\bintersect\b|\bexcept\b/gi,
+        "first",
+        "sqlserver"
+      ) !== null
+    );
   }
 
   /**
    * Find the start index of a top-level trailing ORDER BY clause (not one
    * nested inside a subquery or a window function's OVER (...) clause).
-   * Returns -1 if none exists. Operates on the original (non-blanked) SQL
-   * length, since blankCommentsAndStrings preserves length/position.
+   * Returns -1 if none exists.
    */
   private static findTopLevelOrderByIndex(sql: string): number {
-    const blankedSQL = blankCommentsAndStrings(sql, "sqlserver");
-    let lastIndex = -1;
-    this.scanTopLevel(blankedSQL, /\(|\)|\border\s+by\b/gi, (m) => {
-      lastIndex = m.index;
-    });
-    return lastIndex;
+    return (
+      this.findTopLevelMatch(sql, /\(|\)|\border\s+by\b/gi, "last", "sqlserver")?.index ?? -1
+    );
   }
 
   /**
-   * Add or modify TOP clause in a SQL statement (SQL Server)
+   * Add or tighten the TOP clause of a SQL statement (SQL Server)
    */
   static applyTopToQuery(sql: string, maxRows: number): string {
     if (this.hasSetOperator(sql)) {
@@ -148,80 +239,60 @@ export class SQLRowLimiter {
       // UNION/INTERSECT/EXCEPT output, so wrap the whole statement and cap
       // the outer result set instead, regardless of any TOP already present
       // on an individual branch.
-      const trimmed = sql.trim();
-      const hasSemicolon = trimmed.endsWith(';');
-      const sqlWithoutSemicolon = hasSemicolon ? trimmed.slice(0, -1) : trimmed;
+      const { sql: sqlWithoutSemicolon, semicolon } = trimSemicolon(sql);
+
+      // A leading CTE stays outside the derived table: T-SQL has no
+      // `SELECT ... FROM (WITH ...) AS subq` form, but a CTE declared before
+      // the SELECT is still in scope inside that derived table.
+      const selectMatch = this.findTopLevelSelect(sqlWithoutSemicolon);
+      const cteIndex = selectMatch !== null ? selectMatch.index : 0;
+      const ctePrefix = sqlWithoutSemicolon.slice(0, cteIndex);
+      const body = sqlWithoutSemicolon.slice(cteIndex);
 
       // A top-level ORDER BY must move outside the derived table: T-SQL
       // disallows ORDER BY inside a subquery unless that subquery itself has
       // TOP/OFFSET/FOR XML, so leaving it inside would break the query.
-      const orderByIndex = this.findTopLevelOrderByIndex(sqlWithoutSemicolon);
+      const orderByIndex = this.findTopLevelOrderByIndex(body);
       if (orderByIndex !== -1) {
-        const innerSql = sqlWithoutSemicolon.slice(0, orderByIndex).trimEnd();
-        const orderByClause = sqlWithoutSemicolon.slice(orderByIndex).trim();
-        return `SELECT TOP ${maxRows} * FROM (${innerSql}\n) AS subq ${orderByClause}${hasSemicolon ? ';' : ''}`;
+        const innerSql = body.slice(0, orderByIndex).trimEnd();
+        const orderByClause = body.slice(orderByIndex).trim();
+        return `${ctePrefix}SELECT TOP ${maxRows} * FROM (${innerSql}\n) AS subq ${orderByClause}${semicolon}`;
       }
 
-      return `SELECT TOP ${maxRows} * FROM (${sqlWithoutSemicolon}\n) AS subq${hasSemicolon ? ';' : ''}`;
+      return `${ctePrefix}SELECT TOP ${maxRows} * FROM (${body}\n) AS subq${semicolon}`;
     }
 
-    const existingTop = this.extractTopValue(sql);
+    const existingTop = this.findTopLevelTop(sql);
     if (existingTop !== null) {
       // Use the minimum of existing top and maxRows
-      const effectiveTop = Math.min(existingTop, maxRows);
-      return sql.replace(/\bselect\s+top\s+\d+/i, `SELECT TOP ${effectiveTop}`);
+      const effectiveTop = Math.min(existingTop.value, maxRows);
+      return `${sql.slice(0, existingTop.index)}SELECT TOP ${effectiveTop}${sql.slice(existingTop.index + existingTop.length)}`;
     }
 
-    // Add TOP clause after SELECT
-    return sql.replace(/\bselect\s+/i, `SELECT TOP ${maxRows} `);
+    // Add TOP to the statement's own SELECT — for a CTE that is the final
+    // SELECT, not the one inside a CTE body.
+    const selectMatch = this.findTopLevelSelect(sql);
+    if (selectMatch === null) {
+      return sql;
+    }
+    return `${sql.slice(0, selectMatch.index)}SELECT TOP ${maxRows}${sql.slice(selectMatch.index + selectMatch[0].length)}`;
   }
 
   /**
-   * Check if a LIMIT clause uses a parameter placeholder (not a literal number).
-   * Strips comments and string literals first to avoid false positives.
-   */
-  static hasParameterizedLimit(sql: string): boolean {
-    // Strip comments and strings to avoid matching LIMIT inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    // Check for parameterized LIMIT (excluding literal numbers)
-    const parameterizedLimitRegex = /\blimit\s+(?:\$\d+|\?|@p\d+)/i;
-    return parameterizedLimitRegex.test(cleanedSQL);
-  }
-
-  /**
-   * Apply maxRows limit to a SELECT query only
+   * Apply maxRows limit to a row-returning query only
    *
    * This method is used by PostgreSQL, MySQL, MariaDB, and SQLite connectors which all support
    * the LIMIT clause syntax. SQL Server uses applyMaxRowsForSQLServer() instead with TOP syntax.
-   *
-   * For parameterized LIMIT clauses (e.g., LIMIT $1 or LIMIT ?), we wrap the query in a subquery
-   * to enforce max_rows as a hard cap, since the parameter value is not known until runtime.
    */
   static applyMaxRows(sql: string, maxRows: number | undefined): string {
     if (!maxRows || !this.isSelectQuery(sql)) {
       return sql;
     }
-
-    // If query has a parameterized LIMIT, wrap it in a subquery with maxRows
-    // This ensures max_rows is respected even when user provides a large parameter value
-    if (this.hasParameterizedLimit(sql)) {
-      // Wrap the query: SELECT * FROM (original_query) AS subq LIMIT max_rows
-      // Note: Subquery wrapping is safe for PostgreSQL, MySQL, MariaDB, and SQLite
-      const trimmed = sql.trim();
-      const hasSemicolon = trimmed.endsWith(';');
-      const sqlWithoutSemicolon = hasSemicolon ? trimmed.slice(0, -1) : trimmed;
-      // Close the subquery on a new line: if the inner query ends in a `--`
-      // line comment, a same-line `)` would be swallowed by the comment and
-      // the wrapped statement would be syntactically broken.
-      return `SELECT * FROM (${sqlWithoutSemicolon}\n) AS subq LIMIT ${maxRows}${hasSemicolon ? ';' : ''}`;
-    }
-
-    // For literal LIMIT values, apply the minimum logic
     return this.applyLimitToQuery(sql, maxRows);
   }
 
   /**
-   * Apply maxRows limit to a SELECT query using SQL Server TOP syntax
+   * Apply maxRows limit to a row-returning query using SQL Server TOP syntax
    */
   static applyMaxRowsForSQLServer(sql: string, maxRows: number | undefined): string {
     if (!maxRows || !this.isSelectQuery(sql)) {
@@ -229,4 +300,15 @@ export class SQLRowLimiter {
     }
     return this.applyTopToQuery(sql, maxRows);
   }
+}
+
+/**
+ * Split a trailing semicolon off a statement so a wrapper/suffix can be spliced
+ * in before it, and the caller can put it back.
+ */
+function trimSemicolon(sql: string): { sql: string; semicolon: "" | ";" } {
+  const trimmed = sql.trim();
+  return trimmed.endsWith(";")
+    ? { sql: trimmed.slice(0, -1), semicolon: ";" }
+    : { sql: trimmed, semicolon: "" };
 }


### PR DESCRIPTION
*Two independent bugs in one PR because they were found together and share a test run. They are two clean commits — happy to split into `fix: apply max_rows to comment-prefixed and CTE queries` and `fix(postgres): cancel the running query when the request is aborted` if you prefer one concern per PR.*

Two independent bugs, both of which let a query keep consuming database resources that nobody
asked it to consume. We hit both running DBHub against ~24 production PostgreSQL read replicas
with agents driving `execute_sql`; between them they contributed to replication lag of up to
10.9 h and one production incident caused by a single agent query that ran for 1 h 30.

Each is its own commit and each stands alone.

---

### 1. `max_rows` silently does not apply to many queries — `d3694d0`

`SQLRowLimiter.isSelectQuery` decided whether to cap a statement with:

```ts
static isSelectQuery(sql: string): boolean {
  const trimmed = sql.trim().toLowerCase();
  return trimmed.startsWith('select');
}
```

so anything not opening with a bare `SELECT` got **no LIMIT appended at all**. Not a wrong
limit — no limit, and nothing anywhere says so. Verified by executing the shipped v1.2.0
module (`applyMaxRows(sql, 100)`):

| input | v1.2.0 output |
| --- | --- |
| `-- reporting job\nSELECT * FROM t` | returned **unchanged** |
| `/* tag: report */ SELECT * FROM t` | returned **unchanged** |
| `WITH x AS (SELECT * FROM orders) SELECT * FROM x` | returned **unchanged** |
| `(SELECT id FROM a) UNION (SELECT id FROM b)` | returned **unchanged** |
| `SELECT * FROM (SELECT * FROM t LIMIT 5) s` | returned **unchanged** |
| `SELECT * FROM t` | `SELECT * FROM t\nLIMIT 100` ✅ |

This is not an exotic corner. Leading comments are how queries get attributed
(`-- app=…`, `/* trace-id */`), and a CTE is the ordinary shape of an analytical query — which
is exactly the kind of query a row cap exists to contain. In practice `max_rows` covered far
less than it appeared to.

The existing suite pinned the gap rather than catching it: three integration tests were named
`should not apply maxRows to CTE queries (WITH clause)`. This PR inverts them.

To be clear about what those tests were pinning: `git log -S` shows the `startsWith('select')`
guard and those three tests both arrive in the *same* commit — `4fa886e feat: support max-row
limit`, the commit that introduced `max_rows`. The CTE exclusion was never a separate, deliberate
carve-out; it is a consequence of that one-line classifier, and the tests recorded whatever it
happened to do. (One of the assertions is commented "not limited anymore", which reads as though a
decision had been reversed — the history shows there was no earlier behaviour to reverse.) If the
exclusion *is* wanted, it deserves to be an explicit rule rather than a side effect of the guard,
and this PR should be redirected to documenting it instead.

**Fix.** Classify on the comment/string-blanked text, and treat a leading `WITH` as
row-returning. The SQL sent to the server is never rewritten by the classification, so an
attribution comment survives verbatim — only the classifier sees the blanked form.

A **data-modifying CTE** (`WITH x AS (DELETE … RETURNING *) SELECT …`) is deliberately still
*not* limited: a LIMIT would cap the rows handed back while the write ran in full, which reads
as a cap that isn't one. That check reuses the read-only classifier's own keyword heuristic,
extracted as `hasMutatingKeyword`, so both layers agree on what counts as a write hidden inside
a `WITH`. A false positive there only means the statement keeps today's behaviour.

**Enabling CTEs exposed a second bug**, which is why the diff is larger than "add `with` to a
list". Every LIMIT/TOP helper matched the *first clause found textually*, which on a CTE is the
inner one:

```sql
WITH recent AS (SELECT * FROM orders LIMIT 5)
SELECT * FROM recent JOIN big ON true
```

Naively enabling CTEs would have rewritten the CTE's own `LIMIT 5` and left the statement — the
part that can return millions of rows — uncapped. So the helpers now scan with parenthesis-depth
tracking (the mechanism already in this file for `hasSetOperator` and the ORDER BY hoist) and
reason only about the statement's **own** clause; a nested LIMIT/TOP caps only its branch, so the
statement still gets a cap appended. This also fixes the same pre-existing hole for plain
subqueries (`SELECT * FROM (SELECT * FROM t LIMIT 5) s`, last row of the table above).

On SQL Server, `TOP` now lands on the statement's own `SELECT` rather than the first one
textually (for a CTE, the final `SELECT`), and a leading CTE is kept *outside* the derived table
when a set operation forces the `#387` wrap — T-SQL has no `SELECT … FROM (WITH …) AS subq` form.

**Explicitly preserved:** `SELECT … UNION ALL SELECT …` starts with `select`, still gets a
trailing `LIMIT`, and on PostgreSQL that binds to the whole set operation. Pinned by a
regression test.

---

### 2. MCP cancellation is ignored — the query keeps running — `db26b0b`

`src/tools/execute-sql.ts` receives `extra`, which carries the MCP SDK's `AbortSignal`, and uses
it only for `trackToolRequest(...)`. There was no `AbortSignal`/`AbortController` anywhere in
`src/`, and `ExecuteOptions` had no field to carry one. Cancelling a tool call therefore only
stopped *us waiting for the answer*: the backend went on producing a result set nobody would
ever read.

This is the same class of bug as **#384** (*"MySQL queries can continue running on the server
after query timeout"*) and this change mirrors the fix accepted for it in **#386**. MySQL's
trigger is its own client-side timeout; here the trigger is the client cancelling. Both end the
same way: kill the statement server-side over a second connection, and don't hand the connection
back to the pool in a state the next borrower inherits. PostgreSQL was simply left behind.

It matters most where it hurts most — read replicas serving agents, where an abandoned analytical
query keeps consuming IO for its full runtime and drives replication lag long after the agent has
given up and moved on.

**Reproduction**, as the added integration test `Query cancellation (options.signal)`: start
`SELECT pg_sleep(30)`, abort the signal, then watch `pg_stat_activity`.

- **Before:** the test fails after **30,042 ms** with `expected null to be an instance of Error`
  — the query *resolved*. The abort changed nothing and the backend slept the full 30 s.
- **After:** the statement rejects with SQLSTATE **57014** (`query_canceled`) within
  milliseconds, and the backend is gone from `pg_stat_activity`.

**Fix.**

- `ExecuteOptions` gains an optional `signal`; `execute_sql` passes the request's own. Connectors
  that ignore it are unaffected — MySQL/MariaDB/SQLite/SQL Server behaviour is untouched.
- PostgreSQL cancellation is out-of-band by design: the request must arrive on a *different*
  connection, since the one running the query is blocked waiting for it. `cancelBackend` opens a
  dedicated short-lived connection rather than borrowing from the pool — a pool saturated with the
  very long-running queries being cancelled has nothing left to lend, which is exactly the
  situation this runs in.
  - `pg`'s own `Client.cancel(client, query)` is not reusable here: it needs the internal `Query`
    object (`client.activeQuery === query`), which the promise-based `client.query()` API never
    exposes. `pg_cancel_backend(pid)` over a fresh connection is the same protocol-level
    operation, and matches how `killQuery` was done for MySQL in #386.
- The connection is **destroyed instead of released** after a cancellation. A CancelRequest races
  the statement it targets, so it can instead land on the `ROLLBACK` issued during cleanup and
  leave the session sitting in an aborted transaction. Mirrors MySQL's `isConnectionPoisoned`.
  Covered by a test asserting the connector still works after a cancellation.
- The abort listener is removed in `finally`, so listeners don't accumulate across the statements
  of one request.
- An already-aborted signal is refused before a connection is taken, and re-checked once one is
  held: an `AbortSignal` dispatches `abort` exactly once, so a signal that fired while we waited
  for the pool would never reach a listener registered afterwards.

Cancellation stays advisory — the backend acts on it at an interrupt point, and a statement that
already finished ignores it — so `cancelBackend` is best-effort and logs rather than throwing.

---

## Testing

- `pnpm run test:unit` — **983 passed** (958 on `main`; +25 new).
- `pnpm run test:integration` — **339 passed** across PostgreSQL, MySQL, MariaDB, SQL Server and
  SQLite containers.
- `pnpm run build:backend` — clean.
- Both commits verified green **independently** (commit 1 alone: 981 unit + 98 integration).
- The cancellation fix is backed by a negative control: reverting only the connector change makes
  the new tests fail after 30 s, as shown above.

New coverage: leading `--`/`/* */`/mixed comments; CTE; CTE with an inner LIMIT; CTE with its own
LIMIT; CTE with a parameterized LIMIT; data-modifying CTE (all three of INSERT/UPDATE/DELETE);
parenthesised set operation; nested-subquery LIMIT; `UNION ALL` regression; SQL Server CTE/TOP
cases; signal forwarding from the tool handler; and four PostgreSQL cancellation integration
tests (plain, inside `BEGIN READ ONLY`, pool reuse after cancellation, already-aborted signal).

## Notes for reviewers

- `explain_sql` also runs user SQL and could take the same `signal` — one line — but is left out
  to keep this diff to the reported bugs. Happy to add it.
- Cancellation is implemented for PostgreSQL only. The same treatment for SQLite/SQL Server would
  be a natural follow-up; MySQL already has the timeout-triggered half from #386.
- `npx tsc --noEmit` reports 132 pre-existing errors on `main`; this branch reports the same 132,
  none in the changed files.
