### PR TITLE
Add truncated flag to execute_sql results when max_rows cuts off rows

### DIFF
--- a/docs/tools/execute-sql.mdx
+++ b/docs/tools/execute-sql.mdx
@@ -158,6 +158,7 @@ max_rows = 1000
 - Only applied to SELECT statements, not INSERT/UPDATE/DELETE
 - If your query already has a `LIMIT` or `TOP` clause, DBHub uses the smaller value
 - Can be configured per-tool in [TOML configuration](/config/toml)
+- When the cap actually cuts off rows, the statement's result carries `"truncated": true` alongside `count`, so a capped result is distinguishable from a table that genuinely has exactly `max_rows` rows (detection is exact — DBHub fetches one probe row past the cap; the flag is omitted for complete results). Run `COUNT(*)` to get the true total when you see it.
 
 ## Selective Tool Exposure
 

--- a/src/connectors/__tests__/mariadb.integration.test.ts
+++ b/src/connectors/__tests__/mariadb.integration.test.ts
@@ -413,6 +413,8 @@ describe('MariaDB Connector Integration Tests', () => {
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[1]).toHaveProperty('name');
+      // The cap provably cut off rows (users has more than 2)
+      expect(result.resultSets[0].truncated).toBe(true);
     });
 
     it('should respect existing LIMIT clause when lower than maxRows', async () => {
@@ -421,9 +423,11 @@ describe('MariaDB Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id LIMIT 1',
         { maxRows: 3 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(1);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      // The user's own LIMIT fired, not the cap — no truncation flag
+      expect(result.resultSets[0].truncated).toBeUndefined();
     });
 
     it('should use maxRows when existing LIMIT is higher', async () => {
@@ -432,10 +436,11 @@ describe('MariaDB Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id LIMIT 10',
         { maxRows: 2 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].truncated).toBe(true);
     });
 
     it('should not affect non-SELECT queries', async () => {

--- a/src/connectors/__tests__/mysql.integration.test.ts
+++ b/src/connectors/__tests__/mysql.integration.test.ts
@@ -333,6 +333,8 @@ describe('MySQL Connector Integration Tests', () => {
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[1]).toHaveProperty('name');
+      // The cap provably cut off rows (users has more than 2)
+      expect(result.resultSets[0].truncated).toBe(true);
     });
 
     it('should respect existing LIMIT clause when lower than maxRows', async () => {
@@ -341,9 +343,11 @@ describe('MySQL Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id LIMIT 1',
         { maxRows: 3 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(1);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      // The user's own LIMIT fired, not the cap — no truncation flag
+      expect(result.resultSets[0].truncated).toBeUndefined();
     });
 
     it('should use maxRows when existing LIMIT is higher', async () => {
@@ -352,10 +356,11 @@ describe('MySQL Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id LIMIT 10',
         { maxRows: 2 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].truncated).toBe(true);
     });
 
     it('should not affect non-SELECT queries', async () => {

--- a/src/connectors/__tests__/postgres.integration.test.ts
+++ b/src/connectors/__tests__/postgres.integration.test.ts
@@ -387,6 +387,8 @@ describe('PostgreSQL Connector Integration Tests', () => {
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[1]).toHaveProperty('name');
+      // The cap provably cut off rows (users has more than 2)
+      expect(result.resultSets[0].truncated).toBe(true);
     });
 
     it('should respect existing LIMIT clause when lower than maxRows', async () => {
@@ -395,9 +397,11 @@ describe('PostgreSQL Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id LIMIT 1',
         { maxRows: 3 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(1);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      // The user's own LIMIT fired, not the cap — no truncation flag
+      expect(result.resultSets[0].truncated).toBeUndefined();
     });
 
     it('should use maxRows when existing LIMIT is higher', async () => {
@@ -406,10 +410,11 @@ describe('PostgreSQL Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id LIMIT 10',
         { maxRows: 2 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].truncated).toBe(true);
     });
 
     it('should not affect non-SELECT queries', async () => {

--- a/src/connectors/__tests__/sqlite.integration.test.ts
+++ b/src/connectors/__tests__/sqlite.integration.test.ts
@@ -341,10 +341,71 @@ describe('SQLite Connector Integration Tests', () => {
         'SELECT * FROM users ORDER BY id LIMIT 10',
         { maxRows: 2 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0].name).toBe('John Doe');
       expect(result.resultSets[0].rows[1].name).toBe('Jane Smith');
+      expect(result.resultSets[0].truncated).toBe(true);
+    });
+
+    it('should flag truncated when maxRows cuts off rows', async () => {
+      // users has 3+ rows; the cap of 2 provably cuts rows off
+      const result = await sqliteTest.connector.executeSQL(
+        'SELECT * FROM users ORDER BY id',
+        { maxRows: 2 }
+      );
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].rowCount).toBe(2);
+      expect(result.resultSets[0].truncated).toBe(true);
+      // The echoed SQL is the original statement, not the probe rewrite
+      expect(result.resultSets[0].sql).toBe('SELECT * FROM users ORDER BY id');
+    });
+
+    it('should not flag truncated when the result has exactly maxRows rows', async () => {
+      // Exactly 2 rows exist and the cap is 2 — indistinguishable by count
+      // alone, but the probe row proves the result is complete
+      const result = await sqliteTest.connector.executeSQL(
+        'SELECT 1 AS n UNION ALL SELECT 2',
+        { maxRows: 2 }
+      );
+
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].truncated).toBeUndefined();
+    });
+
+    it('should not flag truncated when the result has fewer rows than maxRows', async () => {
+      const result = await sqliteTest.connector.executeSQL(
+        'SELECT 1 AS n',
+        { maxRows: 2 }
+      );
+
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].truncated).toBeUndefined();
+    });
+
+    it("should not flag truncated when the user's own lower LIMIT fires", async () => {
+      // The user asked for 1 row; the cap of 3 never fired
+      const result = await sqliteTest.connector.executeSQL(
+        'SELECT * FROM users ORDER BY id LIMIT 1',
+        { maxRows: 3 }
+      );
+
+      expect(result.resultSets[0].rows).toHaveLength(1);
+      expect(result.resultSets[0].truncated).toBeUndefined();
+    });
+
+    it('should flag truncated per statement in multi-statement execution', async () => {
+      const result = await sqliteTest.connector.executeSQL(
+        'SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3; SELECT 1 AS m',
+        { maxRows: 2 }
+      );
+
+      expect(result.resultSets).toHaveLength(2);
+      expect(result.resultSets[0].rows).toHaveLength(2);
+      expect(result.resultSets[0].truncated).toBe(true);
+      expect(result.resultSets[1].rows).toHaveLength(1);
+      expect(result.resultSets[1].truncated).toBeUndefined();
     });
 
     it('should not affect non-SELECT queries', async () => {

--- a/src/connectors/__tests__/sqlserver.integration.test.ts
+++ b/src/connectors/__tests__/sqlserver.integration.test.ts
@@ -774,6 +774,8 @@ describe('SQL Server Connector Integration Tests', () => {
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[1]).toHaveProperty('name');
+      // The cap provably cut off rows (users has more than 2)
+      expect(result.resultSets[0].truncated).toBe(true);
     });
 
     it('should respect existing TOP clause when lower than maxRows', async () => {
@@ -782,9 +784,11 @@ describe('SQL Server Connector Integration Tests', () => {
         'SELECT TOP 1 * FROM users ORDER BY id',
         { maxRows: 3 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(1);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
+      // The user's own TOP fired, not the cap — no truncation flag
+      expect(result.resultSets[0].truncated).toBeUndefined();
     });
 
     it('should use maxRows when existing TOP is higher', async () => {
@@ -793,10 +797,11 @@ describe('SQL Server Connector Integration Tests', () => {
         'SELECT TOP 10 * FROM users ORDER BY id',
         { maxRows: 2 }
       );
-      
+
       expect(result.resultSets[0].rows).toHaveLength(2);
       expect(result.resultSets[0].rows[0]).toHaveProperty('name');
       expect(result.resultSets[0].rows[1]).toHaveProperty('name');
+      expect(result.resultSets[0].truncated).toBe(true);
     });
 
     it('should not affect non-SELECT queries', async () => {

--- a/src/connectors/interface.ts
+++ b/src/connectors/interface.ts
@@ -36,6 +36,16 @@ export interface SQLResultSet {
   sql?: string;
   rows: any[];
   rowCount: number;
+  /**
+   * True when a configured max_rows cap cut off this result set: the query
+   * had more rows than the cap allows, and `rows`/`rowCount` reflect only the
+   * first max_rows of them. Omitted (never false) when the result is
+   * complete, so consumers can distinguish a capped result from a table that
+   * genuinely has exactly max_rows rows. Detection uses a probe row (the cap
+   * is applied as LIMIT/TOP max_rows + 1, see SQLRowLimiter.flagTruncation),
+   * so the flag is exact, not a heuristic.
+   */
+  truncated?: boolean;
 }
 
 export interface SQLResult {

--- a/src/connectors/mariadb/index.ts
+++ b/src/connectors/mariadb/index.ts
@@ -653,12 +653,15 @@ export class MariaDBConnector implements Connector {
           // attribution below, whether or not maxRows needs to rewrite it.
           const statements = splitSQLStatements(sql, "mariadb");
           let processedSQL = sql;
+          // Per-statement truncation-probe flags, index-aligned with `statements`
+          let probes: boolean[] = [];
           if (options.maxRows) {
-            const processedStatements = statements.map(statement =>
-              SQLRowLimiter.applyMaxRows(statement, options.maxRows)
+            const rewrites = statements.map(statement =>
+              SQLRowLimiter.applyMaxRowsWithTruncationProbe(statement, options.maxRows)
             );
+            probes = rewrites.map(rewrite => rewrite.probeApplied);
 
-            processedSQL = processedStatements.join('; ');
+            processedSQL = rewrites.map(rewrite => rewrite.sql).join('; ');
             if (sql.trim().endsWith(';')) {
               processedSQL += ';';
             }
@@ -675,6 +678,15 @@ export class MariaDBConnector implements Connector {
 
           // Parse results using shared utility that handles both single and multi-statement queries
           const resultSets = parseQueryResultSets(results, statements);
+
+          // Result sets are per statement in source order, so a length match
+          // means the pairing with the probe flags is exact (same reasoning as
+          // the sql attribution inside parseQueryResultSets).
+          if (resultSets.length === probes.length) {
+            resultSets.forEach((set, index) =>
+              SQLRowLimiter.flagTruncation(set, options.maxRows, probes[index])
+            );
+          }
 
           return { resultSets };
         }

--- a/src/connectors/mysql/index.ts
+++ b/src/connectors/mysql/index.ts
@@ -683,12 +683,15 @@ export class MySQLConnector implements Connector {
           // attribution below, whether or not maxRows needs to rewrite it.
           const statements = splitSQLStatements(sql, "mysql");
           let processedSQL = sql;
+          // Per-statement truncation-probe flags, index-aligned with `statements`
+          let probes: boolean[] = [];
           if (options.maxRows) {
-            const processedStatements = statements.map(statement =>
-              SQLRowLimiter.applyMaxRows(statement, options.maxRows)
+            const rewrites = statements.map(statement =>
+              SQLRowLimiter.applyMaxRowsWithTruncationProbe(statement, options.maxRows)
             );
+            probes = rewrites.map(rewrite => rewrite.probeApplied);
 
-            processedSQL = processedStatements.join('; ');
+            processedSQL = rewrites.map(rewrite => rewrite.sql).join('; ');
             if (sql.trim().endsWith(';')) {
               processedSQL += ';';
             }
@@ -709,6 +712,15 @@ export class MySQLConnector implements Connector {
 
           // Parse results using shared utility that handles both single and multi-statement queries
           const resultSets = parseQueryResultSets(firstResult, statements);
+
+          // Result sets are per statement in source order, so a length match
+          // means the pairing with the probe flags is exact (same reasoning as
+          // the sql attribution inside parseQueryResultSets).
+          if (resultSets.length === probes.length) {
+            resultSets.forEach((set, index) =>
+              SQLRowLimiter.flagTruncation(set, options.maxRows, probes[index])
+            );
+          }
 
           return { resultSets };
         }

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -679,8 +679,11 @@ export class PostgresConnector implements Connector {
       const statements = splitSQLStatements(sql, "postgres");
 
       if (statements.length === 1) {
-        // Single statement - apply maxRows if applicable
-        const processedStatement = SQLRowLimiter.applyMaxRows(statements[0], options.maxRows);
+        // Single statement - apply maxRows (with a truncation probe row) if applicable
+        const { sql: processedStatement, probeApplied } = SQLRowLimiter.applyMaxRowsWithTruncationProbe(
+          statements[0],
+          options.maxRows
+        );
 
         // Engine-level read-only enforcement: when the tool is read-only, run the
         // statement inside a READ ONLY transaction so the database itself rejects any
@@ -692,11 +695,13 @@ export class PostgresConnector implements Connector {
               ? await client.query(processedStatement, parameters)
               : await client.query(processedStatement);
             await client.query('COMMIT');
-            return {
-              resultSets: [
-                { sql: statements[0], rows: result.rows, rowCount: result.rowCount ?? result.rows.length },
-              ],
+            const resultSet: SQLResultSet = {
+              sql: statements[0],
+              rows: result.rows,
+              rowCount: result.rowCount ?? result.rows.length,
             };
+            SQLRowLimiter.flagTruncation(resultSet, options.maxRows, probeApplied);
+            return { resultSets: [resultSet] };
           } catch (error) {
             // Best-effort rollback so a failed ROLLBACK (e.g. dropped connection)
             // can't mask the original query error.
@@ -717,11 +722,13 @@ export class PostgresConnector implements Connector {
           result = await client.query(processedStatement);
         }
         // Explicitly return rows and rowCount to ensure rowCount is preserved
-        return {
-          resultSets: [
-            { sql: statements[0], rows: result.rows, rowCount: result.rowCount ?? result.rows.length },
-          ],
+        const resultSet: SQLResultSet = {
+          sql: statements[0],
+          rows: result.rows,
+          rowCount: result.rowCount ?? result.rows.length,
         };
+        SQLRowLimiter.flagTruncation(resultSet, options.maxRows, probeApplied);
+        return { resultSets: [resultSet] };
       } else {
         // Multiple statements - parameters not supported for multi-statement queries
         if (parameters && parameters.length > 0) {
@@ -740,15 +747,20 @@ export class PostgresConnector implements Connector {
         await client.query(options.readonly ? 'BEGIN READ ONLY' : 'BEGIN');
         try {
           for (let statement of statements) {
-            // Apply maxRows limit to SELECT queries if specified
-            const processedStatement = SQLRowLimiter.applyMaxRows(statement, options.maxRows);
+            // Apply maxRows limit (with a truncation probe row) to SELECT queries if specified
+            const { sql: processedStatement, probeApplied } = SQLRowLimiter.applyMaxRowsWithTruncationProbe(
+              statement,
+              options.maxRows
+            );
 
             const result = await client.query(processedStatement);
-            resultSets.push({
+            const resultSet: SQLResultSet = {
               sql: statement,
               rows: result.rows ?? [],
               rowCount: result.rowCount ?? result.rows?.length ?? 0,
-            });
+            };
+            SQLRowLimiter.flagTruncation(resultSet, options.maxRows, probeApplied);
+            resultSets.push(resultSet);
           }
           await client.query('COMMIT');
         } catch (error) {

--- a/src/connectors/sqlite/index.ts
+++ b/src/connectors/sqlite/index.ts
@@ -489,20 +489,27 @@ export class SQLiteConnector implements Connector {
                                  trimmedStatement.includes('index_list') ||
                                  trimmedStatement.includes('foreign_key_list')));
 
-        // Apply maxRows limit to SELECT queries if specified (not PRAGMA/ANALYZE)
+        // Apply maxRows limit (with a truncation probe row) to SELECT queries
+        // if specified (not PRAGMA/ANALYZE)
+        let probeApplied = false;
         if (options.maxRows) {
-          processedStatement = SQLRowLimiter.applyMaxRows(processedStatement, options.maxRows);
+          const rewrite = SQLRowLimiter.applyMaxRowsWithTruncationProbe(
+            processedStatement,
+            options.maxRows
+          );
+          processedStatement = rewrite.sql;
+          probeApplied = rewrite.probeApplied;
         }
 
         if (isReadStatement) {
           // Pass parameters if provided
-          if (parameters && parameters.length > 0) {
-            const rows = this.prepare(processedStatement).all(...parameters);
-            return { resultSets: [{ sql: statements[0], rows, rowCount: rows.length }] };
-          } else {
-            const rows = this.prepare(processedStatement).all();
-            return { resultSets: [{ sql: statements[0], rows, rowCount: rows.length }] };
-          }
+          const rows =
+            parameters && parameters.length > 0
+              ? this.prepare(processedStatement).all(...parameters)
+              : this.prepare(processedStatement).all();
+          const resultSet: SQLResultSet = { sql: statements[0], rows, rowCount: rows.length };
+          SQLRowLimiter.flagTruncation(resultSet, options.maxRows, probeApplied);
+          return { resultSets: [resultSet] };
         } else {
           // Use run() for statements that don't return data
           let result;
@@ -567,10 +574,15 @@ export class SQLiteConnector implements Connector {
           if (options.readonly) {
             this.db.exec("PRAGMA query_only = ON");
           }
-          // Apply maxRows limit to SELECT queries if specified
-          const processedStatement = SQLRowLimiter.applyMaxRows(statement, options.maxRows);
+          // Apply maxRows limit (with a truncation probe row) to SELECT queries if specified
+          const { sql: processedStatement, probeApplied } = SQLRowLimiter.applyMaxRowsWithTruncationProbe(
+            statement,
+            options.maxRows
+          );
           const rows = this.prepare(processedStatement).all();
-          resultSets.push({ sql: statement, rows, rowCount: rows.length });
+          const resultSet: SQLResultSet = { sql: statement, rows, rowCount: rows.length };
+          SQLRowLimiter.flagTruncation(resultSet, options.maxRows, probeApplied);
+          resultSets.push(resultSet);
         }
 
         return { resultSets };

--- a/src/connectors/sqlserver/index.ts
+++ b/src/connectors/sqlserver/index.ts
@@ -758,10 +758,16 @@ export class SQLServerConnector implements Connector {
     }
 
     try {
-      // Apply maxRows limit to SELECT queries if specified
+      // Apply maxRows limit (with a truncation probe row) to SELECT queries if specified
       let processedSQL = sqlQuery;
+      let probeApplied = false;
       if (options.maxRows) {
-        processedSQL = SQLRowLimiter.applyMaxRowsForSQLServer(sqlQuery, options.maxRows);
+        const rewrite = SQLRowLimiter.applyMaxRowsForSQLServerWithTruncationProbe(
+          sqlQuery,
+          options.maxRows
+        );
+        processedSQL = rewrite.sql;
+        probeApplied = rewrite.probeApplied;
       }
       // Computed once and threaded into buildResultSets below (directly, or via
       // executeReadOnly) rather than re-derived from SQL text on every call.
@@ -772,7 +778,13 @@ export class SQLServerConnector implements Connector {
       // unconditionally ROLLBACK to prevent any modifications from persisting.
       // This is defense-in-depth behind the keyword classifier.
       if (options.readonly) {
-        return await this.executeReadOnly(processedSQL, parameters, isSingleStatement);
+        return await this.executeReadOnly(
+          processedSQL,
+          parameters,
+          isSingleStatement ? sqlQuery : undefined,
+          options.maxRows,
+          probeApplied
+        );
       }
 
       // Create request and collect informational messages (e.g. SET STATISTICS TIME/IO, PRINT)
@@ -795,12 +807,18 @@ export class SQLServerConnector implements Connector {
 
       const result = await request.query(processedSQL);
 
+      const resultSets = SQLServerConnector.buildResultSets(
+        result.recordsets,
+        result.rowsAffected,
+        isSingleStatement ? sqlQuery : undefined,
+      );
+      // The TOP probe rewrite applies to the batch's leading SELECT, whose
+      // rows land in the first result set.
+      if (resultSets.length > 0) {
+        SQLRowLimiter.flagTruncation(resultSets[0], options.maxRows, probeApplied);
+      }
       return {
-        resultSets: SQLServerConnector.buildResultSets(
-          result.recordsets,
-          result.rowsAffected,
-          isSingleStatement ? processedSQL : undefined,
-        ),
+        resultSets,
         ...(messages.length > 0 ? { messages } : {}),
       };
     } catch (error) {
@@ -956,8 +974,12 @@ export class SQLServerConnector implements Connector {
    */
   private async executeReadOnly(
     processedSQL: string,
-    parameters?: any[],
-    isSingleStatement?: boolean,
+    parameters: any[] | undefined,
+    // Original (pre-rewrite) statement text for attribution; undefined for
+    // multi-statement batches, where attribution would be a guess.
+    sourceSql: string | undefined,
+    maxRows: number | undefined,
+    probeApplied: boolean,
   ): Promise<SQLResult> {
     this.assertNoReadOnlyEscapes(processedSQL, { transactionControl: true });
 
@@ -998,12 +1020,18 @@ export class SQLServerConnector implements Connector {
         }
       }
     }
+    const resultSets = SQLServerConnector.buildResultSets(
+      result.recordsets,
+      result.rowsAffected,
+      sourceSql,
+    );
+    // The TOP probe rewrite applies to the batch's leading SELECT, whose rows
+    // land in the first result set.
+    if (resultSets.length > 0) {
+      SQLRowLimiter.flagTruncation(resultSets[0], maxRows, probeApplied);
+    }
     return {
-      resultSets: SQLServerConnector.buildResultSets(
-        result.recordsets,
-        result.rowsAffected,
-        isSingleStatement ? processedSQL : undefined,
-      ),
+      resultSets,
       ...(messages.length > 0 ? { messages } : {}),
     };
   }

--- a/src/tools/__tests__/execute-sql.test.ts
+++ b/src/tools/__tests__/execute-sql.test.ts
@@ -91,6 +91,38 @@ describe('execute-sql tool', () => {
       expect(mockConnector.executeSQL).toHaveBeenCalledWith(sql, { readonly: false, maxRows: undefined });
     });
 
+    it('should surface truncated: true when a result set was capped by max_rows', async () => {
+      const mockResult: SQLResult = {
+        resultSets: [
+          { sql: 'SELECT * FROM users', rows: [{ id: 1 }, { id: 2 }], rowCount: 2, truncated: true },
+        ],
+      };
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
+
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql: 'SELECT * FROM users' }, null);
+      const parsedResult = parseToolResponse(result);
+
+      expect(parsedResult.success).toBe(true);
+      expect(parsedResult.data.statements).toEqual([
+        { sql: 'SELECT * FROM users', rows: [{ id: 1 }, { id: 2 }], count: 2, truncated: true },
+      ]);
+    });
+
+    it('should omit the truncated key entirely for complete results', async () => {
+      const mockResult: SQLResult = {
+        resultSets: [{ sql: 'SELECT * FROM users', rows: [{ id: 1 }], rowCount: 1 }],
+      };
+      vi.mocked(mockConnector.executeSQL).mockResolvedValue(mockResult);
+
+      const handler = createExecuteSqlToolHandler('test_source');
+      const result = await handler({ sql: 'SELECT * FROM users' }, null);
+      const parsedResult = parseToolResponse(result);
+
+      expect(parsedResult.success).toBe(true);
+      expect('truncated' in parsedResult.data.statements[0]).toBe(false);
+    });
+
     it('should handle execution errors', async () => {
       vi.mocked(mockConnector.executeSQL).mockRejectedValue(new Error('Database error'));
 

--- a/src/utils/__tests__/sql-row-limiter.test.ts
+++ b/src/utils/__tests__/sql-row-limiter.test.ts
@@ -250,4 +250,155 @@ describe("SQLRowLimiter", () => {
       expect(result).toBe("SELECT TOP 5 * FROM (SELECT id FROM a UNION ALL SELECT id FROM b) AS t");
     });
   });
+
+  describe("applyMaxRowsWithTruncationProbe", () => {
+    it("should not modify SQL or probe when maxRows is undefined", () => {
+      const sql = "SELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRowsWithTruncationProbe(sql, undefined)).toEqual({
+        sql,
+        probeApplied: false,
+      });
+    });
+
+    it("should not modify or probe non-SELECT queries", () => {
+      const sql = "UPDATE users SET active = true";
+      expect(SQLRowLimiter.applyMaxRowsWithTruncationProbe(sql, 100)).toEqual({
+        sql,
+        probeApplied: false,
+      });
+    });
+
+    it("should add a probe LIMIT of maxRows + 1 when no LIMIT exists", () => {
+      const result = SQLRowLimiter.applyMaxRowsWithTruncationProbe("SELECT * FROM users", 100);
+      expect(result).toEqual({ sql: "SELECT * FROM users\nLIMIT 101", probeApplied: true });
+    });
+
+    it("should not probe when the query's own LIMIT is below the cap", () => {
+      const sql = "SELECT * FROM users LIMIT 50";
+      expect(SQLRowLimiter.applyMaxRowsWithTruncationProbe(sql, 100)).toEqual({
+        sql,
+        probeApplied: false,
+      });
+    });
+
+    it("should not probe when the query's own LIMIT equals the cap", () => {
+      // The user asked for exactly maxRows rows — that's their limit firing,
+      // not the cap, so no probe and never a truncated flag.
+      const sql = "SELECT * FROM users LIMIT 100";
+      expect(SQLRowLimiter.applyMaxRowsWithTruncationProbe(sql, 100)).toEqual({
+        sql,
+        probeApplied: false,
+      });
+    });
+
+    it("should probe with maxRows + 1 when the query's LIMIT exceeds the cap", () => {
+      const result = SQLRowLimiter.applyMaxRowsWithTruncationProbe(
+        "SELECT * FROM users LIMIT 200",
+        100
+      );
+      expect(result).toEqual({ sql: "SELECT * FROM users LIMIT 101", probeApplied: true });
+    });
+
+    it("should probe by wrapping a parameterized LIMIT in a subquery", () => {
+      const result = SQLRowLimiter.applyMaxRowsWithTruncationProbe(
+        "SELECT * FROM users LIMIT $1",
+        100
+      );
+      expect(result).toEqual({
+        sql: "SELECT * FROM (SELECT * FROM users LIMIT $1\n) AS subq LIMIT 101",
+        probeApplied: true,
+      });
+    });
+  });
+
+  describe("applyMaxRowsForSQLServerWithTruncationProbe", () => {
+    it("should not modify SQL or probe when maxRows is undefined", () => {
+      const sql = "SELECT * FROM users";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServerWithTruncationProbe(sql, undefined)).toEqual({
+        sql,
+        probeApplied: false,
+      });
+    });
+
+    it("should not modify or probe non-SELECT queries", () => {
+      const sql = "UPDATE users SET active = 1";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServerWithTruncationProbe(sql, 100)).toEqual({
+        sql,
+        probeApplied: false,
+      });
+    });
+
+    it("should add a probe TOP of maxRows + 1 when no TOP exists", () => {
+      const result = SQLRowLimiter.applyMaxRowsForSQLServerWithTruncationProbe(
+        "SELECT * FROM users",
+        100
+      );
+      expect(result).toEqual({ sql: "SELECT TOP 101 * FROM users", probeApplied: true });
+    });
+
+    it("should not probe when the query's own TOP is within the cap", () => {
+      const sql = "SELECT TOP 50 * FROM users";
+      expect(SQLRowLimiter.applyMaxRowsForSQLServerWithTruncationProbe(sql, 100)).toEqual({
+        sql,
+        probeApplied: false,
+      });
+    });
+
+    it("should probe with maxRows + 1 when the query's TOP exceeds the cap", () => {
+      const result = SQLRowLimiter.applyMaxRowsForSQLServerWithTruncationProbe(
+        "SELECT TOP 200 * FROM users",
+        100
+      );
+      expect(result).toEqual({ sql: "SELECT TOP 101 * FROM users", probeApplied: true });
+    });
+
+    it("should probe a set-operator query even when a branch has its own TOP", () => {
+      // A branch-level TOP caps only that branch, so the whole statement is
+      // wrapped and the probe applies to the combined output.
+      const result = SQLRowLimiter.applyMaxRowsForSQLServerWithTruncationProbe(
+        "SELECT TOP 2 id FROM a UNION ALL SELECT id FROM b",
+        5
+      );
+      expect(result).toEqual({
+        sql: "SELECT TOP 6 * FROM (SELECT TOP 2 id FROM a UNION ALL SELECT id FROM b\n) AS subq",
+        probeApplied: true,
+      });
+    });
+  });
+
+  describe("flagTruncation", () => {
+    it("should drop the probe row, clamp the count, and set truncated", () => {
+      const resultSet = {
+        sql: "SELECT * FROM users",
+        rows: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        rowCount: 3,
+      };
+      SQLRowLimiter.flagTruncation(resultSet, 2, true);
+      expect(resultSet).toEqual({
+        sql: "SELECT * FROM users",
+        rows: [{ id: 1 }, { id: 2 }],
+        rowCount: 2,
+        truncated: true,
+      });
+    });
+
+    it("should leave a complete result untouched (no truncated key)", () => {
+      const resultSet = { rows: [{ id: 1 }, { id: 2 }], rowCount: 2 };
+      SQLRowLimiter.flagTruncation(resultSet, 2, true);
+      expect(resultSet).toEqual({ rows: [{ id: 1 }, { id: 2 }], rowCount: 2 });
+      expect("truncated" in resultSet).toBe(false);
+    });
+
+    it("should do nothing when the probe was not applied", () => {
+      const resultSet = { rows: [{ id: 1 }, { id: 2 }, { id: 3 }], rowCount: 3 };
+      SQLRowLimiter.flagTruncation(resultSet, 2, false);
+      expect(resultSet).toEqual({ rows: [{ id: 1 }, { id: 2 }, { id: 3 }], rowCount: 3 });
+    });
+
+    it("should do nothing when maxRows is undefined", () => {
+      const resultSet = { rows: [{ id: 1 }, { id: 2 }, { id: 3 }], rowCount: 3 };
+      SQLRowLimiter.flagTruncation(resultSet, undefined, true);
+      expect(resultSet).toEqual({ rows: [{ id: 1 }, { id: 2 }, { id: 3 }], rowCount: 3 });
+    });
+  });
 });

--- a/src/utils/sql-row-limiter.ts
+++ b/src/utils/sql-row-limiter.ts
@@ -1,4 +1,19 @@
 import { stripCommentsAndStrings, blankCommentsAndStrings } from "./sql-parser.js";
+import type { SQLResultSet } from "../connectors/interface.js";
+
+/**
+ * Result of a maxRows rewrite that supports truncation detection.
+ *
+ * When `probeApplied` is true, the rewritten SQL requests `maxRows + 1` rows
+ * (a probe row): if the database returns more than `maxRows` rows, the query
+ * provably had more rows than the cap allows. The caller must pass the
+ * executed result through `SQLRowLimiter.flagTruncation()` to drop the probe
+ * row and mark the result set as truncated.
+ */
+export interface MaxRowsRewrite {
+  sql: string;
+  probeApplied: boolean;
+}
 
 /**
  * Shared utility for applying row limits to SELECT queries only using database-native LIMIT clauses
@@ -228,5 +243,70 @@ export class SQLRowLimiter {
       return sql;
     }
     return this.applyTopToQuery(sql, maxRows);
+  }
+
+  /**
+   * Like applyMaxRows, but requests one probe row (maxRows + 1) whenever the
+   * cap is the binding constraint, so callers can detect truncation exactly
+   * instead of guessing from `rowCount === maxRows` (which a table with
+   * exactly maxRows rows also produces).
+   *
+   * `probeApplied` is false when the cap cannot fire: no maxRows, not a
+   * SELECT, or the query's own literal LIMIT is already within the cap (the
+   * user asked for fewer rows than the cap — that is their limit, not
+   * truncation).
+   */
+  static applyMaxRowsWithTruncationProbe(sql: string, maxRows: number | undefined): MaxRowsRewrite {
+    if (!maxRows || !this.isSelectQuery(sql)) {
+      return { sql, probeApplied: false };
+    }
+    if (!this.hasParameterizedLimit(sql)) {
+      const existingLimit = this.extractLimitValue(sql);
+      if (existingLimit !== null && existingLimit <= maxRows) {
+        return { sql, probeApplied: false };
+      }
+    }
+    return { sql: this.applyMaxRows(sql, maxRows + 1), probeApplied: true };
+  }
+
+  /**
+   * SQL Server variant of applyMaxRowsWithTruncationProbe, using TOP syntax.
+   * A set-operator statement is always wrapped (any TOP on an individual
+   * branch caps only that branch, not the combined output), so the probe
+   * applies there regardless of branch-level TOPs.
+   */
+  static applyMaxRowsForSQLServerWithTruncationProbe(
+    sql: string,
+    maxRows: number | undefined
+  ): MaxRowsRewrite {
+    if (!maxRows || !this.isSelectQuery(sql)) {
+      return { sql, probeApplied: false };
+    }
+    if (!this.hasSetOperator(sql)) {
+      const existingTop = this.extractTopValue(sql);
+      if (existingTop !== null && existingTop <= maxRows) {
+        return { sql, probeApplied: false };
+      }
+    }
+    return { sql: this.applyMaxRowsForSQLServer(sql, maxRows + 1), probeApplied: true };
+  }
+
+  /**
+   * Post-process a result set produced by a truncation-probe rewrite: when
+   * the probe row came back (more than maxRows rows), drop it, clamp the
+   * count to maxRows, and mark the set truncated so consumers can tell a
+   * capped result from a complete one.
+   */
+  static flagTruncation(
+    resultSet: SQLResultSet,
+    maxRows: number | undefined,
+    probeApplied: boolean
+  ): void {
+    if (!probeApplied || !maxRows || resultSet.rows.length <= maxRows) {
+      return;
+    }
+    resultSet.rows = resultSet.rows.slice(0, maxRows);
+    resultSet.rowCount = maxRows;
+    resultSet.truncated = true;
   }
 }

--- a/src/utils/tool-handler-helpers.ts
+++ b/src/utils/tool-handler-helpers.ts
@@ -37,11 +37,15 @@ export function getEffectiveSourceId(sourceId?: string): string {
  */
 export function toStatementsPayload(
   resultSets: SQLResultSet[]
-): Array<{ sql?: string; rows: any[]; count: number }> {
+): Array<{ sql?: string; rows: any[]; count: number; truncated?: boolean }> {
   return resultSets.map((set) => ({
     sql: set.sql,
     rows: set.rows,
     count: set.rowCount,
+    // Only present when a max_rows cap actually cut off rows, so consumers
+    // can tell a capped result from a table with exactly max_rows rows
+    // (and complete results don't pay the extra tokens).
+    ...(set.truncated ? { truncated: true } : {}),
   }));
 }
 

--- a/src/utils/tool-metadata.ts
+++ b/src/utils/tool-metadata.ts
@@ -154,7 +154,9 @@ export function getExecuteSqlMetadata(sourceId: string): ToolMetadata {
   };
 
   const readonlyNote = executeOptions.readonly ? " [READ-ONLY MODE]" : "";
-  const maxRowsNote = executeOptions.maxRows ? ` (limited to ${executeOptions.maxRows} rows)` : "";
+  const maxRowsNote = executeOptions.maxRows
+    ? ` (limited to ${executeOptions.maxRows} rows; capped results carry "truncated": true)`
+    : "";
   const description = isSingleSource
     ? `${userDescPrefix}Execute SQL queries on the ${dbType} database${readonlyNote}${maxRowsNote}`
     : `${userDescPrefix}Execute SQL queries on the '${sourceId}' ${dbType} database${readonlyNote}${maxRowsNote}`;


### PR DESCRIPTION
## Summary

Fixes #404 — the `max_rows` cap fired silently: a capped result reported `count` equal to `max_rows`, which is indistinguishable from a table that genuinely has exactly that many rows, so LLM consumers could silently reason from incomplete data.

Now, when the cap actually cuts off rows, the statement's entry in the response carries `"truncated": true` alongside `count`. The flag is omitted entirely for complete results (no token cost on the common path), matching how `search_objects` already signals truncation.

## How it works

Detection is exact rather than a `count === max_rows` heuristic. When the cap is the binding constraint, `SQLRowLimiter` rewrites the query to fetch one probe row past the cap (`LIMIT`/`TOP max_rows + 1`). If the probe row comes back, the connector drops it, clamps `rowCount` to `max_rows`, and marks the result set truncated (`SQLRowLimiter.flagTruncation`). The flag never fires when the query's own smaller `LIMIT`/`TOP` is what bounded the result — that's the user's limit, not the cap.

## Changes

- `src/utils/sql-row-limiter.ts`: new `applyMaxRowsWithTruncationProbe` / `applyMaxRowsForSQLServerWithTruncationProbe` (built on the existing rewrite logic) and `flagTruncation` post-processing helper
- `src/connectors/interface.ts`: optional `truncated` field on `SQLResultSet`
- All five connectors (PostgreSQL, MySQL, MariaDB, SQLite, SQL Server) wire the probe through `executeSQL`, including per-statement flags in multi-statement batches
- `src/utils/tool-handler-helpers.ts`: `toStatementsPayload` emits `truncated: true` when set (shared by `execute_sql` and custom tools)
- `src/utils/tool-metadata.ts`: the tool description's row-limit note now tells consumers capped results carry `"truncated": true`
- SQL Server now echoes the original statement text in `sql` instead of the TOP-rewritten one, matching the other connectors (and not leaking the probe value)
- Docs: `docs/tools/execute-sql.mdx` row-limiting section documents the flag

## Test plan

- [x] New unit tests for the probe rewrites and `flagTruncation` (`sql-row-limiter.test.ts`, 59 tests passing)
- [x] New handler tests: payload carries `truncated: true` when set, omits the key for complete results (`execute-sql.test.ts`)
- [x] New SQLite integration tests: capped vs exactly-`max_rows` vs fewer rows vs user's own lower `LIMIT` vs per-statement in multi-statement batches (49 tests passing locally)
- [x] `truncated` assertions added to the existing `maxRows` integration tests for PostgreSQL, MySQL, MariaDB, SQL Server (Docker-based; will run in CI)
- [x] Full unit suite passes (981 tests), `pnpm run build:backend` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxUnGXE7MRMyezpunumuFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxUnGXE7MRMyezpunumuFH)_