### PR TITLE
fix: apply max_rows to comment-prefixed and CTE queries

### DIFF
--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -391,8 +391,9 @@ describe('MySQL Connector Integration Tests', () => {
       expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
-    it('should not apply maxRows to CTE queries (WITH clause)', async () => {
-      // Test that maxRows is not applied to CTE queries (WITH clause)
+    it('should apply maxRows to CTE queries (WITH clause)', async () => {
+      // A CTE is the ordinary shape of an analytical query, so leaving it
+      // uncapped left max_rows silently inert for most real queries.
       try {
         const result = await mysqlTest.connector.executeSQL(`
           WITH user_summary AS (
@@ -400,9 +401,8 @@ describe('MySQL Connector Integration Tests', () => {
           )
           SELECT * FROM user_summary ORDER BY age
         `, { maxRows: 2 });
-        
-        // Should return all rows since WITH queries are not limited
-        expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+
+        expect(result.resultSets[0].rows).toHaveLength(2);
         expect(result.resultSets[0].rows[0]).toHaveProperty('name');
         expect(result.resultSets[0].rows[0]).toHaveProperty('age');
       } catch (error) {

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -460,19 +460,58 @@ describe('PostgreSQL Connector Integration Tests', () => {
       expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
-    it('should not apply maxRows to CTE queries (WITH clause)', async () => {
-      // Test that maxRows is not applied to CTE queries (WITH clause)
+    it('should apply maxRows to CTE queries (WITH clause)', async () => {
+      // A CTE is the ordinary shape of an analytical query, so leaving it
+      // uncapped left max_rows silently inert for most real queries.
       const result = await postgresTest.connector.executeSQL(`
         WITH user_summary AS (
           SELECT name, age FROM users WHERE age IS NOT NULL
         )
         SELECT * FROM user_summary ORDER BY age
       `, { maxRows: 2 });
-      
-      // Should return all rows since WITH queries are not limited anymore
-      expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[0]).toHaveProperty('age');
+    });
+
+    it('should apply maxRows to a query introduced by a comment', async () => {
+      const result = await postgresTest.connector.executeSQL(
+        '-- dbhub attribution tag\nSELECT name FROM users ORDER BY name',
+        { maxRows: 2 }
+      );
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
+    });
+
+    it('should cap the statement itself rather than tightening a CTE\'s own LIMIT', async () => {
+      // The inner LIMIT caps only the CTE; the statement can still return more
+      // rows than that, so it needs a cap of its own.
+      const result = await postgresTest.connector.executeSQL(`
+        WITH first_three AS (
+          SELECT name FROM users ORDER BY name LIMIT 3
+        )
+        SELECT * FROM first_three
+      `, { maxRows: 2 });
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
+    });
+
+    it('should not apply maxRows to a data-modifying CTE', async () => {
+      const result = await postgresTest.connector.executeSQL(`
+        WITH inserted AS (
+          INSERT INTO users (name, email, age)
+          VALUES ('dm1', 'dm1@dm.com', 41), ('dm2', 'dm2@dm.com', 42), ('dm3', 'dm3@dm.com', 43)
+          RETURNING id, name
+        )
+        SELECT * FROM inserted
+      `, { maxRows: 2 });
+
+      // A LIMIT here would cap the rows handed back while all three rows were
+      // still written - a cap that isn't one.
+      expect(result.resultSets[0].rows).toHaveLength(3);
+
+      await postgresTest.connector.executeSQL("DELETE FROM users WHERE email LIKE '%@dm.com'", {});
     });
 
     it('should handle maxRows in multi-statement execution with transactions', async () => {

--- a/src/connectors/__tests__/sqlite.integration.test.ts
+++ b/src/connectors/__tests__/sqlite.integration.test.ts
@@ -379,17 +379,17 @@ describe('SQLite Connector Integration Tests', () => {
       expect(result.resultSets[0].rows[0]).toHaveProperty('total');
     });
 
-    it('should not apply maxRows to CTE queries (WITH clause)', async () => {
-      // Test that maxRows is not applied to CTE queries (WITH clause)
+    it('should apply maxRows to CTE queries (WITH clause)', async () => {
+      // A CTE is the ordinary shape of an analytical query, so leaving it
+      // uncapped left max_rows silently inert for most real queries.
       const result = await sqliteTest.connector.executeSQL(`
         WITH user_summary AS (
           SELECT name, age FROM users WHERE age IS NOT NULL
         )
         SELECT * FROM user_summary ORDER BY age
       `, { maxRows: 2 });
-      
-      // Should return all rows since WITH queries are not limited anymore
-      expect(result.resultSets[0].rows.length).toBeGreaterThan(2);
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[0]).toHaveProperty('age');
     });

--- a/src/utils/__tests__/sql-row-limiter.test.ts
+++ b/src/utils/__tests__/sql-row-limiter.test.ts
@@ -155,7 +155,168 @@ describe("SQLRowLimiter", () => {
     });
   });
 
+  describe("applyMaxRows - leading comments", () => {
+    // A query introduced by a comment (an attribution tag, say) is still a
+    // SELECT. Classifying on the raw text made `max_rows` silently inert for
+    // every one of them.
+    it("caps a query introduced by a -- line comment", () => {
+      const sql = "-- dbhub agent query\nSELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "-- dbhub agent query\nSELECT * FROM users\nLIMIT 100"
+      );
+    });
+
+    it("caps a query introduced by a block comment", () => {
+      const sql = "/* tag: report */ SELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "/* tag: report */ SELECT * FROM users\nLIMIT 100"
+      );
+    });
+
+    it("caps a query introduced by several mixed leading comments", () => {
+      const sql = "-- one\n/* two */\n-- three\nSELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "-- one\n/* two */\n-- three\nSELECT * FROM users\nLIMIT 100"
+      );
+    });
+
+    it("leaves the caller's comment text untouched", () => {
+      // The comment is load-bearing for query attribution, so only the
+      // classification sees the stripped form - the SQL sent to the server
+      // keeps it verbatim.
+      const sql = "/* app=dbhub; user='bob' */\nSELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toContain("/* app=dbhub; user='bob' */");
+    });
+
+    it("still leaves a non-SELECT hidden behind a comment alone", () => {
+      const sql = "-- looks harmless\nUPDATE users SET active = true";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(sql);
+    });
+  });
+
+  describe("applyMaxRows - CTEs", () => {
+    it("caps a WITH ... SELECT query", () => {
+      const sql = "WITH recent AS (SELECT * FROM orders) SELECT * FROM recent";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "WITH recent AS (SELECT * FROM orders) SELECT * FROM recent\nLIMIT 100"
+      );
+    });
+
+    it("appends its own LIMIT instead of tightening a CTE's inner LIMIT", () => {
+      // The CTE's LIMIT caps only the CTE; the statement can still return far
+      // more rows than that (here via the join), so it needs a cap of its own.
+      const sql =
+        "WITH recent AS (SELECT * FROM orders LIMIT 5) SELECT * FROM recent JOIN big ON true";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "WITH recent AS (SELECT * FROM orders LIMIT 5) SELECT * FROM recent JOIN big ON true\nLIMIT 100"
+      );
+    });
+
+    it("tightens the statement's own LIMIT on a CTE query", () => {
+      const sql = "WITH recent AS (SELECT * FROM orders LIMIT 5) SELECT * FROM recent LIMIT 500";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "WITH recent AS (SELECT * FROM orders LIMIT 5) SELECT * FROM recent LIMIT 100"
+      );
+    });
+
+    it("wraps a CTE query whose own LIMIT is parameterized", () => {
+      const sql = "WITH recent AS (SELECT * FROM orders) SELECT * FROM recent LIMIT $1";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "SELECT * FROM (WITH recent AS (SELECT * FROM orders) SELECT * FROM recent LIMIT $1\n) AS subq LIMIT 100"
+      );
+    });
+
+    it.each([
+      ["DELETE", "WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d"],
+      ["INSERT", "WITH i AS (INSERT INTO t SELECT * FROM s RETURNING *) SELECT * FROM i"],
+      ["UPDATE", "WITH u AS (UPDATE t SET a = 1 RETURNING *) SELECT * FROM u"],
+    ])("does not cap a data-modifying CTE (%s)", (_label, sql) => {
+      // A LIMIT here would cap the rows handed back while the write still runs
+      // in full - a cap that isn't one.
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(sql);
+    });
+  });
+
+  describe("applyMaxRows - set operations and nesting", () => {
+    it("caps a parenthesised set operation", () => {
+      const sql = "(SELECT id FROM a) UNION (SELECT id FROM b)";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "(SELECT id FROM a) UNION (SELECT id FROM b)\nLIMIT 100"
+      );
+    });
+
+    it("keeps appending a trailing LIMIT to a bare UNION ALL, which binds to the whole set operation", () => {
+      const sql = "SELECT id FROM a UNION ALL SELECT id FROM b";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "SELECT id FROM a UNION ALL SELECT id FROM b\nLIMIT 100"
+      );
+    });
+
+    it("appends its own LIMIT instead of tightening a subquery's LIMIT", () => {
+      const sql = "SELECT * FROM (SELECT * FROM t LIMIT 5) s";
+      expect(SQLRowLimiter.applyMaxRows(sql, 100)).toBe(
+        "SELECT * FROM (SELECT * FROM t LIMIT 5) s\nLIMIT 100"
+      );
+    });
+  });
+
+  describe("clause detection ignores nested clauses", () => {
+    it("does not report a subquery's LIMIT as the statement's own", () => {
+      const sql = "SELECT * FROM (SELECT * FROM t LIMIT 5) s";
+      expect(SQLRowLimiter.hasLimitClause(sql)).toBe(false);
+      expect(SQLRowLimiter.extractLimitValue(sql)).toBe(null);
+    });
+
+    it("does not report a CTE's parameterized LIMIT as the statement's own", () => {
+      const sql = "WITH x AS (SELECT * FROM t LIMIT $1) SELECT * FROM x";
+      expect(SQLRowLimiter.hasParameterizedLimit(sql)).toBe(false);
+    });
+
+    it("does not report a CTE's TOP as the statement's own", () => {
+      const sql = "WITH x AS (SELECT TOP 5 id FROM t) SELECT * FROM x";
+      expect(SQLRowLimiter.hasTopClause(sql)).toBe(false);
+      expect(SQLRowLimiter.extractTopValue(sql)).toBe(null);
+    });
+  });
+
   describe("applyMaxRowsForSQLServer", () => {
+    it("caps a query introduced by a leading comment", () => {
+      const sql = "-- tag\nSELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(
+        "-- tag\nSELECT TOP 100 * FROM users"
+      );
+    });
+
+    it("puts TOP on the statement's own SELECT, not on the CTE's", () => {
+      const sql = "WITH x AS (SELECT id FROM t) SELECT * FROM x";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(
+        "WITH x AS (SELECT id FROM t) SELECT TOP 100 * FROM x"
+      );
+    });
+
+    it("leaves a CTE's own TOP alone and caps the final SELECT", () => {
+      const sql = "WITH x AS (SELECT TOP 5 id FROM t) SELECT * FROM x";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(
+        "WITH x AS (SELECT TOP 5 id FROM t) SELECT TOP 100 * FROM x"
+      );
+    });
+
+    it("keeps a leading CTE outside the wrapped subquery for a set operation", () => {
+      // T-SQL has no `SELECT ... FROM (WITH ...) AS subq` form, but a CTE
+      // declared before the SELECT is in scope inside the derived table.
+      const sql = "WITH x AS (SELECT id FROM t) SELECT id FROM x UNION ALL SELECT id FROM y";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(
+        "WITH x AS (SELECT id FROM t) SELECT TOP 100 * FROM (SELECT id FROM x UNION ALL SELECT id FROM y\n) AS subq"
+      );
+    });
+
+    it("does not cap a data-modifying CTE", () => {
+      const sql = "WITH d AS (DELETE FROM t OUTPUT deleted.*) SELECT * FROM d";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, 100)).toBe(sql);
+    });
+  });
+
+  describe("applyMaxRowsForSQLServer - pre-existing behaviour", () => {
     it("should not modify SQL when maxRows is undefined", () => {
       const sql = "SELECT * FROM users";
       expect(SQLRowLimiter.applyMaxRowsForSQLServer(sql, undefined)).toBe(sql);

--- a/src/utils/allowed-keywords.ts
+++ b/src/utils/allowed-keywords.ts
@@ -178,6 +178,19 @@ const mutatingPatterns: Record<ConnectorType, RegExp> = {
   sqlserver: mutatingPatternSqlServer,
 };
 
+/**
+ * Whether (comment/string-stripped) SQL contains a data-modifying keyword.
+ * Shared by the read-only classifier's CTE check and the row limiter, so both
+ * agree on what counts as a write hidden inside a WITH. Falls back to the
+ * dialect-independent keyword set when no connector type is given.
+ */
+export function hasMutatingKeyword(
+  strippedSQL: string,
+  connectorType?: ConnectorType | string
+): boolean {
+  return (mutatingPatterns[connectorType as ConnectorType] ?? mutatingPattern).test(strippedSQL);
+}
+
 const selectIntoPattern = /\bselect\b[\s\S]+\binto\b/i;
 
 /**
@@ -251,11 +264,8 @@ function checkReadOnly(cleanedSQL: string, connectorType: ConnectorType | string
   }
 
   // WITH statements can embed DML in CTEs (e.g. WITH cte AS (UPDATE ...))
-  if (firstWord === "with") {
-    const pattern = mutatingPatterns[connectorType as ConnectorType] ?? mutatingPattern;
-    if (pattern.test(cleanedSQL)) {
-      return false;
-    }
+  if (firstWord === "with" && hasMutatingKeyword(cleanedSQL, connectorType)) {
+    return false;
   }
 
   // SQLite PRAGMA: a pragma that sets a value mutates durable or session state and

--- a/src/utils/sql-row-limiter.ts
+++ b/src/utils/sql-row-limiter.ts
@@ -1,97 +1,122 @@
-import { stripCommentsAndStrings, blankCommentsAndStrings } from "./sql-parser.js";
+import type { ConnectorType } from "../connectors/interface.js";
+import { hasMutatingKeyword } from "./allowed-keywords.js";
+import { blankCommentsAndStrings } from "./sql-parser.js";
 
 /**
- * Shared utility for applying row limits to SELECT queries only using database-native LIMIT clauses
+ * Shared utility for applying row limits to row-returning queries using
+ * database-native LIMIT clauses (or TOP on SQL Server).
+ *
+ * Every check here reasons about the statement's *own* clauses: the SQL is
+ * first blanked of comments and string literals, then scanned with parenthesis
+ * depth tracking, so a LIMIT/TOP/ORDER BY belonging to a CTE body, a subquery,
+ * or one branch of a set operation is never mistaken for the statement's own.
+ * Such a nested clause caps only its own branch, so the statement still needs
+ * a cap of its own.
  */
 export class SQLRowLimiter {
   /**
-   * Check if a SQL statement is a SELECT query that can benefit from row limiting
-   * Only handles SELECT queries
+   * Check if a SQL statement is a row-returning query that can benefit from row limiting.
+   *
+   * Classification runs on the comment-blanked text, so a query introduced by a
+   * `--` or `/* ... *\/` comment — a query tag, say — is classified by its real
+   * leading keyword rather than by the comment. The SQL the caller wrote is
+   * never rewritten by this check: only the classification sees the blanked
+   * form, so an attribution comment survives to the server verbatim.
+   *
+   * `WITH` leads a CTE whose final statement is normally a SELECT, so it is
+   * limitable too — except for a data-modifying CTE
+   * (`WITH x AS (DELETE ... RETURNING *) SELECT ...`), where a LIMIT would cap
+   * the rows handed back while the write still runs in full: a cap that isn't
+   * one. Detection there is the same keyword heuristic the read-only classifier
+   * uses, so a false positive only means the statement keeps today's behaviour
+   * of not being limited.
    */
   static isSelectQuery(sql: string): boolean {
-    const trimmed = sql.trim().toLowerCase();
-    return trimmed.startsWith('select');
+    const blankedSQL = blankCommentsAndStrings(sql).trim().toLowerCase();
+    // Leading parentheses are skipped: `(SELECT ...) UNION (SELECT ...)` is a
+    // row-returning statement whose first token is `(`.
+    const firstKeyword = /^[(\s]*([a-z_]+)/.exec(blankedSQL)?.[1] ?? "";
+    if (firstKeyword === "select") {
+      return true;
+    }
+    return firstKeyword === "with" && !hasMutatingKeyword(blankedSQL);
   }
 
   /**
-   * Check if a SQL statement already has a LIMIT clause.
-   * Strips comments and string literals first to avoid false positives.
+   * Check if a SQL statement has a LIMIT clause of its own.
    */
   static hasLimitClause(sql: string): boolean {
-    // Strip comments and strings to avoid matching LIMIT inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    // Detect LIMIT clause - handles literal numbers and parameter placeholders ($1, ?, @p1)
-    const limitRegex = /\blimit\s+(?:\d+|\$\d+|\?|@p\d+)/i;
-    return limitRegex.test(cleanedSQL);
+    return this.findTopLevelLimit(sql) !== null;
   }
 
   /**
-   * Check if a SQL statement already has a TOP clause (SQL Server).
-   * Strips comments and string literals first to avoid false positives.
+   * Check if a SQL statement has a TOP clause of its own (SQL Server).
    */
   static hasTopClause(sql: string): boolean {
-    // Strip comments and strings to avoid matching TOP inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    // Simple regex to detect TOP clause - handles most common cases
-    const topRegex = /\bselect\s+top\s+\d+/i;
-    return topRegex.test(cleanedSQL);
+    return this.findTopLevelTop(sql) !== null;
   }
 
   /**
-   * Extract existing LIMIT value from SQL if present.
-   * Strips comments and string literals first to avoid false positives.
+   * Extract the statement's own LIMIT value. Null when it has no LIMIT of its
+   * own, or when that LIMIT is a parameter placeholder rather than a literal
+   * (see hasParameterizedLimit).
    */
   static extractLimitValue(sql: string): number | null {
-    // Strip comments and strings to avoid matching LIMIT inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    const limitMatch = cleanedSQL.match(/\blimit\s+(\d+)/i);
-    if (limitMatch) {
-      return parseInt(limitMatch[1], 10);
-    }
-    return null;
+    return this.findTopLevelLimit(sql)?.value ?? null;
   }
 
   /**
-   * Extract existing TOP value from SQL if present (SQL Server).
-   * Strips comments and string literals first to avoid false positives.
+   * Extract the statement's own TOP value (SQL Server), or null when it has none.
    */
   static extractTopValue(sql: string): number | null {
-    // Strip comments and strings to avoid matching TOP inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    const topMatch = cleanedSQL.match(/\bselect\s+top\s+(\d+)/i);
-    if (topMatch) {
-      return parseInt(topMatch[1], 10);
-    }
-    return null;
+    return this.findTopLevelTop(sql)?.value ?? null;
   }
 
   /**
-   * Add or modify LIMIT clause in a SQL statement
+   * Check if the statement's own LIMIT clause uses a parameter placeholder
+   * ($1, ?, @p1) instead of a literal number.
+   */
+  static hasParameterizedLimit(sql: string): boolean {
+    const limit = this.findTopLevelLimit(sql);
+    return limit !== null && limit.value === null;
+  }
+
+  /**
+   * Add or tighten the LIMIT clause of a SQL statement
    */
   static applyLimitToQuery(sql: string, maxRows: number): string {
-    const existingLimit = this.extractLimitValue(sql);
-    
-    if (existingLimit !== null) {
-      // Use the minimum of existing limit and maxRows
-      const effectiveLimit = Math.min(existingLimit, maxRows);
-      return sql.replace(/\blimit\s+\d+/i, `LIMIT ${effectiveLimit}`);
-    } else {
-      // Add LIMIT clause to the end of the query
-      // Handle semicolon at the end
-      const trimmed = sql.trim();
-      const hasSemicolon = trimmed.endsWith(';');
-      const sqlWithoutSemicolon = hasSemicolon ? trimmed.slice(0, -1) : trimmed;
+    const limit = this.findTopLevelLimit(sql);
 
-      // Append on a new line: if the query ends in a `--` line comment, a
-      // same-line LIMIT would land inside the comment and be inert.
-      return `${sqlWithoutSemicolon}\nLIMIT ${maxRows}${hasSemicolon ? ';' : ''}`;
+    if (limit !== null && limit.value !== null) {
+      // Splice at the clause's own position rather than replacing the first
+      // LIMIT found textually, which on a CTE would rewrite the CTE's cap and
+      // leave the statement itself uncapped.
+      const effectiveLimit = Math.min(limit.value, maxRows);
+      return `${sql.slice(0, limit.index)}LIMIT ${effectiveLimit}${sql.slice(limit.index + limit.length)}`;
     }
+
+    const { sql: sqlWithoutSemicolon, semicolon } = trimSemicolon(sql);
+
+    if (limit !== null) {
+      // Parameterized LIMIT: the value only exists at execution time, so it
+      // cannot be compared against maxRows here. Wrap the statement and cap
+      // the outer result set to enforce max_rows as a hard ceiling.
+      // Note: subquery wrapping is safe for PostgreSQL, MySQL, MariaDB and SQLite.
+      // Close the subquery on a new line: if the inner query ends in a `--`
+      // line comment, a same-line `)` would be swallowed by the comment and
+      // the wrapped statement would be syntactically broken.
+      return `SELECT * FROM (${sqlWithoutSemicolon}\n) AS subq LIMIT ${maxRows}${semicolon}`;
+    }
+
+    // Append on a new line: if the query ends in a `--` line comment, a
+    // same-line LIMIT would land inside the comment and be inert.
+    return `${sqlWithoutSemicolon}\nLIMIT ${maxRows}${semicolon}`;
   }
 
   /**
    * Scan blanked (comment/string-free, length-preserving) SQL for parenthesis
    * depth, invoking onMatch for every regex hit at depth 0 (i.e. not nested
-   * inside a subquery, function call, or window OVER clause).
+   * inside a CTE body, subquery, function call, or window OVER clause).
    */
   private static scanTopLevel(
     blankedSQL: string,
@@ -109,37 +134,103 @@ export class SQLRowLimiter {
   }
 
   /**
+   * The first or last regex match at parenthesis depth 0 — one belonging to the
+   * statement itself rather than to a nested query. Match indices refer to
+   * positions in the original `sql`, since blankCommentsAndStrings preserves
+   * length. The regex must offer `\(` and `\)` alternatives so depth can be
+   * tracked, and must carry the `g` flag.
+   */
+  private static findTopLevelMatch(
+    sql: string,
+    regex: RegExp,
+    pick: "first" | "last",
+    dialect?: ConnectorType
+  ): RegExpExecArray | null {
+    const matches: RegExpExecArray[] = [];
+    this.scanTopLevel(blankCommentsAndStrings(sql, dialect), regex, (m) => {
+      matches.push(m);
+    });
+    if (matches.length === 0) {
+      return null;
+    }
+    return pick === "last" ? matches[matches.length - 1] : matches[0];
+  }
+
+  /**
+   * Position and value of the statement's own LIMIT clause. `value` is null
+   * when the clause holds a parameter placeholder instead of a literal.
+   */
+  private static findTopLevelLimit(
+    sql: string
+  ): { index: number; length: number; value: number | null } | null {
+    const match = this.findTopLevelMatch(
+      sql,
+      /\(|\)|\blimit\s+(?:(\d+)|\$\d+|\?|@p\d+)/gi,
+      "last"
+    );
+    if (match === null) {
+      return null;
+    }
+    return {
+      index: match.index,
+      length: match[0].length,
+      value: match[1] !== undefined ? parseInt(match[1], 10) : null,
+    };
+  }
+
+  /** Position and value of the statement's own `SELECT TOP n` clause (SQL Server). */
+  private static findTopLevelTop(
+    sql: string
+  ): { index: number; length: number; value: number } | null {
+    const match = this.findTopLevelMatch(
+      sql,
+      /\(|\)|\bselect\s+top\s+(\d+)/gi,
+      "first",
+      "sqlserver"
+    );
+    if (match === null) {
+      return null;
+    }
+    return { index: match.index, length: match[0].length, value: parseInt(match[1], 10) };
+  }
+
+  /**
+   * The statement's own SELECT keyword (SQL Server). For a CTE this is the
+   * final SELECT, not the one inside a CTE body.
+   */
+  private static findTopLevelSelect(sql: string): RegExpExecArray | null {
+    return this.findTopLevelMatch(sql, /\(|\)|\bselect\b/gi, "first", "sqlserver");
+  }
+
+  /**
    * Check if a SQL statement combines multiple SELECTs with a set operator
    * (UNION [ALL], INTERSECT, EXCEPT) at the top level — i.e. not nested
-   * inside a subquery already wrapped in parentheses. Strips comments and
-   * string literals first to avoid false positives.
+   * inside a subquery already wrapped in parentheses.
    */
   static hasSetOperator(sql: string): boolean {
-    const blankedSQL = blankCommentsAndStrings(sql, "sqlserver");
-    let found = false;
-    this.scanTopLevel(blankedSQL, /\(|\)|\bunion\b|\bintersect\b|\bexcept\b/gi, () => {
-      found = true;
-    });
-    return found;
+    return (
+      this.findTopLevelMatch(
+        sql,
+        /\(|\)|\bunion\b|\bintersect\b|\bexcept\b/gi,
+        "first",
+        "sqlserver"
+      ) !== null
+    );
   }
 
   /**
    * Find the start index of a top-level trailing ORDER BY clause (not one
    * nested inside a subquery or a window function's OVER (...) clause).
-   * Returns -1 if none exists. Operates on the original (non-blanked) SQL
-   * length, since blankCommentsAndStrings preserves length/position.
+   * Returns -1 if none exists.
    */
   private static findTopLevelOrderByIndex(sql: string): number {
-    const blankedSQL = blankCommentsAndStrings(sql, "sqlserver");
-    let lastIndex = -1;
-    this.scanTopLevel(blankedSQL, /\(|\)|\border\s+by\b/gi, (m) => {
-      lastIndex = m.index;
-    });
-    return lastIndex;
+    return (
+      this.findTopLevelMatch(sql, /\(|\)|\border\s+by\b/gi, "last", "sqlserver")?.index ?? -1
+    );
   }
 
   /**
-   * Add or modify TOP clause in a SQL statement (SQL Server)
+   * Add or tighten the TOP clause of a SQL statement (SQL Server)
    */
   static applyTopToQuery(sql: string, maxRows: number): string {
     if (this.hasSetOperator(sql)) {
@@ -148,80 +239,60 @@ export class SQLRowLimiter {
       // UNION/INTERSECT/EXCEPT output, so wrap the whole statement and cap
       // the outer result set instead, regardless of any TOP already present
       // on an individual branch.
-      const trimmed = sql.trim();
-      const hasSemicolon = trimmed.endsWith(';');
-      const sqlWithoutSemicolon = hasSemicolon ? trimmed.slice(0, -1) : trimmed;
+      const { sql: sqlWithoutSemicolon, semicolon } = trimSemicolon(sql);
+
+      // A leading CTE stays outside the derived table: T-SQL has no
+      // `SELECT ... FROM (WITH ...) AS subq` form, but a CTE declared before
+      // the SELECT is still in scope inside that derived table.
+      const selectMatch = this.findTopLevelSelect(sqlWithoutSemicolon);
+      const cteIndex = selectMatch !== null ? selectMatch.index : 0;
+      const ctePrefix = sqlWithoutSemicolon.slice(0, cteIndex);
+      const body = sqlWithoutSemicolon.slice(cteIndex);
 
       // A top-level ORDER BY must move outside the derived table: T-SQL
       // disallows ORDER BY inside a subquery unless that subquery itself has
       // TOP/OFFSET/FOR XML, so leaving it inside would break the query.
-      const orderByIndex = this.findTopLevelOrderByIndex(sqlWithoutSemicolon);
+      const orderByIndex = this.findTopLevelOrderByIndex(body);
       if (orderByIndex !== -1) {
-        const innerSql = sqlWithoutSemicolon.slice(0, orderByIndex).trimEnd();
-        const orderByClause = sqlWithoutSemicolon.slice(orderByIndex).trim();
-        return `SELECT TOP ${maxRows} * FROM (${innerSql}\n) AS subq ${orderByClause}${hasSemicolon ? ';' : ''}`;
+        const innerSql = body.slice(0, orderByIndex).trimEnd();
+        const orderByClause = body.slice(orderByIndex).trim();
+        return `${ctePrefix}SELECT TOP ${maxRows} * FROM (${innerSql}\n) AS subq ${orderByClause}${semicolon}`;
       }
 
-      return `SELECT TOP ${maxRows} * FROM (${sqlWithoutSemicolon}\n) AS subq${hasSemicolon ? ';' : ''}`;
+      return `${ctePrefix}SELECT TOP ${maxRows} * FROM (${body}\n) AS subq${semicolon}`;
     }
 
-    const existingTop = this.extractTopValue(sql);
+    const existingTop = this.findTopLevelTop(sql);
     if (existingTop !== null) {
       // Use the minimum of existing top and maxRows
-      const effectiveTop = Math.min(existingTop, maxRows);
-      return sql.replace(/\bselect\s+top\s+\d+/i, `SELECT TOP ${effectiveTop}`);
+      const effectiveTop = Math.min(existingTop.value, maxRows);
+      return `${sql.slice(0, existingTop.index)}SELECT TOP ${effectiveTop}${sql.slice(existingTop.index + existingTop.length)}`;
     }
 
-    // Add TOP clause after SELECT
-    return sql.replace(/\bselect\s+/i, `SELECT TOP ${maxRows} `);
+    // Add TOP to the statement's own SELECT — for a CTE that is the final
+    // SELECT, not the one inside a CTE body.
+    const selectMatch = this.findTopLevelSelect(sql);
+    if (selectMatch === null) {
+      return sql;
+    }
+    return `${sql.slice(0, selectMatch.index)}SELECT TOP ${maxRows}${sql.slice(selectMatch.index + selectMatch[0].length)}`;
   }
 
   /**
-   * Check if a LIMIT clause uses a parameter placeholder (not a literal number).
-   * Strips comments and string literals first to avoid false positives.
-   */
-  static hasParameterizedLimit(sql: string): boolean {
-    // Strip comments and strings to avoid matching LIMIT inside them
-    const cleanedSQL = stripCommentsAndStrings(sql);
-    // Check for parameterized LIMIT (excluding literal numbers)
-    const parameterizedLimitRegex = /\blimit\s+(?:\$\d+|\?|@p\d+)/i;
-    return parameterizedLimitRegex.test(cleanedSQL);
-  }
-
-  /**
-   * Apply maxRows limit to a SELECT query only
+   * Apply maxRows limit to a row-returning query only
    *
    * This method is used by PostgreSQL, MySQL, MariaDB, and SQLite connectors which all support
    * the LIMIT clause syntax. SQL Server uses applyMaxRowsForSQLServer() instead with TOP syntax.
-   *
-   * For parameterized LIMIT clauses (e.g., LIMIT $1 or LIMIT ?), we wrap the query in a subquery
-   * to enforce max_rows as a hard cap, since the parameter value is not known until runtime.
    */
   static applyMaxRows(sql: string, maxRows: number | undefined): string {
     if (!maxRows || !this.isSelectQuery(sql)) {
       return sql;
     }
-
-    // If query has a parameterized LIMIT, wrap it in a subquery with maxRows
-    // This ensures max_rows is respected even when user provides a large parameter value
-    if (this.hasParameterizedLimit(sql)) {
-      // Wrap the query: SELECT * FROM (original_query) AS subq LIMIT max_rows
-      // Note: Subquery wrapping is safe for PostgreSQL, MySQL, MariaDB, and SQLite
-      const trimmed = sql.trim();
-      const hasSemicolon = trimmed.endsWith(';');
-      const sqlWithoutSemicolon = hasSemicolon ? trimmed.slice(0, -1) : trimmed;
-      // Close the subquery on a new line: if the inner query ends in a `--`
-      // line comment, a same-line `)` would be swallowed by the comment and
-      // the wrapped statement would be syntactically broken.
-      return `SELECT * FROM (${sqlWithoutSemicolon}\n) AS subq LIMIT ${maxRows}${hasSemicolon ? ';' : ''}`;
-    }
-
-    // For literal LIMIT values, apply the minimum logic
     return this.applyLimitToQuery(sql, maxRows);
   }
 
   /**
-   * Apply maxRows limit to a SELECT query using SQL Server TOP syntax
+   * Apply maxRows limit to a row-returning query using SQL Server TOP syntax
    */
   static applyMaxRowsForSQLServer(sql: string, maxRows: number | undefined): string {
     if (!maxRows || !this.isSelectQuery(sql)) {
@@ -229,4 +300,15 @@ export class SQLRowLimiter {
     }
     return this.applyTopToQuery(sql, maxRows);
   }
+}
+
+/**
+ * Split a trailing semicolon off a statement so a wrapper/suffix can be spliced
+ * in before it, and the caller can put it back.
+ */
+function trimSemicolon(sql: string): { sql: string; semicolon: "" | ";" } {
+  const trimmed = sql.trim();
+  return trimmed.endsWith(";")
+    ? { sql: trimmed.slice(0, -1), semicolon: ";" }
+    : { sql: trimmed, semicolon: "" };
 }


### PR DESCRIPTION
Hey 👋  This looks like a bug but if it's wanted behavior, feel free to drop 😊 


`SQLRowLimiter.isSelectQuery` decided whether to cap a statement with:

```ts
static isSelectQuery(sql: string): boolean {
  const trimmed = sql.trim().toLowerCase();
  return trimmed.startsWith('select');
}
```

so anything not opening with a bare `SELECT` got **no LIMIT appended at all**. Not a wrong limit —
no limit, and nothing anywhere says so. Verified by executing the shipped v1.2.0 module
(`applyMaxRows(sql, 100)`):

| input | v1.2.0 output |
| --- | --- |
| `-- reporting job\nSELECT * FROM t` | returned **unchanged** |
| `/* tag: report */ SELECT * FROM t` | returned **unchanged** |
| `WITH x AS (SELECT * FROM orders) SELECT * FROM x` | returned **unchanged** |
| `(SELECT id FROM a) UNION (SELECT id FROM b)` | returned **unchanged** |
| `SELECT * FROM (SELECT * FROM t LIMIT 5) s` | returned **unchanged** |
| `SELECT * FROM t` | `SELECT * FROM t\nLIMIT 100` ✅ |

This is not an exotic corner. Leading comments are how queries get attributed (`-- app=…`,
`/* trace-id */`), and a CTE is the ordinary shape of an analytical query — which is exactly the
kind of query a row cap exists to contain. In practice `max_rows` covered far less than it appeared
to. We hit this running DBHub against ~24 production PostgreSQL read replicas with agents driving
`execute_sql`.

The existing suite pinned the gap rather than catching it: three integration tests were named
`should not apply maxRows to CTE queries (WITH clause)`. This PR inverts them.

To be clear about what those tests were pinning: `git log -S` shows the `startsWith('select')` guard
and those three tests both arrive in the *same* commit — `4fa886e feat: support max-row limit`, the
commit that introduced `max_rows`. The CTE exclusion was never a separate, deliberate carve-out; it
is a consequence of that one-line classifier, and the tests recorded whatever it happened to do.
(One of the assertions is commented "not limited anymore", which reads as though a decision had been
reversed — the history shows there was no earlier behaviour to reverse.) If the exclusion *is*
wanted, it deserves to be an explicit rule rather than a side effect of the guard, and this PR
should be redirected to documenting it instead.

## Fix

Classify on the comment/string-blanked text, and treat a leading `WITH` as row-returning. The SQL
sent to the server is never rewritten by the classification, so an attribution comment survives
verbatim — only the classifier sees the blanked form.

A **data-modifying CTE** (`WITH x AS (DELETE … RETURNING *) SELECT …`) is deliberately still *not*
limited: a LIMIT would cap the rows handed back while the write ran in full, which reads as a cap
that isn't one. That check reuses the read-only classifier's own keyword heuristic, extracted as
`hasMutatingKeyword`, so both layers agree on what counts as a write hidden inside a `WITH`. A false
positive there only means the statement keeps today's behaviour.

**Enabling CTEs exposed a second bug**, which is why the diff is larger than "add `with` to a list".
Every LIMIT/TOP helper matched the *first clause found textually*, which on a CTE is the inner one:

```sql
WITH recent AS (SELECT * FROM orders LIMIT 5)
SELECT * FROM recent JOIN big ON true
```

Naively enabling CTEs would have rewritten the CTE's own `LIMIT 5` and left the statement — the part
that can return millions of rows — uncapped. So the helpers now scan with parenthesis-depth tracking
(the mechanism already in this file for `hasSetOperator` and the ORDER BY hoist) and reason only
about the statement's **own** clause; a nested LIMIT/TOP caps only its branch, so the statement still
gets a cap appended. This also fixes the same pre-existing hole for plain subqueries
(`SELECT * FROM (SELECT * FROM t LIMIT 5) s`, last row of the table above).

On SQL Server, `TOP` now lands on the statement's own `SELECT` rather than the first one textually
(for a CTE, the final `SELECT`), and a leading CTE is kept *outside* the derived table when a set
operation forces the `#387` wrap — T-SQL has no `SELECT … FROM (WITH …) AS subq` form.

**Explicitly preserved:** `SELECT … UNION ALL SELECT …` starts with `select`, still gets a trailing
`LIMIT`, and on PostgreSQL that binds to the whole set operation. Pinned by a regression test.

## Testing

- `pnpm run test:unit` — **981 passed** (958 on `main`; +23 new).
- `pnpm run test:integration` — **334 passed** (331 on `main`; +3) across PostgreSQL, MySQL, MariaDB,
  SQL Server and SQLite containers.
- `pnpm run build:backend` — clean.

New coverage: leading `--`/`/* */`/mixed comments; CTE; CTE with an inner LIMIT; CTE with its own
LIMIT; CTE with a parameterized LIMIT; data-modifying CTE (all three of INSERT/UPDATE/DELETE);
parenthesised set operation; nested-subquery LIMIT; `UNION ALL` regression; and SQL Server CTE/TOP
cases.

## Notes for reviewers

- `npx tsc --noEmit` reports 132 pre-existing errors on `main`; this branch reports the same 132,
  none in the changed files.
- Found alongside a separate PostgreSQL cancellation bug, sent as its own PR — the two are
  independent and share no files but one integration test file.
